### PR TITLE
fix: bump carrier-api to 2.11.1

### DIFF
--- a/custom_components/ha_carrier/manifest.json
+++ b/custom_components/ha_carrier/manifest.json
@@ -8,6 +8,6 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/dahlb/ha_carrier/issues",
   "loggers": ["ha_carrier", "carrier_api"],
-  "requirements": ["carrier-api==2.11.0"],
+  "requirements": ["carrier-api==2.11.1"],
   "version": "2.16.0"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 homeassistant==2025.10.0
 ruff==0.15.1
-carrier-api===2.11.0
+carrier-api===2.11.1


### PR DESCRIPTION
carrier-api 2.11.1 fixes a recurring websocket crash caused by Carrier's cloud sending messages
  without a deviceId field. See dahlb/carrier_api#86.