### PR TITLE
fix: Bump Home Assistant requirement to 2026.3

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -2,5 +2,5 @@
   "name": "Carrier Infinity Thermostat",
   "content_in_root": false,
   "country": ["US"],
-  "homeassistant": "2025.10.0b0"
+  "homeassistant": "2026.3.0b0"
 }


### PR DESCRIPTION
HA 2026.3.0 was the first version requiring Python 3.14

Update hacs.json to require Home Assistant 2026.3.0b0 (was 2025.10.0b0). This updates the integration's declared compatibility in HACS to the newer development release.