### PR TITLE
Fix transient HA unavailable on activity lookup race

### DIFF
--- a/custom_components/ha_carrier/climate.py
+++ b/custom_components/ha_carrier/climate.py
@@ -374,4 +374,10 @@ class Thermostat(CarrierEntity, ClimateEntity):
     @property
     def available(self) -> bool:
         """Return true if sensor is ready for display."""
-        return self._status_zone is not None and self._current_activity() is not None
+        # `find_activity(status.current_activity)` can transiently return None
+        # during websocket/config synchronization. Availability should reflect
+        # zone existence, not activity lookup success in that instant.
+        try:
+            return self._status_zone is not None and self._config_zone is not None
+        except ValueError:
+            return False


### PR DESCRIPTION
Observed intermittent bug: zone climate entity becomes Unavailable in Home Assistant after preset/hold transitions even though Carrier state remains valid.

I had a reproducible scenario for this :
1. start with "Dining room" zone in "Home" mode (set to 68F)
2. set it to 67F (manual) in HA
3. change it to preset "Away" in HA, which heats at 50F
4. zone gets marked as unavailable in HA . It remains in that state, and can no longer be changed from HA.

I found 2 possible workarounds :
1. change the state in the Carrier app, or on the physical thermostat. The zone state in HA_carrier then updates, and it becomes available in HA again
2. reload the HA Carrier integration in HA

Neither of these workarounds are very good. I spent some time debugging this with ChatGPT Codex monitoring the sequence of external events with the Carrier API, and this is the minimal fix it came up with. I tested it, and my reproducible test case now passes.
