### PR TITLE
Remove device class for air filter remaining sensor, as it is not a b…

### DIFF
--- a/custom_components/ha_carrier/sensor.py
+++ b/custom_components/ha_carrier/sensor.py
@@ -302,8 +302,7 @@ class OutdoorTemperatureSensor(CarrierEntity, SensorEntity):
 
 
 class FilterUsedSensor(CarrierEntity, SensorEntity):
-    """Filter used sensor, mimics battery for easy testing."""
-    _attr_device_class = SensorDeviceClass.BATTERY
+    """Air filter remaining sensor."""
     _attr_native_unit_of_measurement = PERCENTAGE
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_icon = "mdi:air-filter"


### PR DESCRIPTION
…attery, and was showing in my battery dashboard in error.