### PR TITLE
fix: yearly energy sensor

### DIFF
--- a/custom_components/ha_carrier/sensor.py
+++ b/custom_components/ha_carrier/sensor.py
@@ -14,7 +14,7 @@ from homeassistant.const import (
     UnitOfVolume, UnitOfPressure,
 )
 from homeassistant.config_entries import ConfigEntry
-from datetime import datetime
+from datetime import UTC, datetime
 from carrier_api import TemperatureUnits
 
 
@@ -102,10 +102,10 @@ class GasMeasurementSensor(CarrierEntity, SensorEntity):
         self.entity_description = SensorEntityDescription(
             key=metric,
             device_class=SensorDeviceClass.GAS,
-            state_class=SensorStateClass.TOTAL_INCREASING,
+            state_class=SensorStateClass.TOTAL,
             native_unit_of_measurement=unit_of_measurement,
             suggested_display_precision=2,
-            last_reset=datetime(year=datetime.now().year, month=1, day=1)
+            last_reset=datetime(year=datetime.now(UTC).year, month=1, day=1, tzinfo=UTC)
         )
         super().__init__(f"{self.fuel_type.capitalize()} Yearly", updater, system_serial)
 
@@ -131,10 +131,10 @@ class PropaneMeasurementSensor(CarrierEntity, SensorEntity):
         self.entity_description = SensorEntityDescription(
             key="propane",
             device_class=SensorDeviceClass.VOLUME,
-            state_class=SensorStateClass.TOTAL_INCREASING,
+            state_class=SensorStateClass.TOTAL,
             native_unit_of_measurement=UnitOfVolume.GALLONS,
             suggested_display_precision=2,
-            last_reset=datetime(year=datetime.now().year, month=1, day=1)
+            last_reset=datetime(year=datetime.now(UTC).year, month=1, day=1, tzinfo=UTC)
         )
         super().__init__("Propane Yearly Gallons", updater, system_serial)
 
@@ -153,10 +153,10 @@ class EnergyMeasurementSensor(CarrierEntity, SensorEntity):
         self.entity_description = SensorEntityDescription(
             key=metric,
             device_class=SensorDeviceClass.ENERGY,
-            state_class=SensorStateClass.TOTAL_INCREASING,
+            state_class=SensorStateClass.TOTAL,
             native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
             suggested_display_precision=0,
-            last_reset=datetime(year=datetime.now().year, month=1, day=1)
+            last_reset=datetime(year=datetime.now(UTC).year, month=1, day=1, tzinfo=UTC)
         )
         super().__init__(f"{self.entity_description.key} Energy Yearly", updater, system_serial)
 


### PR DESCRIPTION
My yearly energy sensor stopped working. I got this error in the home assistant log .

```
This error originated from a custom integration.

Logger: custom_components.ha_carrier
Source: custom_components/ha_carrier/__init__.py:68
integration: Carrier Infinity (documentation, issues)
First occurred: 10:56:57 (5 occurrences)
Last logged: 11:01:58

websocket task exception
Traceback (most recent call last):
  File "/config/custom_components/ha_carrier/__init__.py", line 68, in ws_updates
    await data[DATA_UPDATE_COORDINATOR].api_connection.api_websocket.listener()
  File "/usr/local/lib/python3.13/site-packages/carrier_api/api_websocket.py", line 68, in listener
    await async_callback(msg.data)
  File "/config/custom_components/ha_carrier/carrier_data_update_coordinator.py", line 115, in updated_callback
    self.async_update_listeners()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 200, in async_update_listeners
    update_callback()
    ~~~~~~~~~~~~~~~^^
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 613, in _handle_coordinator_update
    self.async_write_ha_state()
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1018, in async_write_ha_state
    self._async_write_ha_state()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1163, in _async_write_ha_state
    ) = self.__async_calculate_state()
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1072, in __async_calculate_state
    if state_attributes := self.state_attributes:
                           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/sensor/__init__.py", line 443, in state_attributes
    raise ValueError(
    ...<4 lines>...
    )
ValueError: Entity sensor.upstairs_cooling_energy_yearly (<class 'custom_components.ha_carrier.sensor.EnergyMeasurementSensor'>) with state_class total_increasing has set last_reset. Setting last_reset for entities with state_class other than 'total' is not supported. Please update your configuration if state_class is manually configured.
```

I believe the code from commit 38d5afa7c9088d4b9d3af1ce5d030b4667b7b34c is incorrect.

This is the suggested fix, which I tested.
