### PR TITLE
fix: Handle yearly resets of utility meters

### DIFF
--- a/custom_components/ha_carrier/sensor.py
+++ b/custom_components/ha_carrier/sensor.py
@@ -100,7 +100,7 @@ class GasMeasurementSensor(CarrierEntity, SensorEntity):
         self.entity_description = SensorEntityDescription(
             key=metric,
             device_class=SensorDeviceClass.GAS,
-            state_class=SensorStateClass.TOTAL,
+            state_class=SensorStateClass.TOTAL_INCREASING,
             native_unit_of_measurement=unit_of_measurement,
             suggested_display_precision=2,
             last_reset=datetime(year=datetime.now().year, month=1, day=1)
@@ -129,7 +129,7 @@ class PropaneMeasurementSensor(CarrierEntity, SensorEntity):
         self.entity_description = SensorEntityDescription(
             key="propane",
             device_class=SensorDeviceClass.VOLUME,
-            state_class=SensorStateClass.TOTAL,
+            state_class=SensorStateClass.TOTAL_INCREASING,
             native_unit_of_measurement=UnitOfVolume.GALLONS,
             suggested_display_precision=2,
             last_reset=datetime(year=datetime.now().year, month=1, day=1)
@@ -151,7 +151,7 @@ class EnergyMeasurementSensor(CarrierEntity, SensorEntity):
         self.entity_description = SensorEntityDescription(
             key=metric,
             device_class=SensorDeviceClass.ENERGY,
-            state_class=SensorStateClass.TOTAL,
+            state_class=SensorStateClass.TOTAL_INCREASING,
             native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
             suggested_display_precision=0,
             last_reset=datetime(year=datetime.now().year, month=1, day=1)


### PR DESCRIPTION
Total_Increasing works with meters that reset to 0 periodically. Total will act like a net meter. In the current state, it shows a large negative usage on jan 1 every year when the carrier api resets these counters.