### PR TITLE
SensorStateClass.TOTAL_INCREASING and last_reset error

### DIFF
--- a/custom_components/ha_carrier/sensor.py
+++ b/custom_components/ha_carrier/sensor.py
@@ -102,7 +102,7 @@ class GasMeasurementSensor(CarrierEntity, SensorEntity):
         self.entity_description = SensorEntityDescription(
             key=metric,
             device_class=SensorDeviceClass.GAS,
-            state_class=SensorStateClass.TOTAL_INCREASING,
+            state_class=SensorStateClass.TOTAL,
             native_unit_of_measurement=unit_of_measurement,
             suggested_display_precision=2,
             last_reset=datetime(year=datetime.now().year, month=1, day=1)
@@ -131,7 +131,7 @@ class PropaneMeasurementSensor(CarrierEntity, SensorEntity):
         self.entity_description = SensorEntityDescription(
             key="propane",
             device_class=SensorDeviceClass.VOLUME,
-            state_class=SensorStateClass.TOTAL_INCREASING,
+            state_class=SensorStateClass.TOTAL,
             native_unit_of_measurement=UnitOfVolume.GALLONS,
             suggested_display_precision=2,
             last_reset=datetime(year=datetime.now().year, month=1, day=1)
@@ -153,7 +153,7 @@ class EnergyMeasurementSensor(CarrierEntity, SensorEntity):
         self.entity_description = SensorEntityDescription(
             key=metric,
             device_class=SensorDeviceClass.ENERGY,
-            state_class=SensorStateClass.TOTAL_INCREASING,
+            state_class=SensorStateClass.TOTAL,
             native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
             suggested_display_precision=0,
             last_reset=datetime(year=datetime.now().year, month=1, day=1)


### PR DESCRIPTION
First, thank you for the great integration, really appreciate the work that’s gone into this.

I’m seeing the following error related to new EnergyMeasurementSensor:

```
ValueError: Entity sensor.[*]_cooling_energy_yearly 
(<class 'custom_components.ha_carrier.sensor.EnergyMeasurementSensor'>) 
with state_class total_increasing has set last_reset. Setting last_reset for entities with 
state_class other than 'total' is not supported. 
Please update your configuration if state_class is manually configured.
```

Would it make sense to apply this change:
Switch `SensorStateClass.TOTAL_INCREASING` to `SensorStateClass.TOTAL`
