### PR TITLE
fix: npm issues for Release Workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - name: Gets semantic release info
+      - name: Get semantic release info
         id: semantic_release_info
         uses: cycjimmy/semantic-release-action@v6
         with:

--- a/.github/workflows/update_carrier_api.yml
+++ b/.github/workflows/update_carrier_api.yml
@@ -110,7 +110,7 @@ jobs:
 
       - name: Install semver for release notes generation
         if: steps.versions.outputs.update_needed == 'true'
-        run: npm install semver
+        run: npm install --prefix "$RUNNER_TEMP/ha-carrier-semver" semver
 
       - name: Build carrier-api release notes
         if: steps.versions.outputs.update_needed == 'true'
@@ -119,6 +119,7 @@ jobs:
         env:
           CURRENT_VERSION: ${{ steps.versions.outputs.current_manifest }}
           LATEST_VERSION: ${{ steps.versions.outputs.latest }}
+          NODE_PATH: ${{ runner.temp }}/ha-carrier-semver/node_modules
           REPO_OWNER: ${{ github.event.inputs.carrier_api_release_owner || 'dahlb' }}
           REPO_NAME: ${{ github.event.inputs.carrier_api_release_repo || 'carrier_api' }}
         with:

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,7 @@
+{
+  "branches": ["main"],
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,0 @@
-{
-  "release": {
-    "branches": ["main"]
-  }
-}


### PR DESCRIPTION
Sorry about that. This should fix the release workflow to not try to create an npm package

This pull request updates the release automation configuration to better support semantic release and improves the way dependencies are installed in the carrier API update workflow. The most significant changes include moving semantic release configuration to `.releaserc.json`, refining dependency installation for release notes generation, and minor workflow improvements.

**Release automation configuration:**

* Added a new `.releaserc.json` file to configure semantic release branches and plugins, centralizing and standardizing release settings.
* Removed the old release configuration from `package.json`, moving all release-related settings to `.releaserc.json`.

**Carrier API update workflow improvements:**

* Changed the installation of `semver` to use a temporary directory, ensuring a cleaner environment and avoiding polluting the global or project-level `node_modules`.
* Set the `NODE_PATH` environment variable to point to the temporary `semver` installation, ensuring the workflow can find the dependency during release notes generation.

**Minor workflow updates:**

* Fixed a typo in the release workflow step name for getting semantic release info, improving clarity.