### PR TITLE
fix: update carrier api workflow

### DIFF
--- a/.github/workflows/update_carrier_api.yml
+++ b/.github/workflows/update_carrier_api.yml
@@ -316,8 +316,8 @@ jobs:
             } catch (error) {
               const status = error.status ?? error.response?.status;
 
-              if (status === 404) {
-                core.info(`Branch ${branch} was already deleted.`);
+              if (status === 404 || status === 422) {
+                core.info(`Branch ${branch} does not exist; nothing to delete.`);
                 return;
               }
 


### PR DESCRIPTION
## Summary

- Handle GitHub API `422` responses when deleting the temporary `update-carrier-api` branch.
- Treat both `404` and `422` as “branch does not exist” cases so the workflow exits cleanly instead of failing.
- Update the log message to describe the no-op branch deletion case more accurately.
