### PR TITLE
feat: compute propane usage in cubic feet and add propane sensor

### DIFF
--- a/custom_components/ha_carrier/sensor.py
+++ b/custom_components/ha_carrier/sensor.py
@@ -118,7 +118,7 @@ class PropaneMeasurementSensor(CarrierEntity, SensorEntity):
             suggested_display_precision=2,
             last_reset=datetime(year=datetime.now().year, month=1, day=1)
         )
-        super().__init__(f"Propane Yearly Gallons", updater, system_serial)
+        super().__init__("Propane Yearly Gallons", updater, system_serial)
 
     @property
     def native_value(self) -> float:


### PR DESCRIPTION
After further research, I believe I understand the correct conversions.

The exact number of BTUs per gallon of propane varies based on ambient temperature and pressure. Commonly listed values include 91,452, 91,500, 91,502, 91,690, and 91,700 BTU per gallon.

Looking at data from my system, the average BTU per gallon is approximately 91,692 BTU:

| Period    | Unit      | Gallons (App) | BTU per Gallon |
| -------- | ------- | --------------|-----------------|
| Day 1      | 265        |  2.89 | 91695.50173 | 
| Day 2      | 45        | 0.49 | 91836.73469 |
| Month 1  |  16291  | 177.67 | 91692.46356 |
| Month 2  |  4426  |  48.27 | 91692.56267 |
| Year 1      | 18553  | 202.38 |  91674.07847 |
| Year 2      | 4426   | 48.27 |  91692.56267 |

Since 91,692 is closest to 91,690, I chose to use that value for consistency.

Now that we know 1 gallon of propane is equal to 91,690 BTU, we can determine the cubic foot conversion.

There are approximately 0.0278 gallons per cubic foot.

91,690 BTU/gallon × 0.0278 gallons/cubic foot = 2,549.98 BTU

1 gallon of propane = 91,690 BTU
1 cubic foot of propane = 2,549.98 BTU

These numbers also match or close to various online sources:
- https://portal.ct.gov/drs/publications/policy-statements/1992/ps-92-10-1
- https://members.rennlist.com/warren/propane.html
- https://www.generatorjoe.net/html/energy.html
- https://ipm.cahnr.uconn.edu/heating-value-fuels/
- https://www.moderustic.com/BTU-s-are-a-rate-of-usage.html

This change updates the GasMeasurementSensor to report propane usage in cubic feet and introduces a new PropaneMeasurementSensor to track propane usage in gallons.