### PR TITLE
feat: Support 2 stage HPs outdoor unit types

### DIFF
--- a/custom_components/ha_carrier/select.py
+++ b/custom_components/ha_carrier/select.py
@@ -46,7 +46,7 @@ class HeatSourceSelect(CarrierEntity, SelectEntity):
     def __init__(self, updater: CarrierDataUpdateCoordinator, system_serial: str):
         """Declare device class and identifiers."""
         super().__init__("Heat Source", updater, system_serial)
-        if self.carrier_system.profile.outdoor_unit_type in ["varcaphp", "multistghp"]:
+        if self.carrier_system.profile.outdoor_unit_type in ["hp2stg", "varcaphp", "multistghp"]:
             options = [self.idu_only_label(), HEAT_SOURCE_ODU_ONLY_LABEL, HEAT_SOURCE_SYSTEM_LABEL]
         else:
             options = [self.idu_only_label(), HEAT_SOURCE_SYSTEM_LABEL]


### PR DESCRIPTION
Added the value "hp2stg" to the list of outdoor unit types, so my carrier system integration with HA could display the "Heat pump only" mode.

Properties from my system:

```
      "mapped_data": {
        "serial": "**REDACTED**",
        "name": "HomeSystem",
        "profile": {
          "model": "SYSTXCCITW01",
          "brand": "Carrier",
          "firmware": "CESR131493-14.02",
          "indoor_model": "FE4ANF002",
          "indoor_serial": "**REDACTED**",
          "indoor_unit_type": "fancoil",
          "indoor_unit_source": "electric",
          "outdoor_model": "25HNB924A00320",
          "outdoor_serial": "**REDACTED**",
          "outdoor_unit_type": "hp2stg"
        }
```