### PR TITLE
Add HPVarSensor and improve ODU Status logic for Home Assistant

### DIFF
--- a/custom_components/ha_carrier/sensor.py
+++ b/custom_components/ha_carrier/sensor.py
@@ -44,6 +44,8 @@ async def async_setup_entry(hass, config_entry: ConfigEntry, async_add_entities)
                 IndoorUnitOperationalStatusSensor(updater, carrier_system.profile.serial),
             ]
         )
+        if carrier_system.profile.outdoor_unit_type == "varcaphp":
+            entities.append(HPVarSensor(updater, carrier_system.profile.serial))
         if carrier_system.config.humidifier_enabled:
             entities.append(HumidifierRemainingSensor(updater, carrier_system.profile.serial))
         if carrier_system.config.uv_enabled:
@@ -353,19 +355,27 @@ class StaticPressureSensor(CarrierEntity, SensorEntity):
 
 
 class OutdoorUnitOperationalStatusSensor(CarrierEntity, SensorEntity):
-    """Outdoor unit operational status sensor."""
+    """Outdoor unit operational status sensor.
+    Maps numeric string values to 'on' for improved logbook phrasing in Home Assistant.
+    """
     _attr_icon = "mdi:hvac"
 
     def __init__(self, updater: CarrierDataUpdateCoordinator, system_serial: str):
-        """Creates outdoor unit operational status sensor."""
+        """Create outdoor unit operational status sensor."""
         super().__init__("ODU Status", updater, system_serial)
         self.entity_description = SensorEntityDescription(key="ODU Status", device_class=SensorDeviceClass.ENUM)
 
     @property
     def native_value(self) -> Any | None:
-        """Return outdoor unit operational status."""
-        if self.carrier_system.status.outdoor_unit_operational_status is not None:
-            return self.carrier_system.status.outdoor_unit_operational_status
+        """
+        Return outdoor unit operational status. Numeric strings (e.g., '1') are mapped to 'on'.
+        This improves logbook phrasing in Home Assistant.
+        """
+        value = self.carrier_system.status.outdoor_unit_operational_status
+        if value is not None:
+            if isinstance(value, str) and value.isdigit():
+                return "on"
+            return value
 
     @property
     def available(self) -> bool:
@@ -387,6 +397,40 @@ class IndoorUnitOperationalStatusSensor(CarrierEntity, SensorEntity):
         """Return indoor unit operational status."""
         if self.carrier_system.status.indoor_unit_operational_status is not None:
             return self.carrier_system.status.indoor_unit_operational_status
+
+    @property
+    def available(self) -> bool:
+        """Return true if sensor is ready for display."""
+        return self.native_value is not None
+
+
+class HPVarSensor(CarrierEntity, SensorEntity):
+    """HP Var sensor for variable capacity heat pump percentage.
+    Only registered for systems with outdoor_unit_type == 'varcaphp'.
+    Returns the percentage as a float if the value is a numeric string (including decimals),
+    or 0 for any non-numeric value.
+    """
+    _attr_icon = "mdi:percent-box"
+    _attr_native_unit_of_measurement = PERCENTAGE
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
+    def __init__(self, updater: CarrierDataUpdateCoordinator, system_serial: str):
+        """Create HP Var sensor."""
+        super().__init__("HP Var", updater, system_serial)
+
+    @property
+    def native_value(self) -> float | None:
+        """
+        Return HP Var percentage as a float if the value is a numeric string (including decimals).
+        Returns 0 for any non-numeric value.
+        """
+        value = self.carrier_system.status.outdoor_unit_operational_status
+        if isinstance(value, str):
+            try:
+                return float(value)
+            except ValueError:
+                pass
+        return 0
 
     @property
     def available(self) -> bool:


### PR DESCRIPTION
## Pull Request: Add HPVarSensor and Improve ODU Status Logic

To implement closed request 249: https://github.com/dahlb/ha_carrier/issues/249

### Summary

This pull request adds a new sensor for Carrier Infinity systems with variable capacity heat pumps and improves the logbook phrasing for the outdoor unit operational status sensor.

### Features

- **HPVarSensor**:  
  - New sensor entity for systems with `outdoor_unit_type == "varcaphp"`.
  - Reports the variable capacity heat pump percentage as a float, based on the value of `carrier_system.status.outdoor_unit_operational_status`.
  - Accepts only numeric strings (including decimals); returns 0 for non-numeric values.
  - Uses `mdi:percent-box` icon, measurement state class, and no device class.

- **ODU Status Sensor Improvement**:  
  - Maps all numeric string values (e.g., `"1"`) to `"on"` for improved Home Assistant logbook phrasing ("turned on").
  - Leaves non-numeric values unchanged.

### Rationale

- The HPVarSensor provides visibility into the variable capacity operation of compatible heat pumps, which is valuable for monitoring and automations.
- The ODU Status sensor logic is improved for better logbook readability and consistency with Home Assistant conventions.

### Testing

- Tested on a system with `outdoor_unit_type == "varcaphp"` and confirmed correct sensor registration and value reporting.
- Confirmed that ODU Status sensor maps numeric string values to `"on"` and non-numeric values are passed through.

---

**Please let me know if you have any questions or need further adjustments!**