### PR TITLE
fix: state_class for yearly sensors with last_reset

### DIFF
--- a/custom_components/ha_carrier/sensor.py
+++ b/custom_components/ha_carrier/sensor.py
@@ -102,7 +102,7 @@ class GasMeasurementSensor(CarrierEntity, SensorEntity):
         self.entity_description = SensorEntityDescription(
             key=metric,
             device_class=SensorDeviceClass.GAS,
-            state_class=SensorStateClass.TOTAL_INCREASING,
+            state_class=SensorStateClass.TOTAL,
             native_unit_of_measurement=unit_of_measurement,
             suggested_display_precision=2,
             last_reset=datetime(year=datetime.now().year, month=1, day=1)
@@ -131,7 +131,7 @@ class PropaneMeasurementSensor(CarrierEntity, SensorEntity):
         self.entity_description = SensorEntityDescription(
             key="propane",
             device_class=SensorDeviceClass.VOLUME,
-            state_class=SensorStateClass.TOTAL_INCREASING,
+            state_class=SensorStateClass.TOTAL,
             native_unit_of_measurement=UnitOfVolume.GALLONS,
             suggested_display_precision=2,
             last_reset=datetime(year=datetime.now().year, month=1, day=1)
@@ -153,7 +153,7 @@ class EnergyMeasurementSensor(CarrierEntity, SensorEntity):
         self.entity_description = SensorEntityDescription(
             key=metric,
             device_class=SensorDeviceClass.ENERGY,
-            state_class=SensorStateClass.TOTAL_INCREASING,
+            state_class=SensorStateClass.TOTAL,
             native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
             suggested_display_precision=0,
             last_reset=datetime(year=datetime.now().year, month=1, day=1)


### PR DESCRIPTION
## Summary

- Changes `state_class` from `TOTAL_INCREASING` to `TOTAL` for `EnergyMeasurementSensor`, `GasMeasurementSensor`, and `PropaneMeasurementSensor`
- These three yearly sensor classes set `last_reset` to January 1st of the current year, which is only valid with `SensorStateClass.TOTAL` — not `TOTAL_INCREASING`
- Without this fix, HA raises a `ValueError` and the sensors fail to load entirely

## Context

The 2.17.0 release added `last_reset=datetime(year=datetime.now().year, month=1, day=1)` to tell HA these sensors reset each year. However, `last_reset` is incompatible with `TOTAL_INCREASING` — HA only allows it with `TOTAL`.

Error from HA logs:
```
ValueError: Entity sensor.downstairs_cooling_energy_yearly
(<class 'custom_components.ha_carrier.sensor.EnergyMeasurementSensor'>)
with state_class total_increasing has set last_reset.
Setting last_reset for entities with state_class other than 'total' is
not supported.
```

## Test plan

- [ ] Verify the three yearly sensor types load without `ValueError`
- [ ] Confirm energy dashboard still tracks cumulative usage correctly
- [ ] Verify `DailyEnergyMeasurementSensor` (unchanged, no `last_reset`) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)