### PR TITLE
fix: ODU Var sensor stays available when heat pump is idle

### DIFF
--- a/custom_components/ha_carrier/sensor.py
+++ b/custom_components/ha_carrier/sensor.py
@@ -882,24 +882,25 @@ class OutDoorUnitVarSensor(CarrierEntity, SensorEntity):
     def native_value(self) -> float | None:
         """Return normalized variable outdoor unit percentage.
 
+        Non-numeric values such as ``'off'`` are treated as 0 % so the sensor
+        stays available while the unit is idle rather than going unavailable.
+
         Returns:
-            float | None: Percentage when the payload is numeric, else None.
+            float | None: Percentage, or None when no data is present.
         """
         value = self.carrier_system.status.outdoor_unit_operational_status
-        if value is None:
+        if value is None or not isinstance(value, str):
             return None
-        if isinstance(value, str):
-            try:
-                return float(value)
-            except ValueError:
-                return None
-        return None
+        try:
+            return float(value)
+        except ValueError:
+            return 0.0
 
     @property
     def available(self) -> bool:
         """Indicate whether variable-capacity percentage is available.
 
         Returns:
-            bool: True when a normalized percentage value exists.
+            bool: True when outdoor operational status data exists.
         """
         return self.native_value is not None


### PR DESCRIPTION
## Problem

The OutDoorUnitVarSensor (ODU Var) would become unavailable in Home Assistant whenever the heat pump was idle, because the API returns a non-numeric string (e.g. 'off') for outdoor_unit_operational_status in that state. The previous code returned None on any ValueError, which caused available to return False.

## Solution

Non-numeric string values (like 'off') are now treated as 0.0 instead of None. This keeps the sensor available while the unit is idle, with a value of 0%, rather than disappearing from the UI entirely.

The available property now returns True whenever the API provides any status data (i.e. the value is not None and is a string), regardless of whether it's numeric.

## Changes

sensor.py:882-906 — native_value now returns 0.0 on ValueError instead of None; available now reflects data presence rather than a valid numeric value

Fixes #359 