### PR TITLE
fix: startup warning about deprecated TEMP_FAHRENHEIT and TEMP_CELSIUS in 2024.1.6

### DIFF
--- a/custom_components/ha_carrier/climate.py
+++ b/custom_components/ha_carrier/climate.py
@@ -17,10 +17,9 @@ from homeassistant.components.climate import (
 )
 from homeassistant.const import (
     ATTR_TEMPERATURE,
-    TEMP_CELSIUS,
+    UnitOfTemperature,
     PRECISION_HALVES,
     PRECISION_WHOLE,
-    TEMP_FAHRENHEIT,
 )
 from homeassistant.components.climate.const import (
     ATTR_TARGET_TEMP_HIGH,
@@ -142,9 +141,9 @@ class Thermostat(CarrierEntity, ClimateEntity):
             self._updater.carrier_system.status.temperature_unit
             == TemperatureUnits.FAHRENHEIT
         ):
-            return TEMP_FAHRENHEIT
+            return UnitOfTemperature.FAHRENHEIT
         else:
-            return TEMP_CELSIUS
+            return UnitOfTemperature.CELSIUS
 
     @property
     def hvac_mode(self) -> HVACMode | str | None:
@@ -184,7 +183,7 @@ class Thermostat(CarrierEntity, ClimateEntity):
 
     @property
     def target_temperature_step(self) -> float:
-        if self.temperature_unit == TEMP_CELSIUS:
+        if self.temperature_unit == UnitOfTemperature.CELSIUS:
             return PRECISION_HALVES
         else:
             return PRECISION_WHOLE
@@ -318,7 +317,7 @@ class Thermostat(CarrierEntity, ClimateEntity):
             heat_set_point = temperature or heat_set_point
             cool_set_point = self.max_temp
 
-        if self.temperature_unit == TEMP_FAHRENHEIT:
+        if self.temperature_unit == UnitOfTemperature.FAHRENHEIT:
             heat_set_point = int(heat_set_point)
             cool_set_point = int(cool_set_point)
 

--- a/custom_components/ha_carrier/sensor.py
+++ b/custom_components/ha_carrier/sensor.py
@@ -5,8 +5,7 @@ from logging import Logger, getLogger
 
 from homeassistant.components.sensor import SensorEntity, SensorDeviceClass
 from homeassistant.const import (
-    TEMP_CELSIUS,
-    TEMP_FAHRENHEIT,
+    UnitOfTemperature,
     PERCENTAGE,
     UnitOfPressure,
     UnitOfTime,
@@ -96,9 +95,9 @@ class ZoneTemperatureSensor(CarrierEntity, SensorEntity):
             self._updater.carrier_system.status.temperature_unit
             == TemperatureUnits.FAHRENHEIT
         ):
-            return TEMP_FAHRENHEIT
+            return UnitOfTemperature.FAHRENHEIT
         else:
-            return TEMP_CELSIUS
+            return UnitOfTemperature.CELSIUS
 
     @property
     def native_value(self) -> float:
@@ -118,7 +117,7 @@ class OutdoorTemperatureSensor(CarrierEntity, SensorEntity):
     @property
     def native_unit_of_measurement(self) -> str | None:
         """Returns unit of temperature."""
-        return TEMP_FAHRENHEIT
+        return UnitOfTemperature.FAHRENHEIT
 
     @property
     def native_value(self) -> float:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 colorlog==6.8.2
-homeassistant==2023.3.0
+homeassistant==2024.1.6
 pip>=8.0.3,<23.4
 ruff==0.1.14
 carrier-api===1.12.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 colorlog==6.8.2
-homeassistant==2024.1.6
+homeassistant==2023.3.0
 pip>=8.0.3,<23.4
 ruff==0.1.14
 carrier-api===1.12.1


### PR DESCRIPTION
I am running HA Core 2024.1.6

Upon startup, I am seeing the following warnings.  Seemed simple enough to just fix instead of opening an issue.  This change (https://github.com/home-assistant/core/pull/81006) was made in HA core in 2022.11, so this shouldn't reasonably be introducing any backward compatibility issues.

```
2024-02-02 16:30:49.771 WARNING (MainThread) [homeassistant.const] TEMP_CELSIUS was used from ha_carrier, this is a deprecated constant which will be removed in HA Core 2025.1. Use UnitOfTemperature.CELSIUS instead, please create a bug report at https://github.com/dahlb/ha_carrier/issues
2024-02-02 16:30:49.782 WARNING (MainThread) [homeassistant.const] TEMP_FAHRENHEIT was used from ha_carrier, this is a deprecated constant which will be removed in HA Core 2025.1. Use UnitOfTemperature.FAHRENHEIT instead, please create a bug report at https://github.com/dahlb/ha_carrier/issues
2024-02-02 16:30:49.805 WARNING (MainThread) [homeassistant.const] TEMP_CELSIUS was used from ha_carrier, this is a deprecated constant which will be removed in HA Core 2025.1. Use UnitOfTemperature.CELSIUS instead, please create a bug report at https://github.com/dahlb/ha_carrier/issues
2024-02-02 16:30:49.815 WARNING (MainThread) [homeassistant.const] TEMP_FAHRENHEIT was used from ha_carrier, this is a deprecated constant which will be removed in HA Core 2025.1. Use UnitOfTemperature.FAHRENHEIT instead, please create a bug report at https://github.com/dahlb/ha_carrier/issues
```