### PR TITLE
feat: Refactor entities

### DIFF
--- a/custom_components/ha_carrier/__init__.py
+++ b/custom_components/ha_carrier/__init__.py
@@ -12,7 +12,7 @@ from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv, entity_registry as er
-from homeassistant.helpers.entity_registry import RegistryEntry
+from homeassistant.helpers.entity_registry import EntityRegistry, RegistryEntry
 from homeassistant.util import slugify
 
 from .carrier_data_update_coordinator import CarrierDataUpdateCoordinator, CarrierUnauthorizedError
@@ -24,7 +24,7 @@ from .const import (
     WEBSOCKET_RETRY_INITIAL_DELAY_SECONDS,
     WEBSOCKET_RETRY_MAX_DELAY_SECONDS,
 )
-from .util import TIMESTAMP_TYPES, async_redact_data
+from .util import TIMESTAMP_TYPES, async_redact_data, has_heat
 
 type ConfigEntryCarrier = ConfigEntry[CarrierDataUpdateCoordinator]
 
@@ -41,18 +41,20 @@ ENERGY_METRICS: tuple[str, ...] = (
     "fan_gas",
     "loop_pump",
 )
-SYSTEM_ENTITY_SUFFIXES: tuple[str, ...] = (
+ALWAYS_CREATED_SYSTEM_ENTITY_SUFFIXES: tuple[str, ...] = (
     "Online",
-    "Humidifier Running",
-    "Heat Source",
     "Outdoor Temperature",
     "Filter Remaining",
-    "Humidifier Remaining",
-    "UV Lamp Remaining",
     "Airflow",
     "Static Pressure",
     "ODU Status",
     "IDU Status",
+)
+CONDITIONALLY_CREATED_SYSTEM_ENTITY_SUFFIXES: tuple[str, ...] = (
+    "Humidifier Running",
+    "Heat Source",
+    "Humidifier Remaining",
+    "UV Lamp Remaining",
     "ODU Var",
 )
 
@@ -106,7 +108,10 @@ def _async_build_unique_id_migration_map(systems: Iterable[System]) -> dict[str,
     for carrier_system in systems:
         system_serial = carrier_system.profile.serial
 
-        for suffix in SYSTEM_ENTITY_SUFFIXES:
+        for suffix in (
+            *ALWAYS_CREATED_SYSTEM_ENTITY_SUFFIXES,
+            *CONDITIONALLY_CREATED_SYSTEM_ENTITY_SUFFIXES,
+        ):
             _async_add_unique_id_migration(migration_map, system_serial, suffix)
 
         for timestamp_type in TIMESTAMP_TYPES:
@@ -182,36 +187,169 @@ def _async_build_unique_id_migration_map(systems: Iterable[System]) -> dict[str,
     return migration_map
 
 
-def _async_entity_unique_id_migration_updates(
-    entry: RegistryEntry,
-    migration_map: Mapping[str, str],
-    existing_unique_ids: set[str],
-) -> dict[str, str] | None:
-    """Return entity registry updates for one legacy Carrier registry entry.
+def _async_build_created_unique_ids(systems: Iterable[System]) -> set[str]:
+    """Build unique IDs that version 2 setup will create for Carrier systems.
 
     Args:
-        entry: Entity registry entry being considered for migration.
-        migration_map: Old-to-new unique ID migration map.
-        existing_unique_ids: Unique IDs already present for this config entry.
+        systems: Carrier systems loaded from the account during migration.
 
     Returns:
-        dict[str, str] | None: Entity registry update payload, or None.
+        set[str]: Version 2 entity unique IDs expected to be created.
     """
-    new_unique_id = migration_map.get(entry.unique_id)
-    if new_unique_id is None or new_unique_id == entry.unique_id:
-        return None
-    if new_unique_id in existing_unique_ids:
-        _LOGGER.debug(
-            "Skipping Carrier entity unique ID migration for %s; %s already exists",
-            entry.entity_id,
-            new_unique_id,
-        )
-        return None
-    existing_unique_ids.add(new_unique_id)
-    return {"new_unique_id": new_unique_id}
+    created_unique_ids: set[str] = set()
+
+    for carrier_system in systems:
+        system_serial = carrier_system.profile.serial
+        for suffix in ALWAYS_CREATED_SYSTEM_ENTITY_SUFFIXES:
+            created_unique_ids.add(_async_new_unique_id(system_serial, suffix))
+
+        for timestamp_type in TIMESTAMP_TYPES:
+            created_unique_ids.add(
+                _async_new_unique_id(
+                    system_serial,
+                    f"{timestamp_type.replace('_', ' ').title()} Last Updated",
+                )
+            )
+
+        if carrier_system.config.humidifier_enabled:
+            created_unique_ids.add(_async_new_unique_id(system_serial, "Humidifier Running"))
+            created_unique_ids.add(_async_new_unique_id(system_serial, "Humidifier Remaining"))
+        if carrier_system.config.uv_enabled:
+            created_unique_ids.add(_async_new_unique_id(system_serial, "UV Lamp Remaining"))
+        if carrier_system.profile.outdoor_unit_type in ["varcaphp", "varcapac"]:
+            created_unique_ids.add(_async_new_unique_id(system_serial, "ODU Var"))
+        if has_heat(carrier_system):
+            created_unique_ids.add(_async_new_unique_id(system_serial, "Heat Source"))
+
+        for metric in ENERGY_METRICS:
+            if getattr(carrier_system.energy, metric, False) is True:
+                metric_title = metric.replace("_", " ").title()
+                created_unique_ids.add(
+                    _async_new_unique_id(system_serial, f"{metric_title} Energy Year to Date")
+                )
+                created_unique_ids.add(
+                    _async_new_unique_id(system_serial, f"{metric_title} Energy Yesterday")
+                )
+                created_unique_ids.add(
+                    _async_new_unique_id(system_serial, f"{metric_title} Energy Last Month")
+                )
+
+        if getattr(carrier_system.energy, "gas", False) is True:
+            created_unique_ids.add(
+                _async_new_unique_id(
+                    system_serial,
+                    f"{carrier_system.config.fuel_type.capitalize()} Usage Year to Date",
+                )
+            )
+            if carrier_system.config.fuel_type == "propane":
+                created_unique_ids.add(
+                    _async_new_unique_id(system_serial, "Propane Consumption Year to Date")
+                )
+
+        for zone in carrier_system.config.zones:
+            zone_unique_id_suffix = f"zone_{zone.api_id}"
+            created_unique_ids.add(
+                _async_new_unique_id(system_serial, f"{zone_unique_id_suffix}_thermostat")
+            )
+            created_unique_ids.add(
+                _async_new_unique_id(system_serial, f"{zone_unique_id_suffix}_humidity")
+            )
+            created_unique_ids.add(
+                _async_new_unique_id(system_serial, f"{zone_unique_id_suffix}_temperature")
+            )
+            if zone.occupancy_enabled:
+                created_unique_ids.add(
+                    _async_new_unique_id(system_serial, f"{zone_unique_id_suffix}_occupancy")
+                )
+
+    return created_unique_ids
+
+
+def _async_migrate_entity_unique_ids(
+    ent_reg: EntityRegistry,
+    registry_entries: Iterable[RegistryEntry],
+    migration_map: Mapping[str, str],
+    created_unique_ids: set[str],
+) -> None:
+    """Rename or remove legacy Carrier entity registry entries.
+
+    Args:
+        ent_reg: Home Assistant entity registry.
+        registry_entries: Entity registry entries owned by the config entry.
+        migration_map: Old-to-new unique ID migration map.
+        created_unique_ids: Unique IDs that version 2 setup will create.
+
+    Returns:
+        None: Entity registry entries are updated in place.
+    """
+    existing_unique_ids = {entry.unique_id for entry in registry_entries}
+
+    for entry in registry_entries:
+        new_unique_id = migration_map.get(entry.unique_id)
+        if new_unique_id is None or new_unique_id == entry.unique_id:
+            continue
+
+        if new_unique_id not in created_unique_ids:
+            _LOGGER.debug(
+                "Removing stale Carrier entity %s during unique ID migration",
+                entry.entity_id,
+            )
+            ent_reg.async_remove(entry.entity_id)
+            existing_unique_ids.discard(entry.unique_id)
+            continue
+
+        if new_unique_id in existing_unique_ids:
+            _LOGGER.debug(
+                "Removing duplicate legacy Carrier entity %s during unique ID migration",
+                entry.entity_id,
+            )
+            ent_reg.async_remove(entry.entity_id)
+            existing_unique_ids.discard(entry.unique_id)
+            continue
+
+        ent_reg.async_update_entity(entry.entity_id, new_unique_id=new_unique_id)
+        existing_unique_ids.discard(entry.unique_id)
+        existing_unique_ids.add(new_unique_id)
+
+
+async def _async_migrate_entity_registry_unique_ids(
+    hass: HomeAssistant,
+    config_entry: ConfigEntryCarrier,
+    migration_map: Mapping[str, str],
+    created_unique_ids: set[str],
+) -> None:
+    """Migrate or remove entity registry entries for one Carrier config entry.
+
+    Args:
+        hass: Home Assistant instance.
+        config_entry: Carrier config entry being migrated.
+        migration_map: Old-to-new unique ID migration map.
+        created_unique_ids: Unique IDs that version 2 setup will create.
+
+    Returns:
+        None: Entity registry entries are updated in place.
+    """
+    ent_reg = er.async_get(hass)
+    registry_entries = list(ent_reg.entities.get_entries_for_config_entry_id(config_entry.entry_id))
+    _async_migrate_entity_unique_ids(
+        ent_reg,
+        registry_entries,
+        migration_map,
+        created_unique_ids,
+    )
 
 
 async def _migrate_1_to_2(hass: HomeAssistant, config_entry: ConfigEntryCarrier) -> bool:
+    """Migrate a Carrier config entry from version 1 to version 2.
+
+    Args:
+        hass: Home Assistant instance.
+        config_entry: Version 1 Carrier config entry being migrated.
+
+    Returns:
+        bool: True when entity registry migration and config entry version
+            update succeed.
+    """
     try:
         api_connection = ApiConnectionGraphql(
             username=config_entry.data[CONF_USERNAME],
@@ -229,18 +367,11 @@ async def _migrate_1_to_2(hass: HomeAssistant, config_entry: ConfigEntryCarrier)
         _LOGGER.exception("Unable to load Carrier data for config entry migration")
         return False
 
-    migration_map = _async_build_unique_id_migration_map(systems)
-    ent_reg = er.async_get(hass)
-    existing_unique_ids = {
-        entry.unique_id
-        for entry in ent_reg.entities.get_entries_for_config_entry_id(config_entry.entry_id)
-    }
-    await er.async_migrate_entries(
+    await _async_migrate_entity_registry_unique_ids(
         hass,
-        config_entry.entry_id,
-        lambda entry: _async_entity_unique_id_migration_updates(
-            entry, migration_map, existing_unique_ids
-        ),
+        config_entry,
+        _async_build_unique_id_migration_map(systems),
+        _async_build_created_unique_ids(systems),
     )
     hass.config_entries.async_update_entry(config_entry, version=CONFIG_FLOW_VERSION)
     _LOGGER.info("Carrier config entry migration to version %s complete", CONFIG_FLOW_VERSION)

--- a/custom_components/ha_carrier/__init__.py
+++ b/custom_components/ha_carrier/__init__.py
@@ -24,7 +24,7 @@ from .const import (
     WEBSOCKET_RETRY_INITIAL_DELAY_SECONDS,
     WEBSOCKET_RETRY_MAX_DELAY_SECONDS,
 )
-from .util import async_redact_data
+from .util import TIMESTAMP_TYPES, async_redact_data
 
 type ConfigEntryCarrier = ConfigEntry[CarrierDataUpdateCoordinator]
 
@@ -55,7 +55,6 @@ SYSTEM_ENTITY_SUFFIXES: tuple[str, ...] = (
     "IDU Status",
     "ODU Var",
 )
-TIMESTAMP_TYPES: tuple[str, ...] = ("all_data", "websocket", "energy")
 
 
 def _async_new_unique_id(system_serial: str, new_suffix: str) -> str:

--- a/custom_components/ha_carrier/__init__.py
+++ b/custom_components/ha_carrier/__init__.py
@@ -1,19 +1,16 @@
 """Initialize and manage the Home Assistant Carrier integration lifecycle."""
 
 import asyncio
-from collections.abc import Iterable, Mapping
 import logging
 
 from aiohttp import ClientError
-from carrier_api import ApiConnectionGraphql, AuthError, BaseError, System
+from carrier_api import ApiConnectionGraphql
 from gql.transport.exceptions import TransportError, TransportServerError
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers import config_validation as cv, entity_registry as er
-from homeassistant.helpers.entity_registry import EntityRegistry, RegistryEntry
-from homeassistant.util import slugify
+from homeassistant.helpers import config_validation as cv
 
 from .carrier_data_update_coordinator import CarrierDataUpdateCoordinator, CarrierUnauthorizedError
 from .const import (
@@ -24,391 +21,13 @@ from .const import (
     WEBSOCKET_RETRY_INITIAL_DELAY_SECONDS,
     WEBSOCKET_RETRY_MAX_DELAY_SECONDS,
 )
-from .util import TIMESTAMP_TYPES, async_redact_data, has_heat
+from .migrate import migrate_1_to_2
+from .util import async_redact_data
 
 type ConfigEntryCarrier = ConfigEntry[CarrierDataUpdateCoordinator]
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
-
-# For migrations from version 1 to 2
-ENERGY_METRICS: tuple[str, ...] = (
-    "cooling",
-    "hp_heat",
-    "fan",
-    "electric_heat",
-    "reheat",
-    "fan_gas",
-    "loop_pump",
-)
-ALWAYS_CREATED_SYSTEM_ENTITY_SUFFIXES: tuple[str, ...] = (
-    "Online",
-    "Outdoor Temperature",
-    "Filter Remaining",
-    "Airflow",
-    "Static Pressure",
-    "ODU Status",
-    "IDU Status",
-)
-CONDITIONALLY_CREATED_SYSTEM_ENTITY_SUFFIXES: tuple[str, ...] = (
-    "Humidifier Running",
-    "Heat Source",
-    "Humidifier Remaining",
-    "UV Lamp Remaining",
-    "ODU Var",
-)
-
-
-def _async_new_unique_id(system_serial: str, new_suffix: str) -> str:
-    """Return the version 2 unique ID for a Carrier entity.
-
-    Args:
-        system_serial: Carrier system serial number.
-        new_suffix: Version 2 unique ID suffix.
-
-    Returns:
-        str: Slugified version 2 unique ID.
-    """
-    return slugify(f"{system_serial}_{new_suffix}")
-
-
-def _async_add_unique_id_migration(
-    migration_map: dict[str, str],
-    system_serial: str,
-    old_suffix: str,
-    new_suffix: str | None = None,
-) -> None:
-    """Add one legacy unique ID to version 2 unique ID mapping.
-
-    Args:
-        migration_map: Mutable migration map being built.
-        system_serial: Carrier system serial number.
-        old_suffix: Version 1 unique ID suffix.
-        new_suffix: Version 2 unique ID suffix. Defaults to old_suffix.
-
-    Returns:
-        None: The mapping is updated in place.
-    """
-    migration_map[f"{system_serial}_{old_suffix}"] = _async_new_unique_id(
-        system_serial, new_suffix or old_suffix
-    )
-
-
-def _async_build_unique_id_migration_map(systems: Iterable[System]) -> dict[str, str]:
-    """Build old-to-new entity unique ID mappings for Carrier systems.
-
-    Args:
-        systems: Carrier systems loaded from the account during migration.
-
-    Returns:
-        dict[str, str]: Mapping from version 1 unique IDs to version 2 unique IDs.
-    """
-    migration_map: dict[str, str] = {}
-
-    for carrier_system in systems:
-        system_serial = carrier_system.profile.serial
-
-        for suffix in (
-            *ALWAYS_CREATED_SYSTEM_ENTITY_SUFFIXES,
-            *CONDITIONALLY_CREATED_SYSTEM_ENTITY_SUFFIXES,
-        ):
-            _async_add_unique_id_migration(migration_map, system_serial, suffix)
-
-        for timestamp_type in TIMESTAMP_TYPES:
-            _async_add_unique_id_migration(
-                migration_map,
-                system_serial,
-                f"updated {timestamp_type.replace('_', ' ').capitalize()} at",
-                f"{timestamp_type.replace('_', ' ').title()} Last Updated",
-            )
-
-        fuel_type = carrier_system.config.fuel_type
-        _async_add_unique_id_migration(
-            migration_map,
-            system_serial,
-            f"{fuel_type.capitalize()} Yearly",
-            f"{fuel_type.capitalize()} Usage Year to Date",
-        )
-        _async_add_unique_id_migration(
-            migration_map,
-            system_serial,
-            "Propane Yearly Gallons",
-            "Propane Consumption Year to Date",
-        )
-
-        for metric in ENERGY_METRICS:
-            metric_title = metric.replace("_", " ").title()
-            _async_add_unique_id_migration(
-                migration_map,
-                system_serial,
-                f"{metric} Energy Yearly",
-                f"{metric_title} Energy Year to Date",
-            )
-            _async_add_unique_id_migration(
-                migration_map,
-                system_serial,
-                f"{metric} Energy Yesterday",
-                f"{metric_title} Energy Yesterday",
-            )
-            _async_add_unique_id_migration(
-                migration_map,
-                system_serial,
-                f"{metric} Energy Last Month",
-                f"{metric_title} Energy Last Month",
-            )
-
-        for zone in carrier_system.config.zones:
-            zone_unique_id_suffix = f"zone_{zone.api_id}"
-            _async_add_unique_id_migration(
-                migration_map,
-                system_serial,
-                zone.name,
-                f"{zone_unique_id_suffix}_thermostat",
-            )
-            _async_add_unique_id_migration(
-                migration_map,
-                system_serial,
-                f"{zone.name} Occupancy",
-                f"{zone_unique_id_suffix}_occupancy",
-            )
-            _async_add_unique_id_migration(
-                migration_map,
-                system_serial,
-                f"{zone.name} Humidity",
-                f"{zone_unique_id_suffix}_humidity",
-            )
-            _async_add_unique_id_migration(
-                migration_map,
-                system_serial,
-                f"{zone.name} Temperature",
-                f"{zone_unique_id_suffix}_temperature",
-            )
-
-    return migration_map
-
-
-def _async_build_created_unique_ids(systems: Iterable[System]) -> set[str]:
-    """Build unique IDs that version 2 setup will create for Carrier systems.
-
-    Args:
-        systems: Carrier systems loaded from the account during migration.
-
-    Returns:
-        set[str]: Version 2 entity unique IDs expected to be created.
-    """
-    created_unique_ids: set[str] = set()
-
-    for carrier_system in systems:
-        system_serial = carrier_system.profile.serial
-        for suffix in ALWAYS_CREATED_SYSTEM_ENTITY_SUFFIXES:
-            created_unique_ids.add(_async_new_unique_id(system_serial, suffix))
-
-        for timestamp_type in TIMESTAMP_TYPES:
-            created_unique_ids.add(
-                _async_new_unique_id(
-                    system_serial,
-                    f"{timestamp_type.replace('_', ' ').title()} Last Updated",
-                )
-            )
-
-        if carrier_system.config.humidifier_enabled:
-            created_unique_ids.add(_async_new_unique_id(system_serial, "Humidifier Running"))
-            created_unique_ids.add(_async_new_unique_id(system_serial, "Humidifier Remaining"))
-        if carrier_system.config.uv_enabled:
-            created_unique_ids.add(_async_new_unique_id(system_serial, "UV Lamp Remaining"))
-        if carrier_system.profile.outdoor_unit_type in ["varcaphp", "varcapac"]:
-            created_unique_ids.add(_async_new_unique_id(system_serial, "ODU Var"))
-        if has_heat(carrier_system):
-            created_unique_ids.add(_async_new_unique_id(system_serial, "Heat Source"))
-
-        for metric in ENERGY_METRICS:
-            if getattr(carrier_system.energy, metric, False) is True:
-                metric_title = metric.replace("_", " ").title()
-                created_unique_ids.add(
-                    _async_new_unique_id(system_serial, f"{metric_title} Energy Year to Date")
-                )
-                created_unique_ids.add(
-                    _async_new_unique_id(system_serial, f"{metric_title} Energy Yesterday")
-                )
-                created_unique_ids.add(
-                    _async_new_unique_id(system_serial, f"{metric_title} Energy Last Month")
-                )
-
-        if getattr(carrier_system.energy, "gas", False) is True:
-            created_unique_ids.add(
-                _async_new_unique_id(
-                    system_serial,
-                    f"{carrier_system.config.fuel_type.capitalize()} Usage Year to Date",
-                )
-            )
-            if carrier_system.config.fuel_type == "propane":
-                created_unique_ids.add(
-                    _async_new_unique_id(system_serial, "Propane Consumption Year to Date")
-                )
-
-        for zone in carrier_system.config.zones:
-            zone_unique_id_suffix = f"zone_{zone.api_id}"
-            created_unique_ids.add(
-                _async_new_unique_id(system_serial, f"{zone_unique_id_suffix}_thermostat")
-            )
-            created_unique_ids.add(
-                _async_new_unique_id(system_serial, f"{zone_unique_id_suffix}_humidity")
-            )
-            created_unique_ids.add(
-                _async_new_unique_id(system_serial, f"{zone_unique_id_suffix}_temperature")
-            )
-            if zone.occupancy_enabled:
-                created_unique_ids.add(
-                    _async_new_unique_id(system_serial, f"{zone_unique_id_suffix}_occupancy")
-                )
-
-    return created_unique_ids
-
-
-def _async_migrate_entity_unique_ids(
-    ent_reg: EntityRegistry,
-    registry_entries: Iterable[RegistryEntry],
-    migration_map: Mapping[str, str],
-    created_unique_ids: set[str],
-) -> None:
-    """Rename or remove legacy Carrier entity registry entries.
-
-    Args:
-        ent_reg: Home Assistant entity registry.
-        registry_entries: Entity registry entries owned by the config entry.
-        migration_map: Old-to-new unique ID migration map.
-        created_unique_ids: Unique IDs that version 2 setup will create.
-
-    Returns:
-        None: Entity registry entries are updated in place.
-    """
-    existing_unique_ids = {entry.unique_id for entry in registry_entries}
-
-    for entry in registry_entries:
-        new_unique_id = migration_map.get(entry.unique_id)
-        if new_unique_id is None or new_unique_id == entry.unique_id:
-            continue
-
-        if new_unique_id not in created_unique_ids:
-            _LOGGER.debug(
-                "Removing stale Carrier entity %s during unique ID migration",
-                entry.entity_id,
-            )
-            ent_reg.async_remove(entry.entity_id)
-            existing_unique_ids.discard(entry.unique_id)
-            continue
-
-        if new_unique_id in existing_unique_ids:
-            _LOGGER.debug(
-                "Removing duplicate legacy Carrier entity %s during unique ID migration",
-                entry.entity_id,
-            )
-            ent_reg.async_remove(entry.entity_id)
-            existing_unique_ids.discard(entry.unique_id)
-            continue
-
-        ent_reg.async_update_entity(entry.entity_id, new_unique_id=new_unique_id)
-        existing_unique_ids.discard(entry.unique_id)
-        existing_unique_ids.add(new_unique_id)
-
-
-async def _async_migrate_entity_registry_unique_ids(
-    hass: HomeAssistant,
-    config_entry: ConfigEntryCarrier,
-    migration_map: Mapping[str, str],
-    created_unique_ids: set[str],
-) -> None:
-    """Migrate or remove entity registry entries for one Carrier config entry.
-
-    Args:
-        hass: Home Assistant instance.
-        config_entry: Carrier config entry being migrated.
-        migration_map: Old-to-new unique ID migration map.
-        created_unique_ids: Unique IDs that version 2 setup will create.
-
-    Returns:
-        None: Entity registry entries are updated in place.
-    """
-    ent_reg = er.async_get(hass)
-    registry_entries = list(ent_reg.entities.get_entries_for_config_entry_id(config_entry.entry_id))
-    _async_migrate_entity_unique_ids(
-        ent_reg,
-        registry_entries,
-        migration_map,
-        created_unique_ids,
-    )
-
-
-async def _migrate_1_to_2(hass: HomeAssistant, config_entry: ConfigEntryCarrier) -> bool:
-    """Migrate a Carrier config entry from version 1 to version 2.
-
-    Args:
-        hass: Home Assistant instance.
-        config_entry: Version 1 Carrier config entry being migrated.
-
-    Returns:
-        bool: True when entity registry migration and config entry version
-            update succeed.
-    """
-    try:
-        api_connection = ApiConnectionGraphql(
-            username=config_entry.data[CONF_USERNAME],
-            password=config_entry.data[CONF_PASSWORD],
-        )
-        systems = await api_connection.load_data()
-    except (
-        AuthError,
-        BaseError,
-        ClientError,
-        TimeoutError,
-        OSError,
-        TransportError,
-    ):
-        _LOGGER.exception("Unable to load Carrier data for config entry migration")
-        return False
-
-    await _async_migrate_entity_registry_unique_ids(
-        hass,
-        config_entry,
-        _async_build_unique_id_migration_map(systems),
-        _async_build_created_unique_ids(systems),
-    )
-    hass.config_entries.async_update_entry(config_entry, version=CONFIG_FLOW_VERSION)
-    _LOGGER.info("Carrier config entry migration to version %s complete", CONFIG_FLOW_VERSION)
-    return True
-
-
-async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntryCarrier) -> bool:
-    """Migrate Carrier config entries between config flow versions.
-
-    Args:
-        hass: Home Assistant instance.
-        config_entry: Configuration entry being migrated.
-
-    Returns:
-        bool: True when migration succeeds.
-    """
-    _LOGGER.debug(
-        "Migrating Carrier config entry from version %s.%s",
-        config_entry.version,
-        config_entry.minor_version,
-    )
-
-    if config_entry.version == CONFIG_FLOW_VERSION:
-        return True
-
-    if config_entry.version != 1:
-        _LOGGER.error(
-            "Unable to migrate Carrier config entry from version %s", config_entry.version
-        )
-        return False
-
-    if config_entry.version == 1:
-        return await _migrate_1_to_2(hass=hass, config_entry=config_entry)
-
-    if config_entry.version == 2:
-        return True
-    return False
 
 
 async def _async_await_websocket_task(websocket_task: asyncio.Task[None]) -> None:
@@ -563,6 +182,35 @@ async def async_update_options(hass: HomeAssistant, config_entry: ConfigEntryCar
         None: This coroutine schedules and awaits the entry reload.
     """
     await hass.config_entries.async_reload(config_entry.entry_id)
+
+
+async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntryCarrier) -> bool:
+    """Migrate Carrier config entries between config flow versions.
+
+    Args:
+        hass: Home Assistant instance.
+        config_entry: Configuration entry being migrated.
+
+    Returns:
+        bool: True when migration succeeds.
+    """
+    _LOGGER.debug("Migrating Carrier config entry from version %s", config_entry.version)
+
+    if config_entry.version == CONFIG_FLOW_VERSION:
+        return True
+
+    if config_entry.version != 1:
+        _LOGGER.error(
+            "Unable to migrate Carrier config entry from version %s", config_entry.version
+        )
+        return False
+
+    if config_entry.version == 1:
+        return await migrate_1_to_2(hass=hass, config_entry=config_entry)
+
+    if config_entry.version == 2:
+        return True
+    return False
 
 
 async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntryCarrier) -> bool:

--- a/custom_components/ha_carrier/__init__.py
+++ b/custom_components/ha_carrier/__init__.py
@@ -1,19 +1,23 @@
 """Initialize and manage the Home Assistant Carrier integration lifecycle."""
 
 import asyncio
+from collections.abc import Iterable, Mapping
 import logging
 
 from aiohttp import ClientError
-from carrier_api import ApiConnectionGraphql
+from carrier_api import ApiConnectionGraphql, AuthError, BaseError, System
 from gql.transport.exceptions import TransportError, TransportServerError
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import config_validation as cv, entity_registry as er
+from homeassistant.helpers.entity_registry import RegistryEntry
+from homeassistant.util import slugify
 
 from .carrier_data_update_coordinator import CarrierDataUpdateCoordinator, CarrierUnauthorizedError
 from .const import (
+    CONFIG_FLOW_VERSION,
     DOMAIN,
     PLATFORMS,
     TO_REDACT,
@@ -26,6 +30,255 @@ type ConfigEntryCarrier = ConfigEntry[CarrierDataUpdateCoordinator]
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
+
+# For migrations from version 1 to 2
+ENERGY_METRICS: tuple[str, ...] = (
+    "cooling",
+    "hp_heat",
+    "fan",
+    "electric_heat",
+    "reheat",
+    "fan_gas",
+    "loop_pump",
+)
+SYSTEM_ENTITY_SUFFIXES: tuple[str, ...] = (
+    "Online",
+    "Humidifier Running",
+    "Heat Source",
+    "Outdoor Temperature",
+    "Filter Remaining",
+    "Humidifier Remaining",
+    "UV Lamp Remaining",
+    "Airflow",
+    "Static Pressure",
+    "ODU Status",
+    "IDU Status",
+    "ODU Var",
+)
+TIMESTAMP_TYPES: tuple[str, ...] = ("all_data", "websocket", "energy")
+
+
+def _async_new_unique_id(system_serial: str, new_suffix: str) -> str:
+    """Return the version 2 unique ID for a Carrier entity.
+
+    Args:
+        system_serial: Carrier system serial number.
+        new_suffix: Version 2 unique ID suffix.
+
+    Returns:
+        str: Slugified version 2 unique ID.
+    """
+    return slugify(f"{system_serial}_{new_suffix}")
+
+
+def _async_add_unique_id_migration(
+    migration_map: dict[str, str],
+    system_serial: str,
+    old_suffix: str,
+    new_suffix: str | None = None,
+) -> None:
+    """Add one legacy unique ID to version 2 unique ID mapping.
+
+    Args:
+        migration_map: Mutable migration map being built.
+        system_serial: Carrier system serial number.
+        old_suffix: Version 1 unique ID suffix.
+        new_suffix: Version 2 unique ID suffix. Defaults to old_suffix.
+
+    Returns:
+        None: The mapping is updated in place.
+    """
+    migration_map[f"{system_serial}_{old_suffix}"] = _async_new_unique_id(
+        system_serial, new_suffix or old_suffix
+    )
+
+
+def _async_build_unique_id_migration_map(systems: Iterable[System]) -> dict[str, str]:
+    """Build old-to-new entity unique ID mappings for Carrier systems.
+
+    Args:
+        systems: Carrier systems loaded from the account during migration.
+
+    Returns:
+        dict[str, str]: Mapping from version 1 unique IDs to version 2 unique IDs.
+    """
+    migration_map: dict[str, str] = {}
+
+    for carrier_system in systems:
+        system_serial = carrier_system.profile.serial
+
+        for suffix in SYSTEM_ENTITY_SUFFIXES:
+            _async_add_unique_id_migration(migration_map, system_serial, suffix)
+
+        for timestamp_type in TIMESTAMP_TYPES:
+            _async_add_unique_id_migration(
+                migration_map,
+                system_serial,
+                f"updated {timestamp_type.replace('_', ' ').capitalize()} at",
+                f"{timestamp_type.replace('_', ' ').title()} Last Updated",
+            )
+
+        fuel_type = carrier_system.config.fuel_type
+        _async_add_unique_id_migration(
+            migration_map,
+            system_serial,
+            f"{fuel_type.capitalize()} Yearly",
+            f"{fuel_type.capitalize()} Usage Year to Date",
+        )
+        _async_add_unique_id_migration(
+            migration_map,
+            system_serial,
+            "Propane Yearly Gallons",
+            "Propane Consumption Year to Date",
+        )
+
+        for metric in ENERGY_METRICS:
+            metric_title = metric.replace("_", " ").title()
+            _async_add_unique_id_migration(
+                migration_map,
+                system_serial,
+                f"{metric} Energy Yearly",
+                f"{metric_title} Energy Year to Date",
+            )
+            _async_add_unique_id_migration(
+                migration_map,
+                system_serial,
+                f"{metric} Energy Yesterday",
+                f"{metric_title} Energy Yesterday",
+            )
+            _async_add_unique_id_migration(
+                migration_map,
+                system_serial,
+                f"{metric} Energy Last Month",
+                f"{metric_title} Energy Last Month",
+            )
+
+        for zone in carrier_system.config.zones:
+            zone_unique_id_suffix = f"zone_{zone.api_id}"
+            _async_add_unique_id_migration(
+                migration_map,
+                system_serial,
+                zone.name,
+                f"{zone_unique_id_suffix}_thermostat",
+            )
+            _async_add_unique_id_migration(
+                migration_map,
+                system_serial,
+                f"{zone.name} Occupancy",
+                f"{zone_unique_id_suffix}_occupancy",
+            )
+            _async_add_unique_id_migration(
+                migration_map,
+                system_serial,
+                f"{zone.name} Humidity",
+                f"{zone_unique_id_suffix}_humidity",
+            )
+            _async_add_unique_id_migration(
+                migration_map,
+                system_serial,
+                f"{zone.name} Temperature",
+                f"{zone_unique_id_suffix}_temperature",
+            )
+
+    return migration_map
+
+
+def _async_entity_unique_id_migration_updates(
+    entry: RegistryEntry,
+    migration_map: Mapping[str, str],
+    existing_unique_ids: set[str],
+) -> dict[str, str] | None:
+    """Return entity registry updates for one legacy Carrier registry entry.
+
+    Args:
+        entry: Entity registry entry being considered for migration.
+        migration_map: Old-to-new unique ID migration map.
+        existing_unique_ids: Unique IDs already present for this config entry.
+
+    Returns:
+        dict[str, str] | None: Entity registry update payload, or None.
+    """
+    new_unique_id = migration_map.get(entry.unique_id)
+    if new_unique_id is None or new_unique_id == entry.unique_id:
+        return None
+    if new_unique_id in existing_unique_ids:
+        _LOGGER.debug(
+            "Skipping Carrier entity unique ID migration for %s; %s already exists",
+            entry.entity_id,
+            new_unique_id,
+        )
+        return None
+    existing_unique_ids.add(new_unique_id)
+    return {"new_unique_id": new_unique_id}
+
+
+async def _migrate_1_to_2(hass: HomeAssistant, config_entry: ConfigEntryCarrier) -> bool:
+    try:
+        api_connection = ApiConnectionGraphql(
+            username=config_entry.data[CONF_USERNAME],
+            password=config_entry.data[CONF_PASSWORD],
+        )
+        systems = await api_connection.load_data()
+    except (
+        AuthError,
+        BaseError,
+        ClientError,
+        TimeoutError,
+        OSError,
+        TransportError,
+    ):
+        _LOGGER.exception("Unable to load Carrier data for config entry migration")
+        return False
+
+    migration_map = _async_build_unique_id_migration_map(systems)
+    ent_reg = er.async_get(hass)
+    existing_unique_ids = {
+        entry.unique_id
+        for entry in ent_reg.entities.get_entries_for_config_entry_id(config_entry.entry_id)
+    }
+    await er.async_migrate_entries(
+        hass,
+        config_entry.entry_id,
+        lambda entry: _async_entity_unique_id_migration_updates(
+            entry, migration_map, existing_unique_ids
+        ),
+    )
+    hass.config_entries.async_update_entry(config_entry, version=CONFIG_FLOW_VERSION)
+    _LOGGER.info("Carrier config entry migration to version %s complete", CONFIG_FLOW_VERSION)
+    return True
+
+
+async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntryCarrier) -> bool:
+    """Migrate Carrier config entries between config flow versions.
+
+    Args:
+        hass: Home Assistant instance.
+        config_entry: Configuration entry being migrated.
+
+    Returns:
+        bool: True when migration succeeds.
+    """
+    _LOGGER.debug(
+        "Migrating Carrier config entry from version %s.%s",
+        config_entry.version,
+        config_entry.minor_version,
+    )
+
+    if config_entry.version == CONFIG_FLOW_VERSION:
+        return True
+
+    if config_entry.version != 1:
+        _LOGGER.error(
+            "Unable to migrate Carrier config entry from version %s", config_entry.version
+        )
+        return False
+
+    if config_entry.version == 1:
+        return await _migrate_1_to_2(hass=hass, config_entry=config_entry)
+
+    if config_entry.version == 2:
+        return True
+    return False
 
 
 async def _async_await_websocket_task(websocket_task: asyncio.Task[None]) -> None:

--- a/custom_components/ha_carrier/binary_sensor.py
+++ b/custom_components/ha_carrier/binary_sensor.py
@@ -4,17 +4,14 @@ from __future__ import annotations
 
 import logging
 
-from homeassistant.components.binary_sensor import (
-    BinarySensorDeviceClass,
-    BinarySensorEntity,
-    BinarySensorEntityDescription,
-)
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass, BinarySensorEntity
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import ConfigEntryCarrier
 from .carrier_data_update_coordinator import CarrierDataUpdateCoordinator
-from .carrier_entity import CarrierEntity
+from .carrier_entity import CarrierEntity, CarrierZoneEntity
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -30,156 +27,163 @@ async def async_setup_entry(
         hass: Home Assistant instance.
         config_entry: Config entry that owns the Carrier account.
         async_add_entities: Callback used by Home Assistant to register entities.
-
-    Returns:
-        None: Entities are added through the callback.
     """
-    updater = config_entry.runtime_data
-    entities = []
-    for carrier_system in updater.systems:
-        entities.extend(
-            [
-                OnlineSensor(updater, carrier_system.profile.serial),
-                HumidifierSensor(updater, carrier_system.profile.serial),
-            ]
+    coordinator = config_entry.runtime_data
+    entities: list[BinarySensorEntity] = []
+    for carrier_system in coordinator.systems:
+        entities.append(
+            OnlineSensor(coordinator=coordinator, system_serial=carrier_system.profile.serial)
         )
-        for zone in carrier_system.config.zones:
-            if zone.occupancy_enabled:
-                entities.extend(
-                    [
-                        OccupancySensor(
-                            updater, carrier_system.profile.serial, zone_api_id=zone.api_id
-                        ),
-                    ]
+        if carrier_system.config.humidifier_enabled:
+            entities.append(
+                HumidifierSensor(
+                    coordinator=coordinator, system_serial=carrier_system.profile.serial
                 )
+            )
+        entities.extend(
+            OccupancySensor(
+                coordinator=coordinator,
+                system_serial=carrier_system.profile.serial,
+                zone_api_id=zone.api_id,
+            )
+            for zone in carrier_system.config.zones
+            if zone.occupancy_enabled
+        )
     async_add_entities(entities)
 
 
-class OnlineSensor(CarrierEntity, BinarySensorEntity):
+class CarrierBinarySensor(CarrierEntity, BinarySensorEntity):
+    """Shared Carrier base class for system-level binary sensor entities."""
+
+    def __init__(
+        self,
+        entity_name: str,
+        coordinator: CarrierDataUpdateCoordinator,
+        system_serial: str | None = None,
+        unique_id_suffix: str | None = None,
+    ) -> None:
+        """Initialize a Carrier binary sensor entity.
+
+        Args:
+            entity_name: Friendly suffix used in entity name and unique ID.
+            coordinator: Coordinator that provides Carrier data.
+            system_serial: Carrier system serial for this entity.
+            unique_id_suffix: Optional stable suffix used for the entity unique ID.
+
+        Raises:
+            ValueError: Raised when no Carrier system serial is provided.
+        """
+        if system_serial is None:
+            raise ValueError("Carrier binary sensor system serial is required")
+        super().__init__(
+            entity_name=entity_name,
+            coordinator=coordinator,
+            system_serial=system_serial,
+            unique_id_suffix=unique_id_suffix,
+        )
+        self._sync_entity_attrs()
+
+    def _update_entity_attrs(self) -> None:
+        """Update binary sensor attrs from coordinator data."""
+        self._attr_available = False
+
+
+class CarrierZoneBinarySensor(CarrierZoneEntity, CarrierBinarySensor):
+    """Shared Carrier base class for zone-backed binary sensor entities."""
+
+    def __init__(
+        self,
+        entity_name: str,
+        coordinator: CarrierDataUpdateCoordinator,
+        system_serial: str,
+        zone_api_id: str,
+        unique_id_suffix: str,
+    ) -> None:
+        """Initialize a zone-backed Carrier binary sensor entity.
+
+        Args:
+            entity_name: Friendly suffix appended to the zone name for display.
+            coordinator: Coordinator that provides Carrier data.
+            system_serial: Carrier system serial for this entity.
+            zone_api_id: Carrier API identifier for the represented zone.
+            unique_id_suffix: Stable suffix used in the zone entity unique ID.
+        """
+        super().__init__(
+            entity_name,
+            coordinator,
+            system_serial,
+            zone_api_id,
+            unique_id_suffix=unique_id_suffix,
+        )
+
+
+class OnlineSensor(CarrierBinarySensor):
     """Binary sensor that reports whether the Carrier system is reachable."""
 
-    def __init__(self, updater: CarrierDataUpdateCoordinator, system_serial: str) -> None:
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
+
+    def __init__(self, coordinator: CarrierDataUpdateCoordinator, system_serial: str) -> None:
         """Initialize connectivity metadata for a Carrier system.
 
         Args:
-            updater: Coordinator that provides system state.
+            coordinator: Coordinator that provides system state.
             system_serial: Unique Carrier system serial number.
         """
-        super().__init__("Online", updater, system_serial)
-        self.entity_description = BinarySensorEntityDescription(
-            key=f"#{self.carrier_system.profile.serial}-online",
-            device_class=BinarySensorDeviceClass.CONNECTIVITY,
-            icon="mdi:wifi-check",
-        )
+        super().__init__("Online", coordinator, system_serial)
 
-    @property
-    def is_on(self) -> bool | None:
-        """Return whether the thermostat currently reports as online.
-
-        Returns:
-            bool | None: True when connected, False when disconnected.
-        """
-        return not self.carrier_system.status.is_disconnected
-
-    @property
-    def icon(self) -> str | None:
-        """Return an icon that reflects current connectivity.
-
-        Returns:
-            str | None: Connected icon when online, fallback wifi icon otherwise.
-        """
-        if self.is_on:
-            return self.entity_description.icon
-        return "mdi:wifi-strength-outline"
-
-    @property
-    def available(self) -> bool:
-        """Indicate whether the sensor has a usable boolean state.
-
-        Returns:
-            bool: True when state is available.
-        """
-        return self.is_on is not None
+    def _update_entity_attrs(self) -> None:
+        """Update connectivity attrs from coordinator data."""
+        self._attr_is_on = not self.carrier_system.status.is_disconnected
+        self._attr_available = True
+        self._attr_icon = "mdi:wifi-check" if self._attr_is_on else "mdi:wifi-strength-outline"
 
 
-class OccupancySensor(CarrierEntity, BinarySensorEntity):
+class OccupancySensor(CarrierZoneBinarySensor):
     """Binary sensor that mirrors occupancy detection for a Carrier zone."""
 
-    _attr_device_class = BinarySensorDeviceClass.MOTION
+    _attr_device_class = BinarySensorDeviceClass.OCCUPANCY
 
     def __init__(
-        self, updater: CarrierDataUpdateCoordinator, system_serial: str, zone_api_id: str
+        self, coordinator: CarrierDataUpdateCoordinator, system_serial: str, zone_api_id: str
     ) -> None:
         """Initialize an occupancy entity tied to one zone.
 
         Args:
-            updater: Coordinator that provides system and zone state.
+            coordinator: Coordinator that provides system and zone state.
             system_serial: Unique Carrier system serial number.
             zone_api_id: API identifier for the target zone.
         """
-        self.zone_api_id: str = zone_api_id
-        self.coordinator = updater
-        self.coordinator_context = system_serial
-        super().__init__(f"{self._config_zone.name} Occupancy", updater, system_serial)
+        super().__init__(
+            entity_name="Occupancy",
+            coordinator=coordinator,
+            system_serial=system_serial,
+            zone_api_id=zone_api_id,
+            unique_id_suffix="occupancy",
+        )
 
-    @property
-    def is_on(self) -> bool | None:
-        """Return whether the zone currently reports occupancy.
-
-        Returns:
-            bool | None: True when occupancy is detected.
-        """
-        return self._status_zone.occupancy
-
-    @property
-    def available(self) -> bool:
-        """Indicate whether occupancy state can be shown.
-
-        Returns:
-            bool: True when zone occupancy data is available.
-        """
-        return self.is_on is not None
+    def _update_entity_attrs(self) -> None:
+        """Update occupancy attrs from coordinator data."""
+        self._attr_is_on = self._status_zone.occupancy
+        self._attr_available = self._attr_is_on is not None
 
 
-class HumidifierSensor(CarrierEntity, BinarySensorEntity):
+class HumidifierSensor(CarrierBinarySensor):
     """Binary sensor that indicates whether humidification is active."""
 
     _attr_device_class = BinarySensorDeviceClass.RUNNING
 
-    def __init__(self, updater: CarrierDataUpdateCoordinator, system_serial: str) -> None:
+    def __init__(self, coordinator: CarrierDataUpdateCoordinator, system_serial: str) -> None:
         """Initialize a humidifier runtime sensor for one Carrier system.
 
         Args:
-            updater: Coordinator that provides system state.
+            coordinator: Coordinator that provides system state.
             system_serial: Unique Carrier system serial number.
         """
-        super().__init__("Humidifier Running", updater, system_serial)
+        super().__init__("Humidifier Running", coordinator, system_serial)
 
-    @property
-    def is_on(self) -> bool | None:
-        """Return whether the humidifier is currently running.
-
-        Returns:
-            bool | None: Runtime status reported by the Carrier API.
-        """
-        return self.carrier_system.status.humidifier_on
-
-    @property
-    def icon(self) -> str | None:
-        """Return an icon that reflects humidifier runtime state.
-
-        Returns:
-            str | None: On/off humidifier icon based on current state.
-        """
-        if self.is_on:
-            return "mdi:air-humidifier"
-        return "mdi:air-humidifier-off"
-
-    @property
-    def available(self) -> bool:
-        """Indicate whether humidifier state can be displayed.
-
-        Returns:
-            bool: True when humidifier state is available.
-        """
-        return self.is_on is not None
+    def _update_entity_attrs(self) -> None:
+        """Update humidifier attrs from coordinator data."""
+        self._attr_is_on = self.carrier_system.status.humidifier_on
+        self._attr_available = self._attr_is_on is not None
+        self._attr_icon = "mdi:air-humidifier" if self._attr_is_on else "mdi:air-humidifier-off"

--- a/custom_components/ha_carrier/carrier_entity.py
+++ b/custom_components/ha_carrier/carrier_entity.py
@@ -37,7 +37,7 @@ class CarrierEntity(CoordinatorEntity[CarrierDataUpdateCoordinator]):
         """
         super().__init__(coordinator, system_serial)
         self._system_serial = system_serial
-        self._attr_name = f"{entity_name}"
+        self._attr_name = entity_name
         unique_id_raw = f"{system_serial}_{unique_id_suffix or entity_name}"
         self._attr_unique_id = slugify(unique_id_raw)
         self._attr_device_info = DeviceInfo(
@@ -58,10 +58,11 @@ class CarrierEntity(CoordinatorEntity[CarrierDataUpdateCoordinator]):
         """Refresh entity attrs from coordinator data with shared error handling."""
         try:
             self._update_entity_attrs()
-        except ValueError as error:
+        except (ValueError, AttributeError, KeyError, TypeError) as error:
             _LOGGER.debug(
-                "Unable to update Carrier entity %s: %s",
+                "Unable to update Carrier entity %s. %s: %s",
                 self._attr_unique_id,
+                type(error).__name__,
                 error,
             )
             self._attr_available = False

--- a/custom_components/ha_carrier/carrier_entity.py
+++ b/custom_components/ha_carrier/carrier_entity.py
@@ -3,8 +3,10 @@
 import logging
 
 from carrier_api import ConfigZone, StatusZone, System
+from homeassistant.core import callback
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util import slugify
 
 from .carrier_data_update_coordinator import CarrierDataUpdateCoordinator
 from .const import DOMAIN
@@ -15,26 +17,66 @@ _LOGGER: logging.Logger = logging.getLogger(__name__)
 class CarrierEntity(CoordinatorEntity[CarrierDataUpdateCoordinator]):
     """Provide common identity and data access for Carrier entities."""
 
+    _attr_has_entity_name: bool = True
     zone_api_id: str | None = None
 
     def __init__(
         self,
-        entity_type: str,
-        updater: CarrierDataUpdateCoordinator,
-        context: str,
-        **kwargs,
+        entity_name: str,
+        coordinator: CarrierDataUpdateCoordinator,
+        system_serial: str,
+        unique_id_suffix: str | None = None,
     ) -> None:
         """Initialize shared entity identity and coordinator context.
 
         Args:
-            entity_type: Friendly suffix used in entity name and unique ID.
-            updater: Coordinator that supplies Carrier system data.
-            context: Carrier system serial used as coordinator context.
-            **kwargs: Reserved for future entity initialization options.
+            entity_name: Friendly suffix used in entity name and unique ID.
+            coordinator: Coordinator that supplies Carrier system data.
+            system_serial: Carrier system serial used as coordinator context.
+            unique_id_suffix: Optional stable suffix used for the entity unique ID.
         """
-        super().__init__(updater, context)
-        self._attr_name = f"{self.carrier_system.profile.name} {entity_type}"
-        self._attr_unique_id = f"{self.carrier_system.profile.serial}_{entity_type}"
+        super().__init__(coordinator, system_serial)
+        self._system_serial = system_serial
+        self._attr_name = f"{entity_name}"
+        unique_id_raw = f"{system_serial}_{unique_id_suffix or entity_name}"
+        self._attr_unique_id = slugify(unique_id_raw)
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, self.carrier_system.profile.serial)},
+            manufacturer=self.carrier_system.profile.brand,
+            model=self.carrier_system.profile.model,
+            sw_version=self.carrier_system.profile.firmware,
+            name=self.carrier_system.profile.name,
+        )
+
+    def _update_entity_attrs(self) -> None:
+        """Update Home Assistant attrs from the latest coordinator data.
+
+        Subclasses should populate their supported ``self._attr_*`` values here.
+        """
+
+    def _sync_entity_attrs(self) -> None:
+        """Refresh entity attrs from coordinator data with shared error handling."""
+        try:
+            self._update_entity_attrs()
+        except ValueError as error:
+            _LOGGER.debug(
+                "Unable to update Carrier entity %s: %s",
+                self._attr_unique_id,
+                error,
+            )
+            self._attr_available = False
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Refresh entity attrs after a coordinator update."""
+        self._sync_entity_attrs()
+        super()._handle_coordinator_update()
+
+    @callback
+    def _write_local_state(self) -> None:
+        """Refresh attrs after local state mutation and write them to Home Assistant."""
+        self._sync_entity_attrs()
+        self.async_write_ha_state()
 
     @property
     def carrier_system(self) -> System:
@@ -46,9 +88,9 @@ class CarrierEntity(CoordinatorEntity[CarrierDataUpdateCoordinator]):
         Raises:
             ValueError: Raised when the configured system serial is unknown.
         """
-        csystem = self.coordinator.system(system_serial=self.coordinator_context)
+        csystem = self.coordinator.system(system_serial=self._system_serial)
         if csystem is None:
-            raise ValueError(f"Carrier System not found: {self.coordinator_context}")
+            raise ValueError(f"Carrier System not found: {self._system_serial}")
         return csystem
 
     @property
@@ -85,17 +127,67 @@ class CarrierEntity(CoordinatorEntity[CarrierDataUpdateCoordinator]):
             raise ValueError(f"Config Zone not found: {self.zone_api_id}")
         raise ValueError("No zone api id defined")
 
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Build Home Assistant device metadata for this Carrier system.
+
+class CarrierZoneEntity(CarrierEntity):
+    """Shared Carrier entity base for entities bound to a specific zone."""
+
+    zone_name: str | None = None
+
+    @staticmethod
+    def resolve_zone_name(
+        coordinator: CarrierDataUpdateCoordinator,
+        system_serial: str,
+        zone_api_id: str,
+    ) -> str:
+        """Return the configured name for a Carrier zone.
+
+        Args:
+            coordinator: Coordinator that supplies Carrier system data.
+            system_serial: Carrier system serial used as coordinator context.
+            zone_api_id: Carrier API identifier for the represented zone.
 
         Returns:
-            DeviceInfo: Device registry payload shared by all child entities.
+            str: Configured zone name.
+
+        Raises:
+            ValueError: Raised when the system or zone cannot be resolved.
         """
-        return DeviceInfo(
-            identifiers={(DOMAIN, self.carrier_system.profile.serial)},
-            manufacturer=self.carrier_system.profile.brand,
-            model=self.carrier_system.profile.model,
-            sw_version=self.carrier_system.profile.firmware,
-            name=self.carrier_system.profile.name,
+        carrier_system = coordinator.system(system_serial=system_serial)
+        if carrier_system is None:
+            raise ValueError(f"Carrier System not found: {system_serial}")
+        for zone in carrier_system.config.zones:
+            if zone.api_id == zone_api_id:
+                return zone.name
+        raise ValueError(f"Config Zone not found: {zone_api_id}")
+
+    def __init__(
+        self,
+        entity_name: str,
+        coordinator: CarrierDataUpdateCoordinator,
+        system_serial: str,
+        zone_api_id: str,
+        unique_id_suffix: str | None = None,
+    ) -> None:
+        """Initialize a zone-scoped Carrier entity.
+
+        Args:
+            entity_name: Friendly suffix appended to the zone name for display.
+            coordinator: Coordinator that supplies Carrier system data.
+            system_serial: Carrier system serial used as coordinator context.
+            zone_api_id: Carrier API identifier for the represented zone.
+            unique_id_suffix: Optional stable suffix appended to the zone unique ID.
+        """
+        self.zone_api_id = zone_api_id
+        self.zone_name = self.resolve_zone_name(coordinator, system_serial, zone_api_id)
+        zone_unique_id_suffix = f"zone_{zone_api_id}"
+        if unique_id_suffix is not None:
+            zone_unique_id_suffix = f"{zone_unique_id_suffix}_{unique_id_suffix}"
+        combined_entity_name = self.zone_name
+        if entity_name:
+            combined_entity_name = f"{self.zone_name} {entity_name}"
+        super().__init__(
+            entity_name=combined_entity_name,
+            coordinator=coordinator,
+            system_serial=system_serial,
+            unique_id_suffix=zone_unique_id_suffix,
         )

--- a/custom_components/ha_carrier/carrier_entity.py
+++ b/custom_components/ha_carrier/carrier_entity.py
@@ -127,6 +127,11 @@ class CarrierEntity(CoordinatorEntity[CarrierDataUpdateCoordinator]):
             raise ValueError(f"Config Zone not found: {self.zone_api_id}")
         raise ValueError("No zone api id defined")
 
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return self.coordinator.last_update_success and getattr(self, "_attr_available", True)
+
 
 class CarrierZoneEntity(CarrierEntity):
     """Shared Carrier entity base for entities bound to a specific zone."""

--- a/custom_components/ha_carrier/climate.py
+++ b/custom_components/ha_carrier/climate.py
@@ -2,16 +2,21 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
 from datetime import datetime
 from functools import partial
 import logging
 from typing import Any
 
-from carrier_api import ActivityTypes, ConfigZoneActivity, FanModes, SystemModes, TemperatureUnits
+from carrier_api import (
+    ActivityTypes,
+    ConfigZoneActivity,
+    FanModes,
+    System,
+    SystemModes,
+    TemperatureUnits,
+)
 from homeassistant.components.climate import (
     ClimateEntity,
-    ClimateEntityDescription,
     ClimateEntityFeature,
     HVACAction,
     HVACMode,
@@ -29,19 +34,49 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import ConfigEntryCarrier
 from .carrier_data_update_coordinator import CarrierDataUpdateCoordinator
-from .carrier_entity import CarrierEntity
+from .carrier_entity import CarrierZoneEntity
 from .const import CONF_INFINITE_HOLDS, DEFAULT_INFINITE_HOLDS, FAN_AUTO
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
-SUPPORT_FLAGS = (
+SUPPORT_FLAGS: ClimateEntityFeature = (
     ClimateEntityFeature.TURN_ON
     | ClimateEntityFeature.TURN_OFF
     | ClimateEntityFeature.TARGET_TEMPERATURE
     | ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
-    | ClimateEntityFeature.FAN_MODE
     | ClimateEntityFeature.PRESET_MODE
 )
+
+HEAT_TYPES: list[str] = [
+    "hp_heat",
+    "electric_heat",
+    "reheat",
+    "loop_pump",
+]
+
+COOL_TYPES: list[str] = [
+    "cooling",
+]
+
+FAN_TYPES: list[str] = [
+    "fan",
+    "fan_gas",
+]
+
+
+def has_heat(carrier_system: System) -> bool:
+    """Return True if the Carrier system supports heat source selection."""
+    return any(getattr(carrier_system.energy, heat_type, False) is True for heat_type in HEAT_TYPES)
+
+
+def has_cool(carrier_system: System) -> bool:
+    """Return True if the Carrier system supports cool source selection."""
+    return any(getattr(carrier_system.energy, cool_type, False) is True for cool_type in COOL_TYPES)
+
+
+def has_fan(carrier_system: System) -> bool:
+    """Return True if the Carrier system supports fan mode selection."""
+    return any(getattr(carrier_system.energy, fan_type, False) is True for fan_type in FAN_TYPES)
 
 
 async def async_setup_entry(
@@ -55,235 +90,94 @@ async def async_setup_entry(
         hass: Home Assistant instance.
         config_entry: Carrier integration config entry.
         async_add_entities: Callback used to register entities.
-
-    Returns:
-        None: Thermostat entities are registered through the callback.
     """
     _LOGGER.debug("setting up climate entry")
     infinite_hold = config_entry.options.get(CONF_INFINITE_HOLDS, DEFAULT_INFINITE_HOLDS)
-    updater = config_entry.runtime_data
-    entities = []
-    for carrier_system in updater.systems:
-        for zone in carrier_system.config.zones:
-            entities.extend(
-                [
-                    Thermostat(
-                        updater,
-                        carrier_system.profile.serial,
-                        infinite_hold=infinite_hold,
-                        zone_api_id=zone.api_id,
-                    ),
-                ]
+    coordinator = config_entry.runtime_data
+    entities: list[Thermostat] = []
+    for carrier_system in coordinator.systems:
+        support_flags = SUPPORT_FLAGS
+        hvac_modes: list[HVACMode] = [
+            HVACMode.OFF,
+        ]
+        if has_fan(carrier_system):
+            support_flags |= ClimateEntityFeature.FAN_MODE
+            hvac_modes.append(HVACMode.FAN_ONLY)
+        if has_cool(carrier_system):
+            hvac_modes.append(HVACMode.COOL)
+        if has_heat(carrier_system):
+            hvac_modes.append(HVACMode.HEAT)
+        if has_cool(carrier_system) and has_heat(carrier_system):
+            hvac_modes.append(HVACMode.HEAT_COOL)
+        entities.extend(
+            Thermostat(
+                coordinator=coordinator,
+                system_serial=carrier_system.profile.serial,
+                infinite_hold=infinite_hold,
+                zone_api_id=zone.api_id,
+                support_flags=support_flags,
+                hvac_modes=hvac_modes,
             )
+            for zone in carrier_system.config.zones
+        )
     async_add_entities(entities)
 
 
-class Thermostat(CarrierEntity, ClimateEntity):
-    """Climate entity that controls a single Carrier zone thermostat."""
-
-    _attr_supported_features = SUPPORT_FLAGS
-    _enable_turn_on_off_backwards_compatibility = False
-    _attr_max_humidity = 45
-    _attr_min_humidity = 0
+class CarrierClimate(CarrierZoneEntity, ClimateEntity):
+    """Shared Carrier base class for zone-backed climate entities."""
 
     def __init__(
         self,
-        updater: CarrierDataUpdateCoordinator,
+        entity_name: str,
+        coordinator: CarrierDataUpdateCoordinator,
         system_serial: str,
-        infinite_hold: bool,
         zone_api_id: str,
+        unique_id_suffix: str,
     ) -> None:
-        """Initialize thermostat state and supported controls for one zone.
+        """Initialize a zone-backed Carrier climate entity.
 
         Args:
-            updater: Coordinator that provides Carrier system and zone state.
-            system_serial: Carrier system serial for this thermostat.
-            infinite_hold: Whether manual holds should be open-ended.
+            entity_name: Friendly suffix appended to the zone name for display.
+            coordinator: Coordinator that provides Carrier data.
+            system_serial: Carrier system serial for this entity.
             zone_api_id: Carrier API identifier for the represented zone.
+            unique_id_suffix: Stable suffix used in the zone entity unique ID.
         """
-        _LOGGER.debug("infinite_hold:%s", infinite_hold)
-        self.infinite_hold: bool = infinite_hold
-        self.zone_api_id: str = zone_api_id
-        self.coordinator = updater
-        self.coordinator_context = system_serial
-        self.entity_description = ClimateEntityDescription(
-            key=f"#{system_serial}-zone{self.zone_api_id}-climate",
+        super().__init__(
+            entity_name=entity_name,
+            coordinator=coordinator,
+            system_serial=system_serial,
+            zone_api_id=zone_api_id,
+            unique_id_suffix=unique_id_suffix,
         )
-        super().__init__(f"{self._config_zone.name}", updater, system_serial)
-        self._attr_fan_modes = [
-            fan_mode.value for fan_mode in [FanModes.LOW, FanModes.MED, FanModes.HIGH]
-        ]
-        self._attr_fan_modes.append(FAN_AUTO)
-        self._attr_hvac_modes = [
-            HVACMode.OFF,
-            HVACMode.FAN_ONLY,
-            HVACMode.HEAT_COOL,
-            HVACMode.HEAT,
-            HVACMode.COOL,
-        ]
-        self._attr_preset_modes = [activity.type.value for activity in self._config_zone.activities]
-        self._attr_preset_modes.append("resume")
-        if self.carrier_system.config.humidifier_enabled:
-            self._attr_supported_features |= ClimateEntityFeature.TARGET_HUMIDITY
-
-    @property
-    def current_humidity(self) -> int | None:
-        """Return the latest humidity reading for this zone.
-
-        Returns:
-            int | None: Relative humidity percentage reported by Carrier.
-        """
-        return self._status_zone.humidity
-
-    @property
-    def current_temperature(self) -> float | None:
-        """Return the latest ambient temperature for this zone.
-
-        Returns:
-            float | None: Current zone temperature.
-        """
-        return self._status_zone.temperature
-
-    @property
-    def temperature_unit(self) -> str:
-        """Return the temperature unit used by the current system.
-
-        Returns:
-            str: Home Assistant temperature unit constant.
-        """
-        if self.carrier_system.status.temperature_unit == TemperatureUnits.FAHRENHEIT:
-            return UnitOfTemperature.FAHRENHEIT
-        return UnitOfTemperature.CELSIUS
-
-    @property
-    def hvac_mode(self) -> HVACMode | None:
-        """Map Carrier system mode to a Home Assistant HVAC mode.
-
-        Returns:
-            HVACMode | None: Current mode translated for Home Assistant.
-        """
-        ha_mode = None
-        match self.carrier_system.config.mode:
-            case SystemModes.COOL.value:
-                ha_mode = HVACMode.COOL
-            case SystemModes.HEAT.value:
-                ha_mode = HVACMode.HEAT
-            case SystemModes.OFF.value:
-                ha_mode = HVACMode.OFF
-            case SystemModes.AUTO.value:
-                ha_mode = HVACMode.HEAT_COOL
-            case SystemModes.FAN_ONLY.value:
-                ha_mode = HVACMode.FAN_ONLY
-        return ha_mode
-
-    @property
-    def hvac_action(self) -> HVACAction | None:
-        """Infer the active HVAC action from zone runtime data.
-
-        Returns:
-            HVACAction | None: Heating, cooling, fan, idle, or off state.
-        """
-        if self.hvac_mode == HVACMode.OFF:
-            return HVACAction.OFF
-        if self._status_zone.conditioning is None or self._status_zone.conditioning == "idle":
-            return HVACAction.IDLE
-        if "heat" in self._status_zone.conditioning:
-            return HVACAction.HEATING
-        if "cool" in self._status_zone.conditioning:
-            return HVACAction.COOLING
-        if self._status_zone.fan == FanModes.OFF:
-            return HVACAction.IDLE
-        return HVACAction.FAN
+        self._sync_entity_attrs()
 
     def _current_activity(self) -> ConfigZoneActivity | None:
         """Return the current Carrier activity profile for this zone.
 
         Returns:
-            ConfigZoneActivity | None: Activity associated with current zone
-                state, if available.
+            ConfigZoneActivity | None: Activity associated with current zone state.
         """
-        return self._config_zone.find_activity(self._status_zone.current_activity)
+        activity_type = self._config_zone.hold_activity or self._status_zone.current_activity
+        return self._config_zone.find_activity(activity_type)
 
-    @property
-    def target_temperature_step(self) -> float:
-        """Return the smallest setpoint increment accepted by this system.
-
-        Returns:
-            float: 0.5 in Celsius mode, 1.0 in Fahrenheit mode.
-        """
-        if self.temperature_unit == UnitOfTemperature.CELSIUS:
-            return PRECISION_HALVES
-        return PRECISION_WHOLE
-
-    @property
-    def target_temperature(self) -> float | None:
-        """Return the active single setpoint for heat-only or cool-only mode.
-
-        Returns:
-            float | None: Current heat or cool setpoint, depending on mode.
-        """
-        # Use actual setpoints from status, not config activity lookup
-        # This fixes bug where API returns stale currentActivity but correct htsp/clsp
-        if self.hvac_mode == HVACMode.HEAT:
-            return self._status_zone.heat_set_point
-        if self.hvac_mode == HVACMode.COOL:
-            return self._status_zone.cool_set_point
-        return None
-
-    @property
-    def target_temperature_high(self) -> float | None:
-        """Return the active high setpoint in auto changeover mode.
-
-        Returns:
-            float | None: Cool setpoint when operating in heat/cool mode.
-        """
-        # Use actual setpoints from status, not config activity lookup
-        if self.hvac_mode == HVACMode.HEAT_COOL:
-            return self._status_zone.cool_set_point
-        return None
-
-    @property
-    def target_temperature_low(self) -> float | None:
-        """Return the active low setpoint in auto changeover mode.
-
-        Returns:
-            float | None: Heat setpoint when operating in heat/cool mode.
-        """
-        # Use actual setpoints from status, not config activity lookup
-        if self.hvac_mode == HVACMode.HEAT_COOL:
-            return self._status_zone.heat_set_point
-        return None
-
-    @property
-    def target_humidity(self) -> float | None:
-        """Return the configured humidifier heating target when supported.
-
-        Returns:
-            float | None: Target humidity percentage for heating mode.
-        """
-        if self.carrier_system.config.humidifier_enabled:
-            return self.carrier_system.config.humidifier_heat_target
-        return None
-
-    @property
-    def preset_mode(self) -> str | None:
+    def _preset_mode(self) -> str | None:
         """Return the preset that best matches current zone setpoints.
 
         Returns:
             str | None: Matching activity type or API-reported fallback.
         """
-        # Get actual setpoints from status (not from activity lookup)
         actual_heat = self._status_zone.heat_set_point
         actual_cool = self._status_zone.cool_set_point
-        # Find which activity matches these setpoints
         for activity in self._config_zone.activities:
             if activity.heat_set_point == actual_heat and activity.cool_set_point == actual_cool:
                 return activity.type.value
-        # No match found - fall back to API's reported activity
-        # This could happen during transitions or with custom setpoints
+
         _LOGGER.debug(
-            "Zone %s: No activity matched setpoints (heat=%s, cool=%s). "
-            "Falling back to API activity: %s",
+            (
+                "Zone %s: No activity matched setpoints (heat=%s, cool=%s). "
+                "Falling back to API activity: %s"
+            ),
             self._config_zone.name,
             actual_heat,
             actual_cool,
@@ -299,13 +193,71 @@ class Thermostat(CarrierEntity, ClimateEntity):
             return self._status_zone.current_activity
         return current_activity.type.value
 
-    @property
-    def fan_mode(self) -> str | None:
-        """Return the user-facing fan mode for the current activity.
+    def _update_entity_attrs(self) -> None:
+        """Update climate attrs from coordinator data."""
+        if self.carrier_system.status.temperature_unit == TemperatureUnits.FAHRENHEIT:
+            temperature_unit = UnitOfTemperature.FAHRENHEIT
+        else:
+            temperature_unit = UnitOfTemperature.CELSIUS
 
-        Returns:
-            str | None: Explicit fan speed or auto mode label.
-        """
+        hvac_mode: HVACMode | None
+        match self.carrier_system.config.mode:
+            case SystemModes.COOL.value:
+                hvac_mode = HVACMode.COOL
+            case SystemModes.HEAT.value:
+                hvac_mode = HVACMode.HEAT
+            case SystemModes.OFF.value:
+                hvac_mode = HVACMode.OFF
+            case SystemModes.AUTO.value:
+                hvac_mode = HVACMode.HEAT_COOL
+            case SystemModes.FAN_ONLY.value:
+                hvac_mode = HVACMode.FAN_ONLY
+            case _:
+                hvac_mode = None
+
+        self._attr_current_humidity = self._status_zone.humidity
+        self._attr_current_temperature = self._status_zone.temperature
+        self._attr_temperature_unit = temperature_unit
+        self._attr_hvac_mode = hvac_mode
+        if hvac_mode == HVACMode.OFF:
+            self._attr_hvac_action = HVACAction.OFF
+        elif hvac_mode == HVACMode.FAN_ONLY:
+            if self._status_zone.fan == FanModes.OFF:
+                self._attr_hvac_action = HVACAction.IDLE
+            else:
+                self._attr_hvac_action = HVACAction.FAN
+        elif self._status_zone.conditioning is None or self._status_zone.conditioning == "idle":
+            self._attr_hvac_action = HVACAction.IDLE
+        elif "heat" in self._status_zone.conditioning:
+            self._attr_hvac_action = HVACAction.HEATING
+        elif "cool" in self._status_zone.conditioning:
+            self._attr_hvac_action = HVACAction.COOLING
+        elif self._status_zone.fan == FanModes.OFF:
+            self._attr_hvac_action = HVACAction.IDLE
+        else:
+            self._attr_hvac_action = HVACAction.FAN
+
+        if temperature_unit == UnitOfTemperature.CELSIUS:
+            self._attr_target_temperature_step = PRECISION_HALVES
+        else:
+            self._attr_target_temperature_step = PRECISION_WHOLE
+        self._attr_target_temperature = None
+        self._attr_target_temperature_high = None
+        self._attr_target_temperature_low = None
+        if hvac_mode == HVACMode.HEAT:
+            self._attr_target_temperature = self._status_zone.heat_set_point
+        elif hvac_mode == HVACMode.COOL:
+            self._attr_target_temperature = self._status_zone.cool_set_point
+        elif hvac_mode == HVACMode.HEAT_COOL:
+            self._attr_target_temperature_high = self._status_zone.cool_set_point
+            self._attr_target_temperature_low = self._status_zone.heat_set_point
+
+        if self.carrier_system.config.humidifier_enabled:
+            self._attr_target_humidity = self.carrier_system.config.humidifier_heat_target
+        else:
+            self._attr_target_humidity = None
+
+        self._attr_preset_mode = self._preset_mode()
         current_activity = self._current_activity()
         if current_activity is None:
             _LOGGER.debug(
@@ -313,19 +265,78 @@ class Thermostat(CarrierEntity, ClimateEntity):
                 self._config_zone.name,
                 self._status_zone.current_activity,
             )
-            return None
-        if current_activity.fan == FanModes.OFF:
-            return FAN_AUTO
-        return current_activity.fan.value
+            self._attr_fan_mode = None
+        elif current_activity.fan == FanModes.OFF:
+            self._attr_fan_mode = FAN_AUTO
+        else:
+            self._attr_fan_mode = current_activity.fan.value
+
+        hold_activity_name = (
+            self._config_zone.hold_activity.value if self._config_zone.hold_activity else None
+        )
+        self._attr_extra_state_attributes = {
+            "conditioning": self._status_zone.conditioning,
+            "status_mode": self.carrier_system.status.mode,
+            "blower_rpm": self.carrier_system.status.blower_rpm,
+            "damper_position": self._status_zone.damper_position,
+            "hold_activity": hold_activity_name,
+            "hold_until": self._config_zone.hold_until,
+            "next_activity_time": self._config_zone.next_activity_time(),
+        }
+        self._attr_available = True
+
+
+class Thermostat(CarrierClimate):
+    """Climate entity that controls a single Carrier zone thermostat."""
+
+    _enable_turn_on_off_backwards_compatibility = False
+    _attr_max_humidity = 45
+    _attr_min_humidity = 0
+
+    def __init__(
+        self,
+        coordinator: CarrierDataUpdateCoordinator,
+        system_serial: str,
+        infinite_hold: bool,
+        zone_api_id: str,
+        support_flags: ClimateEntityFeature,
+        hvac_modes: list[HVACMode],
+    ) -> None:
+        """Initialize thermostat state and supported controls for one zone.
+
+        Args:
+            coordinator: Coordinator that provides Carrier system and zone state.
+            system_serial: Carrier system serial for this thermostat.
+            infinite_hold: Whether manual holds should be open-ended.
+            zone_api_id: Carrier API identifier for the represented zone.
+            support_flags: Climate entity features supported by the system.
+            hvac_modes: HVAC modes supported by the system.
+        """
+        _LOGGER.debug("infinite_hold: %s", infinite_hold)
+        self.infinite_hold = infinite_hold
+        super().__init__(
+            entity_name="",  # Climate Entity will just be the Zone Name
+            coordinator=coordinator,
+            system_serial=system_serial,
+            zone_api_id=zone_api_id,
+            unique_id_suffix="thermostat",
+        )
+        self._attr_supported_features = support_flags
+        self._attr_fan_modes = [
+            fan_mode.value for fan_mode in [FanModes.LOW, FanModes.MED, FanModes.HIGH]
+        ]
+        self._attr_fan_modes.append(FAN_AUTO)
+        self._attr_hvac_modes = hvac_modes
+        self._attr_preset_modes = [activity.type.value for activity in self._config_zone.activities]
+        self._attr_preset_modes.append("resume")
+        if self.carrier_system.config.humidifier_enabled:
+            self._attr_supported_features |= ClimateEntityFeature.TARGET_HUMIDITY
 
     async def async_set_humidity(self, humidity: int) -> None:
         """Set and normalize a new target humidity value.
 
         Args:
             humidity: Requested target humidity percentage.
-
-        Returns:
-            None: State is updated locally after a successful API call.
         """
         _LOGGER.debug("Setting target humidity to %s", humidity)
         if humidity > 45:
@@ -345,7 +356,7 @@ class Thermostat(CarrierEntity, ClimateEntity):
             ),
         )
         self.carrier_system.config.humidifier_heat_target = rounded_humidity
-        self.async_write_ha_state()
+        self._write_local_state()
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set the Carrier system mode from a Home Assistant HVAC mode.
@@ -353,13 +364,10 @@ class Thermostat(CarrierEntity, ClimateEntity):
         Args:
             hvac_mode: Requested Home Assistant HVAC mode.
 
-        Returns:
-            None: State is updated locally after a successful API call.
-
         Raises:
             ValueError: Raised when the provided mode is unsupported.
         """
-        _LOGGER.debug("set_hvac_mode; hvac_mode:%s", hvac_mode)
+        _LOGGER.debug("set_hvac_mode; hvac_mode: %s", hvac_mode)
         match hvac_mode.strip().lower():
             case HVACMode.COOL:
                 mode = SystemModes.COOL
@@ -382,18 +390,17 @@ class Thermostat(CarrierEntity, ClimateEntity):
             ),
         )
         self.carrier_system.config.mode = mode.value
-        self.async_write_ha_state()
+        self._write_local_state()
 
     @property
     def _hold_until(self) -> datetime | None:
         """Return hold end time based on integration hold preference.
 
         Returns:
-            datetime | None: Next schedule transition when finite holds are
-            enabled, otherwise None for an indefinite hold.
+            datetime | None: Next schedule transition or None for an indefinite hold.
         """
         _LOGGER.debug(
-            "infinite_hold:%s; holding until:'%s'",
+            "infinite_hold: %s; holding until: %s",
             self.infinite_hold,
             self._config_zone.next_activity_time(),
         )
@@ -406,11 +413,8 @@ class Thermostat(CarrierEntity, ClimateEntity):
 
         Args:
             preset_mode: Requested preset mode or the special "resume" value.
-
-        Returns:
-            None: Entity state is updated after applying the change.
         """
-        _LOGGER.debug("set_preset_mode; preset_mode:%s", preset_mode)
+        _LOGGER.debug("set_preset_mode; preset_mode: %s", preset_mode)
         if preset_mode == "resume":
             await self.coordinator.async_perform_api_call(
                 "resume schedule",
@@ -422,29 +426,28 @@ class Thermostat(CarrierEntity, ClimateEntity):
             )
             self.coordinator.data_flush = True
             await self.coordinator.async_refresh()
-        else:
-            activity_type = ActivityTypes(preset_mode.strip().lower())
-            selected_activity = self._config_zone.find_activity(activity_type)
-            hold_until_sent = self._hold_until
-            await self.coordinator.async_perform_api_call(
-                "set preset mode",
-                partial(
-                    self.coordinator.api_connection.set_config_hold,
-                    system_serial=self.carrier_system.profile.serial,
-                    zone_id=self.zone_api_id,
-                    activity_type=activity_type,
-                    hold_until=hold_until_sent,
-                ),
-            )
-            # Mirror the requested hold locally so the entity reflects the user's
-            # selection immediately instead of waiting for the next coordinator poll.
-            self._config_zone.hold = True
-            self._config_zone.hold_activity = activity_type
-            self._config_zone.hold_until = hold_until_sent
-            if selected_activity is not None:
-                self._status_zone.heat_set_point = selected_activity.heat_set_point
-                self._status_zone.cool_set_point = selected_activity.cool_set_point
-            self.async_write_ha_state()
+            return
+
+        activity_type = ActivityTypes(preset_mode.strip().lower())
+        selected_activity = self._config_zone.find_activity(activity_type)
+        hold_until_sent = self._hold_until
+        await self.coordinator.async_perform_api_call(
+            "set preset mode",
+            partial(
+                self.coordinator.api_connection.set_config_hold,
+                system_serial=self.carrier_system.profile.serial,
+                zone_id=self.zone_api_id,
+                activity_type=activity_type,
+                hold_until=hold_until_sent,
+            ),
+        )
+        self._config_zone.hold = True
+        self._config_zone.hold_activity = activity_type
+        self._config_zone.hold_until = hold_until_sent
+        if selected_activity is not None:
+            self._status_zone.heat_set_point = selected_activity.heat_set_point
+            self._status_zone.cool_set_point = selected_activity.cool_set_point
+        self._write_local_state()
 
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set fan speed behavior for the current activity profile.
@@ -452,17 +455,11 @@ class Thermostat(CarrierEntity, ClimateEntity):
         Args:
             fan_mode: Requested fan mode label from Home Assistant.
 
-        Returns:
-            None: Entity state is updated after applying the change.
-
         Raises:
             HomeAssistantError: Raised when the current activity is unavailable.
         """
-        _LOGGER.debug("set_fan_mode; fan_mode:%s", fan_mode)
-        if fan_mode == FAN_AUTO:
-            fan_mode = FanModes.OFF
-        else:
-            fan_mode = FanModes(fan_mode)
+        _LOGGER.debug("set_fan_mode; fan_mode: %s", fan_mode)
+        selected_fan_mode = FanModes.OFF if fan_mode == FAN_AUTO else FanModes(fan_mode)
         current_activity = self._current_activity()
         if current_activity is None:
             raise HomeAssistantError("Current activity unavailable, try again later")
@@ -473,27 +470,22 @@ class Thermostat(CarrierEntity, ClimateEntity):
                 system_serial=self.carrier_system.profile.serial,
                 zone_id=self.zone_api_id,
                 activity_type=current_activity.type,
-                fan_mode=fan_mode,
+                fan_mode=selected_fan_mode,
             ),
         )
-        current_activity.fan = fan_mode
-        self.async_write_ha_state()
+        current_activity.fan = selected_fan_mode
+        self._write_local_state()
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Update target setpoints and apply a manual hold.
 
         Args:
-            **kwargs: Home Assistant temperature arguments, including optional
-                low/high setpoints and single temperature values.
-
-        Returns:
-            None: Local status/config values are updated after successful writes.
+            **kwargs: Home Assistant temperature arguments.
 
         Raises:
-            HomeAssistantError: Raised when the manual activity profile cannot
-                be resolved for this zone.
+            HomeAssistantError: Raised when the manual activity profile cannot be resolved.
         """
-        _LOGGER.debug("set_temperature; kwargs:%s", kwargs)
+        _LOGGER.debug("set_temperature; kwargs: %s", kwargs)
         heat_set_point = kwargs.get(ATTR_TARGET_TEMP_LOW)
         cool_set_point = kwargs.get(ATTR_TARGET_TEMP_HIGH)
         temperature = kwargs.get(ATTR_TEMPERATURE)
@@ -513,13 +505,12 @@ class Thermostat(CarrierEntity, ClimateEntity):
         fan_mode = manual_activity.fan
 
         _LOGGER.debug(
-            "set_temperature; heat_set_point:%s, cool_set_point:%s, fan_mode:%s",
+            "set_temperature; heat_set_point: %s, cool_set_point: %s, fan_mode: %s",
             heat_set_point,
             cool_set_point,
             fan_mode,
         )
-        # Apply setpoints before enabling the hold so a failed second write does
-        # not leave the thermostat pinned to MANUAL with stale temperatures.
+
         await self.coordinator.async_perform_api_call(
             "set manual activity",
             partial(
@@ -549,40 +540,4 @@ class Thermostat(CarrierEntity, ClimateEntity):
         manual_activity.heat_set_point = heat_set_point
         self._status_zone.cool_set_point = cool_set_point
         self._status_zone.heat_set_point = heat_set_point
-        self.async_write_ha_state()
-
-    @property
-    def extra_state_attributes(self) -> Mapping[str, Any] | None:
-        """Expose supplemental runtime and hold metadata.
-
-        Returns:
-            Mapping[str, Any] | None: Additional state attributes for diagnostics
-            and UI display.
-        """
-        hold_activity_name = (
-            self._config_zone.hold_activity.value if self._config_zone.hold_activity else None
-        )
-        return {
-            "conditioning": self._status_zone.conditioning,
-            "status_mode": self.carrier_system.status.mode,
-            "blower_rpm": self.carrier_system.status.blower_rpm,
-            "damper_position": self._status_zone.damper_position,
-            "hold_activity": hold_activity_name,
-            "hold_until": self._config_zone.hold_until,
-            "next_activity_time": self._config_zone.next_activity_time(),
-        }
-
-    @property
-    def available(self) -> bool:
-        """Indicate whether zone status/config data can be resolved.
-
-        Returns:
-            bool: True when both status and config zone data are available.
-        """
-        # `find_activity(status.current_activity)` can transiently return None
-        # during websocket/config synchronization. Availability should reflect
-        # zone existence, not activity lookup success in that instant.
-        try:
-            return self._status_zone is not None and self._config_zone is not None
-        except ValueError:
-            return False
+        self._write_local_state()

--- a/custom_components/ha_carrier/climate.py
+++ b/custom_components/ha_carrier/climate.py
@@ -33,11 +33,10 @@ from .util import has_cool, has_fan, has_heat
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
-SUPPORT_FLAGS: ClimateEntityFeature = (
+BASE_SUPPORT_FLAGS: ClimateEntityFeature = (
     ClimateEntityFeature.TURN_ON
     | ClimateEntityFeature.TURN_OFF
     | ClimateEntityFeature.TARGET_TEMPERATURE
-    | ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
     | ClimateEntityFeature.PRESET_MODE
 )
 
@@ -59,7 +58,7 @@ async def async_setup_entry(
     coordinator = config_entry.runtime_data
     entities: list[Thermostat] = []
     for carrier_system in coordinator.systems:
-        support_flags = SUPPORT_FLAGS
+        support_flags = BASE_SUPPORT_FLAGS
         hvac_modes: list[HVACMode] = [
             HVACMode.OFF,
         ]
@@ -71,6 +70,7 @@ async def async_setup_entry(
         if has_heat(carrier_system):
             hvac_modes.append(HVACMode.HEAT)
         if has_cool(carrier_system) and has_heat(carrier_system):
+            support_flags |= ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
             hvac_modes.append(HVACMode.HEAT_COOL)
         entities.extend(
             Thermostat(

--- a/custom_components/ha_carrier/climate.py
+++ b/custom_components/ha_carrier/climate.py
@@ -465,6 +465,11 @@ class Thermostat(CarrierClimate):
             heat_set_point = temperature or heat_set_point
             cool_set_point = manual_activity.cool_set_point
 
+        if heat_set_point is None or cool_set_point is None:
+            raise HomeAssistantError(
+                "Both heat and cool set points must be resolved before applying a manual hold"
+            )
+
         fan_mode = manual_activity.fan
 
         _LOGGER.debug(

--- a/custom_components/ha_carrier/climate.py
+++ b/custom_components/ha_carrier/climate.py
@@ -7,14 +7,7 @@ from functools import partial
 import logging
 from typing import Any
 
-from carrier_api import (
-    ActivityTypes,
-    ConfigZoneActivity,
-    FanModes,
-    System,
-    SystemModes,
-    TemperatureUnits,
-)
+from carrier_api import ActivityTypes, ConfigZoneActivity, FanModes, SystemModes, TemperatureUnits
 from homeassistant.components.climate import (
     ClimateEntity,
     ClimateEntityFeature,
@@ -36,6 +29,7 @@ from . import ConfigEntryCarrier
 from .carrier_data_update_coordinator import CarrierDataUpdateCoordinator
 from .carrier_entity import CarrierZoneEntity
 from .const import CONF_INFINITE_HOLDS, DEFAULT_INFINITE_HOLDS, FAN_AUTO
+from .util import has_cool, has_fan, has_heat
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -46,37 +40,6 @@ SUPPORT_FLAGS: ClimateEntityFeature = (
     | ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
     | ClimateEntityFeature.PRESET_MODE
 )
-
-HEAT_TYPES: list[str] = [
-    "hp_heat",
-    "electric_heat",
-    "reheat",
-    "loop_pump",
-]
-
-COOL_TYPES: list[str] = [
-    "cooling",
-]
-
-FAN_TYPES: list[str] = [
-    "fan",
-    "fan_gas",
-]
-
-
-def has_heat(carrier_system: System) -> bool:
-    """Return True if the Carrier system supports heat source selection."""
-    return any(getattr(carrier_system.energy, heat_type, False) is True for heat_type in HEAT_TYPES)
-
-
-def has_cool(carrier_system: System) -> bool:
-    """Return True if the Carrier system supports cool source selection."""
-    return any(getattr(carrier_system.energy, cool_type, False) is True for cool_type in COOL_TYPES)
-
-
-def has_fan(carrier_system: System) -> bool:
-    """Return True if the Carrier system supports fan mode selection."""
-    return any(getattr(carrier_system.energy, fan_type, False) is True for fan_type in FAN_TYPES)
 
 
 async def async_setup_entry(

--- a/custom_components/ha_carrier/const.py
+++ b/custom_components/ha_carrier/const.py
@@ -8,7 +8,7 @@ VERSION: str = "2.19.5"
 DOMAIN: str = "ha_carrier"
 
 # Integration Setting Constants
-CONFIG_FLOW_VERSION: int = 1
+CONFIG_FLOW_VERSION: int = 2
 PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
     Platform.SENSOR,

--- a/custom_components/ha_carrier/migrate.py
+++ b/custom_components/ha_carrier/migrate.py
@@ -16,19 +16,10 @@ from homeassistant.helpers.entity_registry import EntityRegistry, RegistryEntry
 from homeassistant.util import slugify
 
 from .const import CONFIG_FLOW_VERSION
-from .util import TIMESTAMP_TYPES, has_heat
+from .util import ENERGY_METRIC_MAP, TIMESTAMP_TYPES, has_heat
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
-ENERGY_METRICS: tuple[str, ...] = (
-    "cooling",
-    "hp_heat",
-    "fan",
-    "electric_heat",
-    "reheat",
-    "fan_gas",
-    "loop_pump",
-)
 ALWAYS_CREATED_SYSTEM_ENTITY_SUFFIXES: tuple[str, ...] = (
     "Online",
     "Outdoor Temperature",
@@ -124,7 +115,7 @@ def _async_build_unique_id_migration_map(systems: Iterable[System]) -> dict[str,
             "Propane Consumption Year to Date",
         )
 
-        for metric in ENERGY_METRICS:
+        for metric in ENERGY_METRIC_MAP:
             metric_title = metric.replace("_", " ").title()
             _async_add_unique_id_migration(
                 migration_map,
@@ -209,7 +200,7 @@ def _async_build_created_unique_ids(systems: Iterable[System]) -> set[str]:
         if has_heat(carrier_system):
             created_unique_ids.add(_async_new_unique_id(system_serial, "Heat Source"))
 
-        for metric in ENERGY_METRICS:
+        for metric in ENERGY_METRIC_MAP:
             if getattr(carrier_system.energy, metric, False) is True:
                 metric_title = metric.replace("_", " ").title()
                 created_unique_ids.add(

--- a/custom_components/ha_carrier/migrate.py
+++ b/custom_components/ha_carrier/migrate.py
@@ -36,6 +36,16 @@ CONDITIONALLY_CREATED_SYSTEM_ENTITY_SUFFIXES: tuple[str, ...] = (
     "UV Lamp Remaining",
     "ODU Var",
 )
+ZONE_ENTITY_SUFFIXES: dict[str, str] = {
+    "thermostat": "",
+    "occupancy": " Occupancy",
+    "humidity": " Humidity",
+    "temperature": " Temperature",
+}
+SYSTEM_ENTITY_SUFFIXES: set[str] = {
+    *ALWAYS_CREATED_SYSTEM_ENTITY_SUFFIXES,
+    *CONDITIONALLY_CREATED_SYSTEM_ENTITY_SUFFIXES,
+}
 
 
 def _async_new_unique_id(system_serial: str, new_suffix: str) -> str:
@@ -73,11 +83,240 @@ def _async_add_unique_id_migration(
     )
 
 
-def _async_build_unique_id_migration_map(systems: Iterable[System]) -> dict[str, str]:
+def _async_old_unique_id_suffix(entry: RegistryEntry, system_serial: str) -> str | None:
+    """Return the v1 unique ID suffix for an entity registry entry.
+
+    Args:
+        entry: Entity registry entry being considered for migration.
+        system_serial: Carrier system serial number expected in the unique ID.
+
+    Returns:
+        str | None: Legacy suffix after the system serial prefix, or None when
+            the entry does not belong to the system serial.
+    """
+    unique_id_prefix = f"{system_serial}_"
+    if not entry.unique_id.startswith(unique_id_prefix):
+        return None
+    return entry.unique_id.removeprefix(unique_id_prefix)
+
+
+def _async_zone_entry_kind(entry: RegistryEntry, system_serial: str) -> str | None:
+    """Return the zone entity kind represented by a v1 registry entry.
+
+    Args:
+        entry: Entity registry entry being considered for migration.
+        system_serial: Carrier system serial number expected in the unique ID.
+
+    Returns:
+        str | None: Zone entity kind such as ``thermostat`` or ``humidity``.
+    """
+    old_suffix = _async_old_unique_id_suffix(entry, system_serial)
+    if old_suffix is None:
+        return None
+
+    # Climate entries are zone thermostats even when the zone name itself ends
+    # with a sensor-like suffix such as " Humidity" or " Temperature".
+    if entry.domain == "climate":
+        return "thermostat"
+
+    # Several system-level entities also end with zone-like words. Keep them out
+    # of zone migration classification so "Outdoor Temperature" is not treated
+    # as a zone temperature entity.
+    if old_suffix in SYSTEM_ENTITY_SUFFIXES:
+        return None
+
+    for kind, display_suffix in ZONE_ENTITY_SUFFIXES.items():
+        if display_suffix and old_suffix.endswith(display_suffix):
+            return kind
+
+    return None
+
+
+def _async_add_zone_unique_id_migration(
+    migration_map: dict[str, str],
+    system_serial: str,
+    legacy_zone_name: str,
+    zone_api_id: str,
+    kind: str,
+) -> None:
+    """Add one legacy zone unique ID to version 2 unique ID mapping.
+
+    Args:
+        migration_map: Mutable migration map being built.
+        system_serial: Carrier system serial number.
+        legacy_zone_name: Zone name stored in the v1 unique ID.
+        zone_api_id: Stable Carrier zone API identifier.
+        kind: Zone entity kind being migrated.
+
+    Returns:
+        None: The mapping is updated in place.
+    """
+    display_suffix = ZONE_ENTITY_SUFFIXES[kind]
+    _async_add_unique_id_migration(
+        migration_map,
+        system_serial,
+        f"{legacy_zone_name}{display_suffix}",
+        f"zone_{zone_api_id}_{kind}",
+    )
+
+
+def _async_legacy_zone_name_from_entry(
+    entry: RegistryEntry,
+    system_serial: str,
+    kind: str,
+) -> str | None:
+    """Return the legacy zone name stored in a v1 registry entry.
+
+    Args:
+        entry: Entity registry entry being considered for migration.
+        system_serial: Carrier system serial number expected in the unique ID.
+        kind: Zone entity kind being migrated.
+
+    Returns:
+        str | None: Legacy zone name, or None when the entry does not match.
+    """
+    old_suffix = _async_old_unique_id_suffix(entry, system_serial)
+    if old_suffix is None:
+        return None
+
+    display_suffix = ZONE_ENTITY_SUFFIXES[kind]
+    if display_suffix:
+        if not old_suffix.endswith(display_suffix):
+            return None
+        return old_suffix[: -len(display_suffix)]
+
+    if _async_zone_entry_kind(entry, system_serial) == "thermostat":
+        return old_suffix
+    return None
+
+
+def _async_build_registry_zone_migration_map(
+    systems: Iterable[System],
+    registry_entries: Iterable[RegistryEntry],
+) -> dict[str, str]:
+    """Build zone unique ID mappings from existing registry entries.
+
+    Args:
+        systems: Carrier systems loaded from the account during migration.
+        registry_entries: Existing entity registry entries for the config entry.
+
+    Returns:
+        dict[str, str]: Registry-derived v1 to v2 zone unique ID mappings.
+    """
+    migration_map: dict[str, str] = {}
+    entries = list(registry_entries)
+
+    for carrier_system in systems:
+        system_serial = carrier_system.profile.serial
+        zones = list(carrier_system.config.zones)
+
+        for kind in ZONE_ENTITY_SUFFIXES:
+            # v1 zone unique IDs used the display name stored in the registry.
+            # Build the old side from registry entries instead of current
+            # Carrier zone names so user-renamed zones still migrate.
+            matched_entries = [
+                entry for entry in entries if _async_zone_entry_kind(entry, system_serial) == kind
+            ]
+            legacy_name_to_entry: dict[str, RegistryEntry] = {}
+            for entry in matched_entries:
+                legacy_zone_name = _async_legacy_zone_name_from_entry(entry, system_serial, kind)
+                if legacy_zone_name is None:
+                    continue
+                if legacy_zone_name in legacy_name_to_entry:
+                    _LOGGER.warning(
+                        "Skipping ambiguous Carrier %s zone migration for %s: "
+                        "duplicate legacy zone name %s",
+                        kind,
+                        system_serial,
+                        legacy_zone_name,
+                    )
+                    legacy_name_to_entry = {}
+                    break
+                legacy_name_to_entry[legacy_zone_name] = entry
+
+            if not legacy_name_to_entry:
+                continue
+
+            # Current live data is only used to resolve the target zone API ID.
+            # Duplicate names make that association unsafe, so skip instead of
+            # guessing and possibly moving an entity to the wrong zone.
+            zone_name_to_zone = {zone.name: zone for zone in zones}
+            if len(zone_name_to_zone) != len(zones):
+                _LOGGER.warning(
+                    "Skipping ambiguous Carrier %s zone migration for %s: duplicate zone names",
+                    kind,
+                    system_serial,
+                )
+                continue
+
+            for legacy_zone_name, zone in zone_name_to_zone.items():
+                if legacy_zone_name not in legacy_name_to_entry:
+                    continue
+                # Exact name match: the common case, and the safest mapping.
+                _async_add_zone_unique_id_migration(
+                    migration_map,
+                    system_serial,
+                    legacy_zone_name,
+                    zone.api_id,
+                    kind,
+                )
+
+            unmatched_zones = [zone for zone in zones if zone.name not in legacy_name_to_entry]
+            unmatched_legacy_names = [
+                legacy_zone_name
+                for legacy_zone_name in legacy_name_to_entry
+                if legacy_zone_name not in zone_name_to_zone
+            ]
+
+            if len(unmatched_legacy_names) != len(unmatched_zones):
+                # Different counts means no one-to-one fallback is possible.
+                if unmatched_legacy_names or unmatched_zones:
+                    _LOGGER.warning(
+                        "Skipping ambiguous Carrier %s zone migration for %s: "
+                        "%s unmatched entries, %s unmatched zones",
+                        kind,
+                        system_serial,
+                        len(unmatched_legacy_names),
+                        len(unmatched_zones),
+                    )
+                continue
+
+            if len(unmatched_legacy_names) == 1 and len(unmatched_zones) == 1:
+                # One old zone and one live zone remain unmatched. Treat this as
+                # the only safe rename fallback.
+                legacy_zone_name = unmatched_legacy_names[0]
+                zone = unmatched_zones[0]
+                _async_add_zone_unique_id_migration(
+                    migration_map,
+                    system_serial,
+                    legacy_zone_name,
+                    zone.api_id,
+                    kind,
+                )
+                continue
+
+            if unmatched_legacy_names or unmatched_zones:
+                # Multiple unmatched zones could be reordered or renamed; do not
+                # pair by position because that can assign the wrong zone API ID.
+                _LOGGER.warning(
+                    "Skipping ambiguous Carrier %s zone migration for %s: "
+                    "legacy zone names do not uniquely match current zone names",
+                    kind,
+                    system_serial,
+                )
+
+    return migration_map
+
+
+def _async_build_unique_id_migration_map(
+    systems: Iterable[System],
+    registry_entries: Iterable[RegistryEntry],
+) -> dict[str, str]:
     """Build old-to-new entity unique ID mappings for Carrier systems.
 
     Args:
         systems: Carrier systems loaded from the account during migration.
+        registry_entries: Existing entity registry entries for the config entry.
 
     Returns:
         dict[str, str]: Mapping from version 1 unique IDs to version 2 unique IDs.
@@ -87,6 +326,9 @@ def _async_build_unique_id_migration_map(systems: Iterable[System]) -> dict[str,
     for carrier_system in systems:
         system_serial = carrier_system.profile.serial
 
+        # System-level v1 unique IDs only changed by slugification and, for a
+        # few entities, display suffix changes. These do not depend on zone API
+        # IDs, so they can be mapped directly from live system data.
         for suffix in (
             *ALWAYS_CREATED_SYSTEM_ENTITY_SUFFIXES,
             *CONDITIONALLY_CREATED_SYSTEM_ENTITY_SUFFIXES,
@@ -136,33 +378,9 @@ def _async_build_unique_id_migration_map(systems: Iterable[System]) -> dict[str,
                 f"{metric_title} Energy Last Month",
             )
 
-        for zone in carrier_system.config.zones:
-            zone_unique_id_suffix = f"zone_{zone.api_id}"
-            _async_add_unique_id_migration(
-                migration_map,
-                system_serial,
-                zone.name,
-                f"{zone_unique_id_suffix}_thermostat",
-            )
-            _async_add_unique_id_migration(
-                migration_map,
-                system_serial,
-                f"{zone.name} Occupancy",
-                f"{zone_unique_id_suffix}_occupancy",
-            )
-            _async_add_unique_id_migration(
-                migration_map,
-                system_serial,
-                f"{zone.name} Humidity",
-                f"{zone_unique_id_suffix}_humidity",
-            )
-            _async_add_unique_id_migration(
-                migration_map,
-                system_serial,
-                f"{zone.name} Temperature",
-                f"{zone_unique_id_suffix}_temperature",
-            )
-
+    # Zone entities need registry context because their v1 unique IDs were based
+    # on names and v2 unique IDs are based on stable Carrier zone API IDs.
+    migration_map.update(_async_build_registry_zone_migration_map(systems, registry_entries))
     return migration_map
 
 
@@ -249,7 +467,8 @@ def _async_migrate_entity_unique_ids(
     registry_entries: Iterable[RegistryEntry],
     migration_map: Mapping[str, str],
     created_unique_ids: set[str],
-) -> None:
+    allow_deletions: bool,
+) -> list[RegistryEntry]:
     """Rename or remove legacy Carrier entity registry entries.
 
     Args:
@@ -257,64 +476,83 @@ def _async_migrate_entity_unique_ids(
         registry_entries: Entity registry entries owned by the config entry.
         migration_map: Old-to-new unique ID migration map.
         created_unique_ids: Unique IDs that version 2 setup will create.
+        allow_deletions: Whether stale entries may be removed.
 
     Returns:
-        None: Entity registry entries are updated in place.
+        list[RegistryEntry]: Registry entries that could not be matched and updated.
     """
     existing_unique_ids = {entry.unique_id for entry in registry_entries}
+    unmatched_entries: list[RegistryEntry] = []
 
     for entry in registry_entries:
         new_unique_id = migration_map.get(entry.unique_id)
-        if new_unique_id is None or new_unique_id == entry.unique_id:
+        if new_unique_id == entry.unique_id:
+            continue
+
+        if new_unique_id is None:
+            unmatched_entries.append(entry)
             continue
 
         if new_unique_id not in created_unique_ids:
-            _LOGGER.debug(
-                "Removing stale Carrier entity %s during unique ID migration",
-                entry.entity_id,
-            )
-            ent_reg.async_remove(entry.entity_id)
-            existing_unique_ids.discard(entry.unique_id)
+            # Only remove stale entities when live discovery succeeded. If the
+            # Carrier API was unavailable, created_unique_ids is incomplete.
+            if allow_deletions:
+                _LOGGER.info(
+                    "Removing stale Carrier entity %s during unique ID migration",
+                    entry.entity_id,
+                )
+                ent_reg.async_remove(entry.entity_id)
+                existing_unique_ids.discard(entry.unique_id)
+            else:
+                unmatched_entries.append(entry)
             continue
 
         if new_unique_id in existing_unique_ids:
-            _LOGGER.debug(
-                "Removing duplicate legacy Carrier entity %s during unique ID migration",
-                entry.entity_id,
-            )
-            ent_reg.async_remove(entry.entity_id)
-            existing_unique_ids.discard(entry.unique_id)
+            # A current v2 entry already exists. Remove only the old duplicate,
+            # and only when live data proved the new entity should exist.
+            if allow_deletions:
+                _LOGGER.info(
+                    "Removing duplicate legacy Carrier entity %s during unique ID migration",
+                    entry.entity_id,
+                )
+                ent_reg.async_remove(entry.entity_id)
+                existing_unique_ids.discard(entry.unique_id)
+            else:
+                unmatched_entries.append(entry)
             continue
 
         ent_reg.async_update_entity(entry.entity_id, new_unique_id=new_unique_id)
         existing_unique_ids.discard(entry.unique_id)
         existing_unique_ids.add(new_unique_id)
 
+    return unmatched_entries
+
 
 async def _async_migrate_entity_registry_unique_ids(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
-    migration_map: Mapping[str, str],
-    created_unique_ids: set[str],
-) -> None:
+    systems: Iterable[System],
+    allow_deletions: bool,
+) -> list[RegistryEntry]:
     """Migrate or remove entity registry entries for one Carrier config entry.
 
     Args:
         hass: Home Assistant instance.
         config_entry: Carrier config entry being migrated.
-        migration_map: Old-to-new unique ID migration map.
-        created_unique_ids: Unique IDs that version 2 setup will create.
+        systems: Carrier systems loaded from the account during migration.
+        allow_deletions: Whether stale entries may be removed.
 
     Returns:
-        None: Entity registry entries are updated in place.
+        list[RegistryEntry]: Registry entries that could not be matched and updated.
     """
     ent_reg = er.async_get(hass)
     registry_entries = list(ent_reg.entities.get_entries_for_config_entry_id(config_entry.entry_id))
-    _async_migrate_entity_unique_ids(
+    return _async_migrate_entity_unique_ids(
         ent_reg,
         registry_entries,
-        migration_map,
-        created_unique_ids,
+        _async_build_unique_id_migration_map(systems, registry_entries),
+        _async_build_created_unique_ids(systems),
+        allow_deletions,
     )
 
 
@@ -329,12 +567,14 @@ async def migrate_1_to_2(hass: HomeAssistant, config_entry: ConfigEntry) -> bool
         bool: True when entity registry migration and config entry version
             update succeed.
     """
+    systems_loaded = False
     try:
         api_connection = ApiConnectionGraphql(
             username=config_entry.data[CONF_USERNAME],
             password=config_entry.data[CONF_PASSWORD],
         )
         systems = await api_connection.load_data()
+        systems_loaded = True
     except (
         AuthError,
         BaseError,
@@ -343,15 +583,37 @@ async def migrate_1_to_2(hass: HomeAssistant, config_entry: ConfigEntry) -> bool
         OSError,
         TransportError,
     ):
-        _LOGGER.exception("Unable to load Carrier data for config entry migration")
-        return False
+        _LOGGER.warning(
+            "Unable to load Carrier data for config entry migration; "
+            "continuing without destructive entity registry cleanup",
+            exc_info=True,
+        )
+        systems = []
 
-    await _async_migrate_entity_registry_unique_ids(
+    if systems_loaded and not systems:
+        _LOGGER.warning(
+            "No Carrier systems loaded for config entry migration; "
+            "running non-destructive registry migration only"
+        )
+
+    # Missing live data still lets the migration attempt safe registry updates,
+    # but it must not delete stale entries or mark the config entry as migrated.
+    unmatched_entries = await _async_migrate_entity_registry_unique_ids(
         hass,
         config_entry,
-        _async_build_unique_id_migration_map(systems),
-        _async_build_created_unique_ids(systems),
+        systems,
+        bool(systems),
     )
-    hass.config_entries.async_update_entry(config_entry, version=CONFIG_FLOW_VERSION)
-    _LOGGER.info("Carrier config entry migration to version %s complete", CONFIG_FLOW_VERSION)
+    if unmatched_entries:
+        _LOGGER.info(
+            "Carrier config entry migration could not match and update entities: %s",
+            [entry.entity_id for entry in unmatched_entries],
+        )
+    if systems_loaded:
+        hass.config_entries.async_update_entry(config_entry, version=CONFIG_FLOW_VERSION)
+        _LOGGER.info("Carrier config entry migration to version %s complete", CONFIG_FLOW_VERSION)
+    else:
+        _LOGGER.warning(
+            "Carrier migration deferred due to data-load failure; will retry on next startup"
+        )
     return True

--- a/custom_components/ha_carrier/migrate.py
+++ b/custom_components/ha_carrier/migrate.py
@@ -1,0 +1,366 @@
+"""Config entry migration helpers for the Carrier integration."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+import logging
+
+from aiohttp import ClientError
+from carrier_api import ApiConnectionGraphql, AuthError, BaseError, System
+from gql.transport.exceptions import TransportError
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.entity_registry import EntityRegistry, RegistryEntry
+from homeassistant.util import slugify
+
+from .const import CONFIG_FLOW_VERSION
+from .util import TIMESTAMP_TYPES, has_heat
+
+_LOGGER: logging.Logger = logging.getLogger(__name__)
+
+ENERGY_METRICS: tuple[str, ...] = (
+    "cooling",
+    "hp_heat",
+    "fan",
+    "electric_heat",
+    "reheat",
+    "fan_gas",
+    "loop_pump",
+)
+ALWAYS_CREATED_SYSTEM_ENTITY_SUFFIXES: tuple[str, ...] = (
+    "Online",
+    "Outdoor Temperature",
+    "Filter Remaining",
+    "Airflow",
+    "Static Pressure",
+    "ODU Status",
+    "IDU Status",
+)
+CONDITIONALLY_CREATED_SYSTEM_ENTITY_SUFFIXES: tuple[str, ...] = (
+    "Humidifier Running",
+    "Heat Source",
+    "Humidifier Remaining",
+    "UV Lamp Remaining",
+    "ODU Var",
+)
+
+
+def _async_new_unique_id(system_serial: str, new_suffix: str) -> str:
+    """Return the version 2 unique ID for a Carrier entity.
+
+    Args:
+        system_serial: Carrier system serial number.
+        new_suffix: Version 2 unique ID suffix.
+
+    Returns:
+        str: Slugified version 2 unique ID.
+    """
+    return slugify(f"{system_serial}_{new_suffix}")
+
+
+def _async_add_unique_id_migration(
+    migration_map: dict[str, str],
+    system_serial: str,
+    old_suffix: str,
+    new_suffix: str | None = None,
+) -> None:
+    """Add one legacy unique ID to version 2 unique ID mapping.
+
+    Args:
+        migration_map: Mutable migration map being built.
+        system_serial: Carrier system serial number.
+        old_suffix: Version 1 unique ID suffix.
+        new_suffix: Version 2 unique ID suffix. Defaults to old_suffix.
+
+    Returns:
+        None: The mapping is updated in place.
+    """
+    migration_map[f"{system_serial}_{old_suffix}"] = _async_new_unique_id(
+        system_serial, new_suffix or old_suffix
+    )
+
+
+def _async_build_unique_id_migration_map(systems: Iterable[System]) -> dict[str, str]:
+    """Build old-to-new entity unique ID mappings for Carrier systems.
+
+    Args:
+        systems: Carrier systems loaded from the account during migration.
+
+    Returns:
+        dict[str, str]: Mapping from version 1 unique IDs to version 2 unique IDs.
+    """
+    migration_map: dict[str, str] = {}
+
+    for carrier_system in systems:
+        system_serial = carrier_system.profile.serial
+
+        for suffix in (
+            *ALWAYS_CREATED_SYSTEM_ENTITY_SUFFIXES,
+            *CONDITIONALLY_CREATED_SYSTEM_ENTITY_SUFFIXES,
+        ):
+            _async_add_unique_id_migration(migration_map, system_serial, suffix)
+
+        for timestamp_type in TIMESTAMP_TYPES:
+            _async_add_unique_id_migration(
+                migration_map,
+                system_serial,
+                f"updated {timestamp_type.replace('_', ' ').capitalize()} at",
+                f"{timestamp_type.replace('_', ' ').title()} Last Updated",
+            )
+
+        fuel_type = carrier_system.config.fuel_type
+        _async_add_unique_id_migration(
+            migration_map,
+            system_serial,
+            f"{fuel_type.capitalize()} Yearly",
+            f"{fuel_type.capitalize()} Usage Year to Date",
+        )
+        _async_add_unique_id_migration(
+            migration_map,
+            system_serial,
+            "Propane Yearly Gallons",
+            "Propane Consumption Year to Date",
+        )
+
+        for metric in ENERGY_METRICS:
+            metric_title = metric.replace("_", " ").title()
+            _async_add_unique_id_migration(
+                migration_map,
+                system_serial,
+                f"{metric} Energy Yearly",
+                f"{metric_title} Energy Year to Date",
+            )
+            _async_add_unique_id_migration(
+                migration_map,
+                system_serial,
+                f"{metric} Energy Yesterday",
+                f"{metric_title} Energy Yesterday",
+            )
+            _async_add_unique_id_migration(
+                migration_map,
+                system_serial,
+                f"{metric} Energy Last Month",
+                f"{metric_title} Energy Last Month",
+            )
+
+        for zone in carrier_system.config.zones:
+            zone_unique_id_suffix = f"zone_{zone.api_id}"
+            _async_add_unique_id_migration(
+                migration_map,
+                system_serial,
+                zone.name,
+                f"{zone_unique_id_suffix}_thermostat",
+            )
+            _async_add_unique_id_migration(
+                migration_map,
+                system_serial,
+                f"{zone.name} Occupancy",
+                f"{zone_unique_id_suffix}_occupancy",
+            )
+            _async_add_unique_id_migration(
+                migration_map,
+                system_serial,
+                f"{zone.name} Humidity",
+                f"{zone_unique_id_suffix}_humidity",
+            )
+            _async_add_unique_id_migration(
+                migration_map,
+                system_serial,
+                f"{zone.name} Temperature",
+                f"{zone_unique_id_suffix}_temperature",
+            )
+
+    return migration_map
+
+
+def _async_build_created_unique_ids(systems: Iterable[System]) -> set[str]:
+    """Build unique IDs that version 2 setup will create for Carrier systems.
+
+    Args:
+        systems: Carrier systems loaded from the account during migration.
+
+    Returns:
+        set[str]: Version 2 entity unique IDs expected to be created.
+    """
+    created_unique_ids: set[str] = set()
+
+    for carrier_system in systems:
+        system_serial = carrier_system.profile.serial
+        for suffix in ALWAYS_CREATED_SYSTEM_ENTITY_SUFFIXES:
+            created_unique_ids.add(_async_new_unique_id(system_serial, suffix))
+
+        for timestamp_type in TIMESTAMP_TYPES:
+            created_unique_ids.add(
+                _async_new_unique_id(
+                    system_serial,
+                    f"{timestamp_type.replace('_', ' ').title()} Last Updated",
+                )
+            )
+
+        if carrier_system.config.humidifier_enabled:
+            created_unique_ids.add(_async_new_unique_id(system_serial, "Humidifier Running"))
+            created_unique_ids.add(_async_new_unique_id(system_serial, "Humidifier Remaining"))
+        if carrier_system.config.uv_enabled:
+            created_unique_ids.add(_async_new_unique_id(system_serial, "UV Lamp Remaining"))
+        if carrier_system.profile.outdoor_unit_type in ["varcaphp", "varcapac"]:
+            created_unique_ids.add(_async_new_unique_id(system_serial, "ODU Var"))
+        if has_heat(carrier_system):
+            created_unique_ids.add(_async_new_unique_id(system_serial, "Heat Source"))
+
+        for metric in ENERGY_METRICS:
+            if getattr(carrier_system.energy, metric, False) is True:
+                metric_title = metric.replace("_", " ").title()
+                created_unique_ids.add(
+                    _async_new_unique_id(system_serial, f"{metric_title} Energy Year to Date")
+                )
+                created_unique_ids.add(
+                    _async_new_unique_id(system_serial, f"{metric_title} Energy Yesterday")
+                )
+                created_unique_ids.add(
+                    _async_new_unique_id(system_serial, f"{metric_title} Energy Last Month")
+                )
+
+        if getattr(carrier_system.energy, "gas", False) is True:
+            created_unique_ids.add(
+                _async_new_unique_id(
+                    system_serial,
+                    f"{carrier_system.config.fuel_type.capitalize()} Usage Year to Date",
+                )
+            )
+            if carrier_system.config.fuel_type == "propane":
+                created_unique_ids.add(
+                    _async_new_unique_id(system_serial, "Propane Consumption Year to Date")
+                )
+
+        for zone in carrier_system.config.zones:
+            zone_unique_id_suffix = f"zone_{zone.api_id}"
+            created_unique_ids.add(
+                _async_new_unique_id(system_serial, f"{zone_unique_id_suffix}_thermostat")
+            )
+            created_unique_ids.add(
+                _async_new_unique_id(system_serial, f"{zone_unique_id_suffix}_humidity")
+            )
+            created_unique_ids.add(
+                _async_new_unique_id(system_serial, f"{zone_unique_id_suffix}_temperature")
+            )
+            if zone.occupancy_enabled:
+                created_unique_ids.add(
+                    _async_new_unique_id(system_serial, f"{zone_unique_id_suffix}_occupancy")
+                )
+
+    return created_unique_ids
+
+
+def _async_migrate_entity_unique_ids(
+    ent_reg: EntityRegistry,
+    registry_entries: Iterable[RegistryEntry],
+    migration_map: Mapping[str, str],
+    created_unique_ids: set[str],
+) -> None:
+    """Rename or remove legacy Carrier entity registry entries.
+
+    Args:
+        ent_reg: Home Assistant entity registry.
+        registry_entries: Entity registry entries owned by the config entry.
+        migration_map: Old-to-new unique ID migration map.
+        created_unique_ids: Unique IDs that version 2 setup will create.
+
+    Returns:
+        None: Entity registry entries are updated in place.
+    """
+    existing_unique_ids = {entry.unique_id for entry in registry_entries}
+
+    for entry in registry_entries:
+        new_unique_id = migration_map.get(entry.unique_id)
+        if new_unique_id is None or new_unique_id == entry.unique_id:
+            continue
+
+        if new_unique_id not in created_unique_ids:
+            _LOGGER.debug(
+                "Removing stale Carrier entity %s during unique ID migration",
+                entry.entity_id,
+            )
+            ent_reg.async_remove(entry.entity_id)
+            existing_unique_ids.discard(entry.unique_id)
+            continue
+
+        if new_unique_id in existing_unique_ids:
+            _LOGGER.debug(
+                "Removing duplicate legacy Carrier entity %s during unique ID migration",
+                entry.entity_id,
+            )
+            ent_reg.async_remove(entry.entity_id)
+            existing_unique_ids.discard(entry.unique_id)
+            continue
+
+        ent_reg.async_update_entity(entry.entity_id, new_unique_id=new_unique_id)
+        existing_unique_ids.discard(entry.unique_id)
+        existing_unique_ids.add(new_unique_id)
+
+
+async def _async_migrate_entity_registry_unique_ids(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    migration_map: Mapping[str, str],
+    created_unique_ids: set[str],
+) -> None:
+    """Migrate or remove entity registry entries for one Carrier config entry.
+
+    Args:
+        hass: Home Assistant instance.
+        config_entry: Carrier config entry being migrated.
+        migration_map: Old-to-new unique ID migration map.
+        created_unique_ids: Unique IDs that version 2 setup will create.
+
+    Returns:
+        None: Entity registry entries are updated in place.
+    """
+    ent_reg = er.async_get(hass)
+    registry_entries = list(ent_reg.entities.get_entries_for_config_entry_id(config_entry.entry_id))
+    _async_migrate_entity_unique_ids(
+        ent_reg,
+        registry_entries,
+        migration_map,
+        created_unique_ids,
+    )
+
+
+async def migrate_1_to_2(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+    """Migrate a Carrier config entry from version 1 to version 2.
+
+    Args:
+        hass: Home Assistant instance.
+        config_entry: Version 1 Carrier config entry being migrated.
+
+    Returns:
+        bool: True when entity registry migration and config entry version
+            update succeed.
+    """
+    try:
+        api_connection = ApiConnectionGraphql(
+            username=config_entry.data[CONF_USERNAME],
+            password=config_entry.data[CONF_PASSWORD],
+        )
+        systems = await api_connection.load_data()
+    except (
+        AuthError,
+        BaseError,
+        ClientError,
+        TimeoutError,
+        OSError,
+        TransportError,
+    ):
+        _LOGGER.exception("Unable to load Carrier data for config entry migration")
+        return False
+
+    await _async_migrate_entity_registry_unique_ids(
+        hass,
+        config_entry,
+        _async_build_unique_id_migration_map(systems),
+        _async_build_created_unique_ids(systems),
+    )
+    hass.config_entries.async_update_entry(config_entry, version=CONFIG_FLOW_VERSION)
+    _LOGGER.info("Carrier config entry migration to version %s complete", CONFIG_FLOW_VERSION)
+    return True

--- a/custom_components/ha_carrier/select.py
+++ b/custom_components/ha_carrier/select.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from functools import partial
 import logging
 
-from carrier_api import System
 from carrier_api.const import HeatSourceTypes
 from homeassistant.components.select import SelectEntity
 from homeassistant.core import HomeAssistant
@@ -16,20 +15,9 @@ from . import ConfigEntryCarrier
 from .carrier_data_update_coordinator import CarrierDataUpdateCoordinator
 from .carrier_entity import CarrierEntity
 from .const import HEAT_SOURCE_IDU_ONLY_LABEL, HEAT_SOURCE_ODU_ONLY_LABEL, HEAT_SOURCE_SYSTEM_LABEL
+from .util import has_heat
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
-
-HEAT_TYPES: list[str] = [
-    "hp_heat",
-    "electric_heat",
-    "reheat",
-    "loop_pump",
-]
-
-
-def has_heat(carrier_system: System) -> bool:
-    """Return True if the Carrier system supports heat source selection."""
-    return any(getattr(carrier_system.energy, heat_type, False) is True for heat_type in HEAT_TYPES)
 
 
 async def async_setup_entry(

--- a/custom_components/ha_carrier/select.py
+++ b/custom_components/ha_carrier/select.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 from functools import partial
 import logging
 
+from carrier_api import System
 from carrier_api.const import HeatSourceTypes
-from homeassistant.components.select import SelectEntity, SelectEntityDescription
+from homeassistant.components.select import SelectEntity
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import ConfigEntryCarrier
@@ -16,6 +18,18 @@ from .carrier_entity import CarrierEntity
 from .const import HEAT_SOURCE_IDU_ONLY_LABEL, HEAT_SOURCE_ODU_ONLY_LABEL, HEAT_SOURCE_SYSTEM_LABEL
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
+
+HEAT_TYPES: list[str] = [
+    "hp_heat",
+    "electric_heat",
+    "reheat",
+    "loop_pump",
+]
+
+
+def has_heat(carrier_system: System) -> bool:
+    """Return True if the Carrier system supports heat source selection."""
+    return any(getattr(carrier_system.energy, heat_type, False) is True for heat_type in HEAT_TYPES)
 
 
 async def async_setup_entry(
@@ -29,75 +43,107 @@ async def async_setup_entry(
         hass: Home Assistant instance.
         config_entry: Carrier integration config entry.
         async_add_entities: Callback used to register entity instances.
-
-    Returns:
-        None: Entities are registered through the callback.
     """
-    updater = config_entry.runtime_data
-    entities = []
-    for system in updater.systems:
-        entities.extend(
-            [
-                HeatSourceSelect(updater, system.profile.serial),
-            ]
-        )
+    coordinator = config_entry.runtime_data
+    entities: list[SelectEntity] = [
+        HeatSourceSelect(coordinator=coordinator, system_serial=system.profile.serial)
+        for system in coordinator.systems
+        if has_heat(system)
+    ]
     async_add_entities(entities)
 
 
-class HeatSourceSelect(CarrierEntity, SelectEntity):
+class CarrierSelect(CarrierEntity, SelectEntity):
+    """Shared Carrier base class for select entities."""
+
+    def __init__(
+        self,
+        entity_name: str,
+        coordinator: CarrierDataUpdateCoordinator,
+        system_serial: str | None = None,
+        unique_id_suffix: str | None = None,
+    ) -> None:
+        """Initialize a Carrier select entity.
+
+        Args:
+            entity_name: Friendly suffix used in entity name and unique ID.
+            coordinator: Coordinator that provides Carrier data.
+            system_serial: Carrier system serial for this entity.
+            unique_id_suffix: Optional stable suffix used for the entity unique ID.
+
+        Raises:
+            ValueError: Raised when no Carrier system serial is provided.
+        """
+        if system_serial is None:
+            raise ValueError("Carrier select system serial is required")
+        super().__init__(
+            entity_name=entity_name,
+            coordinator=coordinator,
+            system_serial=system_serial,
+            unique_id_suffix=unique_id_suffix,
+        )
+        self._sync_entity_attrs()
+
+    def _update_entity_attrs(self) -> None:
+        """Update select attrs from coordinator data."""
+        self._attr_available = False
+
+
+class HeatSourceSelect(CarrierSelect):
     """Select entity that controls which unit provides primary heating."""
 
     _attr_icon = "mdi:heat-pump"
+    _attr_options: list[str]
 
-    def __init__(self, updater: CarrierDataUpdateCoordinator, system_serial: str) -> None:
+    def __init__(self, coordinator: CarrierDataUpdateCoordinator, system_serial: str) -> None:
         """Initialize selectable heat source options for one system.
 
         Args:
-            updater: Coordinator that provides Carrier system state.
+            coordinator: Coordinator that provides Carrier system state.
             system_serial: Unique Carrier system serial number.
         """
-        super().__init__("Heat Source", updater, system_serial)
+        super().__init__("Heat Source", coordinator, system_serial)
         if self.carrier_system.profile.outdoor_unit_type in [
             "hp2stg",
             "varcaphp",
             "multistghp",
             "GeoHP",
         ]:
-            options = [
-                self.idu_only_label(),
+            self._attr_options = [
+                self._idu_only_label(self.carrier_system.profile.indoor_unit_source),
                 HEAT_SOURCE_ODU_ONLY_LABEL,
                 HEAT_SOURCE_SYSTEM_LABEL,
             ]
         else:
-            options = [self.idu_only_label(), HEAT_SOURCE_SYSTEM_LABEL]
-        self.entity_description = SelectEntityDescription(
-            key=f"#{self.carrier_system.profile.serial}-heat_source", options=options
-        )
+            self._attr_options = [
+                self._idu_only_label(self.carrier_system.profile.indoor_unit_source),
+                HEAT_SOURCE_SYSTEM_LABEL,
+            ]
 
-    def idu_only_label(self) -> str:
+    @staticmethod
+    def _idu_only_label(indoor_unit_source: str | None) -> str:
         """Return the label for indoor-unit-only heat source mode.
 
+        Args:
+            indoor_unit_source: Fuel source reported by the indoor unit.
+
         Returns:
-            str: Human-readable option label with the indoor fuel source when available.
+            str: Human-readable option label.
         """
-        if self.carrier_system.profile.indoor_unit_source is None:
+        if indoor_unit_source is None:
             return HEAT_SOURCE_IDU_ONLY_LABEL
-        return HEAT_SOURCE_IDU_ONLY_LABEL.replace(
-            "gas", self.carrier_system.profile.indoor_unit_source
-        )
+        return HEAT_SOURCE_IDU_ONLY_LABEL.replace("gas", indoor_unit_source)
 
-    @property
-    def current_option(self) -> str | None:
-        """Return the currently selected heat source option label.
-
-        Returns:
-            str | None: Matching option label for the active Carrier heat source.
-        """
-        return {
-            HeatSourceTypes.IDU_ONLY.value: self.idu_only_label(),
+    def _update_entity_attrs(self) -> None:
+        """Update heat source attrs from coordinator data."""
+        self._attr_current_option = {
+            HeatSourceTypes.IDU_ONLY.value: self._idu_only_label(
+                self.carrier_system.profile.indoor_unit_source
+            ),
             HeatSourceTypes.ODU_ONLY.value: HEAT_SOURCE_ODU_ONLY_LABEL,
             HeatSourceTypes.SYSTEM.value: HEAT_SOURCE_SYSTEM_LABEL,
         }.get(self.carrier_system.config.heat_source)
+        self._attr_available = self._attr_current_option is not None
 
     async def async_select_option(self, option: str) -> None:
         """Apply a new heat source option to the Carrier system.
@@ -105,14 +151,21 @@ class HeatSourceSelect(CarrierEntity, SelectEntity):
         Args:
             option: Selected Home Assistant option label.
 
-        Returns:
-            None: The state is updated in-place and written to Home Assistant.
+        Raises:
+            HomeAssistantError: Raised when the selected option is not a known heat source label.
         """
-        new_heat_source: HeatSourceTypes = {
-            self.idu_only_label(): HeatSourceTypes.IDU_ONLY,
+        heat_source_map: dict[str, HeatSourceTypes] = {
+            self._idu_only_label(
+                self.carrier_system.profile.indoor_unit_source
+            ): HeatSourceTypes.IDU_ONLY,
             HEAT_SOURCE_ODU_ONLY_LABEL: HeatSourceTypes.ODU_ONLY,
             HEAT_SOURCE_SYSTEM_LABEL: HeatSourceTypes.SYSTEM,
-        }.get(option, HeatSourceTypes.SYSTEM)
+        }
+        if option not in heat_source_map:
+            _LOGGER.error("Unsupported heat source option selected: %s", option)
+            raise HomeAssistantError(f"Unsupported heat source option: {option}")
+
+        new_heat_source = heat_source_map[option]
         _LOGGER.debug("Selected heat source: %s", new_heat_source)
         await self.coordinator.async_perform_api_call(
             "set heat source",
@@ -123,13 +176,4 @@ class HeatSourceSelect(CarrierEntity, SelectEntity):
             ),
         )
         self.carrier_system.config.heat_source = new_heat_source.value
-        self.async_write_ha_state()
-
-    @property
-    def available(self) -> bool:
-        """Indicate whether the select can present a valid option.
-
-        Returns:
-            bool: True when a current option can be resolved.
-        """
-        return self.current_option is not None
+        self._write_local_state()

--- a/custom_components/ha_carrier/sensor.py
+++ b/custom_components/ha_carrier/sensor.py
@@ -22,6 +22,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from . import ConfigEntryCarrier
 from .carrier_data_update_coordinator import CarrierDataUpdateCoordinator
 from .carrier_entity import CarrierEntity, CarrierZoneEntity
+from .util import TIMESTAMP_TYPES
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -59,21 +60,6 @@ async def async_setup_entry(
                 FilterUsedSensor(
                     coordinator=coordinator, system_serial=carrier_system.profile.serial
                 ),
-                TimestampSensor(
-                    coordinator=coordinator,
-                    system_serial=carrier_system.profile.serial,
-                    timestamp_type="all_data",
-                ),
-                TimestampSensor(
-                    coordinator=coordinator,
-                    system_serial=carrier_system.profile.serial,
-                    timestamp_type="websocket",
-                ),
-                TimestampSensor(
-                    coordinator=coordinator,
-                    system_serial=carrier_system.profile.serial,
-                    timestamp_type="energy",
-                ),
                 AirflowSensor(coordinator=coordinator, system_serial=carrier_system.profile.serial),
                 StaticPressureSensor(
                     coordinator=coordinator, system_serial=carrier_system.profile.serial
@@ -86,6 +72,17 @@ async def async_setup_entry(
                 ),
             ]
         )
+        entities.extend(
+            [
+                TimestampSensor(
+                    coordinator=coordinator,
+                    system_serial=carrier_system.profile.serial,
+                    timestamp_type=timestamp_type,
+                )
+                for timestamp_type in TIMESTAMP_TYPES
+            ]
+        )
+
         if carrier_system.profile.outdoor_unit_type in ["varcaphp", "varcapac"]:
             entities.append(
                 OutdoorUnitVarSensor(

--- a/custom_components/ha_carrier/sensor.py
+++ b/custom_components/ha_carrier/sensor.py
@@ -425,7 +425,7 @@ class DailyEnergyMeasurementSensor(CarrierSensor):
     """Sensor for yesterday's energy usage by Carrier metric."""
 
     _attr_device_class = SensorDeviceClass.ENERGY
-    _attr_state_class = SensorStateClass.TOTAL_INCREASING
+    _attr_state_class = SensorStateClass.TOTAL
     _attr_native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
     _attr_suggested_display_precision = 1
 
@@ -473,7 +473,7 @@ class MonthlyEnergyMeasurementSensor(CarrierSensor):
     """Sensor for last month's energy usage by Carrier metric."""
 
     _attr_device_class = SensorDeviceClass.ENERGY
-    _attr_state_class = SensorStateClass.TOTAL_INCREASING
+    _attr_state_class = SensorStateClass.TOTAL
     _attr_native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
     _attr_suggested_display_precision = 0
 
@@ -582,7 +582,7 @@ class OutdoorTemperatureSensor(CarrierSensor):
 
 
 class FilterUsedSensor(CarrierSensor):
-    """Filter life sensor represented as a battery-style percentage."""
+    """Filter life sensor represented as a percentage."""
 
     _attr_native_unit_of_measurement = PERCENTAGE
     _attr_state_class = SensorStateClass.MEASUREMENT

--- a/custom_components/ha_carrier/sensor.py
+++ b/custom_components/ha_carrier/sensor.py
@@ -3,19 +3,13 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from datetime import datetime
 import logging
-from typing import Any
 
 from carrier_api import TemperatureUnits
-from homeassistant.components.sensor import (
-    SensorDeviceClass,
-    SensorEntity,
-    SensorEntityDescription,
-    SensorStateClass,
-)
+from homeassistant.components.sensor import SensorDeviceClass, SensorEntity, SensorStateClass
 from homeassistant.const import (
     PERCENTAGE,
+    EntityCategory,
     UnitOfEnergy,
     UnitOfPressure,
     UnitOfTemperature,
@@ -27,9 +21,19 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import ConfigEntryCarrier
 from .carrier_data_update_coordinator import CarrierDataUpdateCoordinator
-from .carrier_entity import CarrierEntity
+from .carrier_entity import CarrierEntity, CarrierZoneEntity
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
+
+ENERGY_METRIC_MAP: dict[str, str] = {
+    "cooling": "coolingKwh",
+    "hp_heat": "hPHeatKwh",
+    "fan": "fanKwh",
+    "electric_heat": "eHeatKwh",
+    "reheat": "reheatKwh",
+    "fan_gas": "fanGasKwh",
+    "loop_pump": "loopPumpKwh",
+}
 
 
 async def async_setup_entry(
@@ -43,74 +47,183 @@ async def async_setup_entry(
         hass: Home Assistant instance.
         config_entry: Carrier integration config entry.
         async_add_entities: Callback used to register created entities.
-
-    Returns:
-        None: Entities are registered through the callback.
     """
-    updater = config_entry.runtime_data
-    entities = []
-    for carrier_system in updater.systems:
+    coordinator = config_entry.runtime_data
+    entities: list[SensorEntity] = []
+    for carrier_system in coordinator.systems:
         entities.extend(
             [
-                OutdoorTemperatureSensor(updater, carrier_system.profile.serial),
-                FilterUsedSensor(updater, carrier_system.profile.serial),
-                TimestampSensor(updater, carrier_system.profile.serial, "all_data"),
-                TimestampSensor(updater, carrier_system.profile.serial, "websocket"),
-                TimestampSensor(updater, carrier_system.profile.serial, "energy"),
-                AirflowSensor(updater, carrier_system.profile.serial),
-                StaticPressureSensor(updater, carrier_system.profile.serial),
-                OutdoorUnitOperationalStatusSensor(updater, carrier_system.profile.serial),
-                IndoorUnitOperationalStatusSensor(updater, carrier_system.profile.serial),
+                OutdoorTemperatureSensor(
+                    coordinator=coordinator, system_serial=carrier_system.profile.serial
+                ),
+                FilterUsedSensor(
+                    coordinator=coordinator, system_serial=carrier_system.profile.serial
+                ),
+                TimestampSensor(
+                    coordinator=coordinator,
+                    system_serial=carrier_system.profile.serial,
+                    timestamp_type="all_data",
+                ),
+                TimestampSensor(
+                    coordinator=coordinator,
+                    system_serial=carrier_system.profile.serial,
+                    timestamp_type="websocket",
+                ),
+                TimestampSensor(
+                    coordinator=coordinator,
+                    system_serial=carrier_system.profile.serial,
+                    timestamp_type="energy",
+                ),
+                AirflowSensor(coordinator=coordinator, system_serial=carrier_system.profile.serial),
+                StaticPressureSensor(
+                    coordinator=coordinator, system_serial=carrier_system.profile.serial
+                ),
+                OutdoorUnitOperationalStatusSensor(
+                    coordinator=coordinator, system_serial=carrier_system.profile.serial
+                ),
+                IndoorUnitOperationalStatusSensor(
+                    coordinator=coordinator, system_serial=carrier_system.profile.serial
+                ),
             ]
         )
         if carrier_system.profile.outdoor_unit_type in ["varcaphp", "varcapac"]:
-            entities.append(OutDoorUnitVarSensor(updater, carrier_system.profile.serial))
+            entities.append(
+                OutdoorUnitVarSensor(
+                    coordinator=coordinator, system_serial=carrier_system.profile.serial
+                )
+            )
         if carrier_system.config.humidifier_enabled:
-            entities.append(HumidifierRemainingSensor(updater, carrier_system.profile.serial))
+            entities.append(
+                HumidifierRemainingSensor(
+                    coordinator=coordinator, system_serial=carrier_system.profile.serial
+                )
+            )
         if carrier_system.config.uv_enabled:
-            entities.append(UVLampRemainingSensor(updater, carrier_system.profile.serial))
-        for electric_metric in [
-            "cooling",
-            "hp_heat",
-            "fan",
-            "electric_heat",
-            "reheat",
-            "fan_gas",
-            "loop_pump",
-        ]:
-            if getattr(carrier_system.energy, electric_metric):
-                entities.append(
-                    EnergyMeasurementSensor(updater, carrier_system.profile.serial, electric_metric)
+            entities.append(
+                UVLampRemainingSensor(
+                    coordinator=coordinator, system_serial=carrier_system.profile.serial
                 )
-                entities.append(
-                    DailyEnergyMeasurementSensor(
-                        updater, carrier_system.profile.serial, electric_metric
-                    )
+            )
+        for electric_metric in ENERGY_METRIC_MAP:
+            if getattr(carrier_system.energy, electric_metric, False) is True:
+                entities.extend(
+                    [
+                        YearlyEnergyMeasurementSensor(
+                            coordinator=coordinator,
+                            system_serial=carrier_system.profile.serial,
+                            metric=electric_metric,
+                        ),
+                        DailyEnergyMeasurementSensor(
+                            coordinator=coordinator,
+                            system_serial=carrier_system.profile.serial,
+                            metric=electric_metric,
+                        ),
+                        MonthlyEnergyMeasurementSensor(
+                            coordinator=coordinator,
+                            system_serial=carrier_system.profile.serial,
+                            metric=electric_metric,
+                        ),
+                    ]
                 )
-                entities.append(
-                    MonthlyEnergyMeasurementSensor(
-                        updater, carrier_system.profile.serial, electric_metric
-                    )
+        gas_measurement = getattr(carrier_system.energy, "gas", False)
+        if gas_measurement is True:
+            entities.append(
+                GasMeasurementSensor(
+                    coordinator=coordinator,
+                    system_serial=carrier_system.profile.serial,
+                    fuel_type=carrier_system.config.fuel_type,
                 )
-        if carrier_system.energy.gas:
-            entities.append(GasMeasurementSensor(updater, carrier_system.profile.serial, "gas"))
+            )
             if carrier_system.config.fuel_type == "propane":
-                entities.append(PropaneMeasurementSensor(updater, carrier_system.profile.serial))
+                entities.append(
+                    PropaneMeasurementSensor(
+                        coordinator=coordinator, system_serial=carrier_system.profile.serial
+                    )
+                )
         for zone in carrier_system.config.zones:
             entities.extend(
                 [
                     ZoneTemperatureSensor(
-                        updater, carrier_system.profile.serial, zone_api_id=zone.api_id
+                        coordinator=coordinator,
+                        system_serial=carrier_system.profile.serial,
+                        zone_api_id=zone.api_id,
                     ),
                     ZoneHumiditySensor(
-                        updater, carrier_system.profile.serial, zone_api_id=zone.api_id
+                        coordinator=coordinator,
+                        system_serial=carrier_system.profile.serial,
+                        zone_api_id=zone.api_id,
                     ),
                 ]
             )
     async_add_entities(entities)
 
 
-class ZoneHumiditySensor(CarrierEntity, SensorEntity):
+class CarrierSensor(CarrierEntity, SensorEntity):
+    """Shared Carrier base class for system-level sensor entities."""
+
+    def __init__(
+        self,
+        entity_name: str,
+        coordinator: CarrierDataUpdateCoordinator,
+        system_serial: str | None = None,
+        unique_id_suffix: str | None = None,
+    ) -> None:
+        """Initialize a Carrier sensor entity.
+
+        Args:
+            entity_name: Friendly suffix used in entity name and unique ID.
+            coordinator: Coordinator that provides Carrier data.
+            system_serial: Carrier system serial for this entity.
+            unique_id_suffix: Optional stable suffix used for the entity unique ID.
+
+        Raises:
+            ValueError: Raised when no Carrier system serial is provided.
+        """
+        if system_serial is None:
+            raise ValueError("Carrier sensor system serial is required")
+        super().__init__(
+            entity_name=entity_name,
+            coordinator=coordinator,
+            system_serial=system_serial,
+            unique_id_suffix=unique_id_suffix,
+        )
+        self._sync_entity_attrs()
+
+    def _update_entity_attrs(self) -> None:
+        """Update sensor attrs from coordinator data."""
+        self._attr_available = False
+
+
+class CarrierZoneSensor(CarrierZoneEntity, CarrierSensor):
+    """Shared Carrier base class for zone-backed sensor entities."""
+
+    def __init__(
+        self,
+        entity_name: str,
+        coordinator: CarrierDataUpdateCoordinator,
+        system_serial: str,
+        zone_api_id: str,
+        unique_id_suffix: str,
+    ) -> None:
+        """Initialize a zone-backed Carrier sensor entity.
+
+        Args:
+            entity_name: Friendly suffix appended to the zone name for display.
+            coordinator: Coordinator that provides Carrier data.
+            system_serial: Carrier system serial for this entity.
+            zone_api_id: Carrier API identifier for the represented zone.
+            unique_id_suffix: Stable suffix used in the zone entity unique ID.
+        """
+        super().__init__(
+            entity_name=entity_name,
+            coordinator=coordinator,
+            system_serial=system_serial,
+            zone_api_id=zone_api_id,
+            unique_id_suffix=unique_id_suffix,
+        )
+
+
+class ZoneHumiditySensor(CarrierZoneSensor):
     """Sensor entity that reports current humidity for a specific zone."""
 
     _attr_device_class = SensorDeviceClass.HUMIDITY
@@ -118,565 +231,473 @@ class ZoneHumiditySensor(CarrierEntity, SensorEntity):
     _attr_native_unit_of_measurement = PERCENTAGE
 
     def __init__(
-        self, updater: CarrierDataUpdateCoordinator, system_serial: str, zone_api_id: str
+        self, coordinator: CarrierDataUpdateCoordinator, system_serial: str, zone_api_id: str
     ) -> None:
         """Initialize a zone humidity sensor.
 
         Args:
-            updater: Coordinator that provides system and zone data.
+            coordinator: Coordinator that provides system and zone data.
             system_serial: Carrier system serial tied to the zone.
             zone_api_id: Carrier API identifier for the represented zone.
         """
-        self.zone_api_id: str = zone_api_id
-        self.coordinator = updater
-        self.coordinator_context = system_serial
-        super().__init__(f"{self._config_zone.name} Humidity", updater, system_serial)
+        super().__init__(
+            entity_name="Humidity",
+            coordinator=coordinator,
+            system_serial=system_serial,
+            zone_api_id=zone_api_id,
+            unique_id_suffix="humidity",
+        )
 
-    @property
-    def native_value(self) -> int | None:
-        """Return current zone humidity.
-
-        Returns:
-            int | None: Relative humidity percentage for the zone, or None when unavailable.
-        """
-        return self._status_zone.humidity
-
-    @property
-    def available(self) -> bool:
-        """Indicate whether humidity data can be shown.
-
-        Returns:
-            bool: True when a zone humidity value is present.
-        """
-        return self.native_value is not None
+    def _update_entity_attrs(self) -> None:
+        """Update humidity attrs from coordinator data."""
+        self._attr_native_value = self._status_zone.humidity
+        self._attr_available = self._attr_native_value is not None
 
 
-class GasMeasurementSensor(CarrierEntity, SensorEntity):
+class GasMeasurementSensor(CarrierSensor):
     """Yearly gas usage sensor with fuel-specific unit conversion."""
 
+    _attr_device_class = SensorDeviceClass.GAS
+    _attr_state_class = SensorStateClass.TOTAL_INCREASING
+
     def __init__(
-        self, updater: CarrierDataUpdateCoordinator, system_serial: str, metric: str
+        self,
+        coordinator: CarrierDataUpdateCoordinator,
+        system_serial: str,
+        fuel_type: str,
     ) -> None:
         """Initialize a yearly gas consumption sensor.
 
         Args:
-            updater: Coordinator that provides system energy payloads.
+            coordinator: Coordinator that provides system energy payloads.
             system_serial: Carrier system serial for this entity.
-            metric: Carrier energy metric key used as the sensor key.
+            fuel_type: Configured fuel type for the Carrier system.
 
         Raises:
             ValueError: Raised when the system serial cannot be resolved.
         """
-        carrier_system = updater.system(system_serial=system_serial)
-        if carrier_system is None:
-            raise ValueError(
-                f"No carrier system found for serial {system_serial!r}; "
-                "cannot initialize GasMeasurementSensor."
-            )
-        self.fuel_type = carrier_system.config.fuel_type
-        unit_of_measurement = UnitOfVolume.CUBIC_METERS  # for therms
-        if self.fuel_type == "propane":
-            unit_of_measurement = UnitOfVolume.CUBIC_FEET
-        self.entity_description = SensorEntityDescription(
-            key=metric,
-            device_class=SensorDeviceClass.GAS,
-            state_class=SensorStateClass.TOTAL_INCREASING,
-            native_unit_of_measurement=unit_of_measurement,
-            suggested_display_precision=2,
+        self.fuel_type = fuel_type
+        super().__init__(
+            entity_name=f"{self.fuel_type.capitalize()} Usage Year to Date",
+            coordinator=coordinator,
+            system_serial=system_serial,
         )
-        super().__init__(f"{self.fuel_type.capitalize()} Yearly", updater, system_serial)
 
-    @property
-    def native_value(self) -> float | None:
-        """Return yearly gas usage converted to the configured gas unit.
-
-        Returns:
-            float | None: Converted yearly gas consumption value, or None when unavailable.
-        """
-        gas = self.carrier_system.energy.current_year_measurements().gas
-        if gas is None:
-            return None
-
-        value = gas
         match self.carrier_system.config.gas_unit:
             case "gallon":
-                value = (
-                    value / 2.54998
-                )  # Convert kBTU to cubic feet (1 cubic foot = 2,549.98 BTU, so divide by 2.54998)
+                self._attr_native_unit_of_measurement = UnitOfVolume.CUBIC_FEET
+                self._attr_suggested_display_precision = 2
+            case "therm" | "gjoule":
+                self._attr_native_unit_of_measurement = UnitOfVolume.CUBIC_METERS
+                self._attr_suggested_display_precision = 2
+            case _:
+                self._attr_native_unit_of_measurement = UnitOfVolume.CUBIC_METERS
+                self._attr_suggested_display_precision = 2
+
+    def _update_entity_attrs(self) -> None:
+        """Update gas usage attrs from coordinator data."""
+        if self.carrier_system.energy.raw is None:
+            self._attr_available = False
+            return
+
+        api_field = "gas"
+        energy_periods = self.carrier_system.energy.raw.get("energyPeriods", [])
+        value: float | None = None
+        for period in energy_periods:
+            if period.get("energyPeriodType") == "year1":
+                value = period.get(api_field)
+                break
+        if value is None:
+            self._attr_available = False
+            return
+
+        match self.carrier_system.config.gas_unit:
+            case "gallon":
+                # Convert kBTU to cubic feet (1 cubic foot = 2,549.98 BTU, so divide by 2.54998)
+                value = value / 2.54998
             case "therm":
-                value = (
-                    value / 100 * 2.8328611898017
-                )  # /100 to therms then * to convert from therms to cubic meters
+                # /100 to therms then * to convert from therms to cubic meters
+                value = value / 100 * 2.8328611898017
             case "gjoule":
                 # /100 to gjoules (because carrier keeps it an integer in the api
                 # response even though it is a float) then * to convert from gjoules
                 # to cubic meters
                 value = value / 100 * 25.5
-        return value
-
-    @property
-    def available(self) -> bool:
-        """Indicate whether gas usage data can be displayed.
-
-        Returns:
-            bool: True when a computed gas value is available.
-        """
-        return self.native_value is not None
+            case _:
+                self._attr_available = False
+                return
+        self._attr_native_value = value
+        self._attr_available = True
 
 
-class PropaneMeasurementSensor(CarrierEntity, SensorEntity):
+class PropaneMeasurementSensor(CarrierSensor):
     """Yearly propane usage sensor expressed in gallons."""
 
-    def __init__(self, updater: CarrierDataUpdateCoordinator, system_serial: str) -> None:
+    _attr_device_class = SensorDeviceClass.VOLUME
+    _attr_state_class = SensorStateClass.TOTAL_INCREASING
+    _attr_native_unit_of_measurement = UnitOfVolume.GALLONS
+    _attr_suggested_display_precision = 2
+
+    def __init__(self, coordinator: CarrierDataUpdateCoordinator, system_serial: str) -> None:
         """Initialize a yearly propane consumption sensor.
 
         Args:
-            updater: Coordinator that provides energy payloads.
+            coordinator: Coordinator that provides energy payloads.
             system_serial: Carrier system serial for this entity.
         """
-        self.entity_description = SensorEntityDescription(
-            key="propane",
-            device_class=SensorDeviceClass.VOLUME,
-            state_class=SensorStateClass.TOTAL_INCREASING,
-            native_unit_of_measurement=UnitOfVolume.GALLONS,
-            suggested_display_precision=2,
+        super().__init__(
+            entity_name="Propane Consumption Year to Date",
+            coordinator=coordinator,
+            system_serial=system_serial,
         )
-        super().__init__("Propane Yearly Gallons", updater, system_serial)
 
-    @property
-    def native_value(self) -> float | None:
-        """Return yearly propane usage converted from kBTU to gallons.
+    def _update_entity_attrs(self) -> None:
+        """Update propane usage attrs from coordinator data."""
+        if self.carrier_system.energy.raw is None:
+            self._attr_available = False
+            return
 
-        Returns:
-            float | None: Converted yearly propane volume in gallons, or None when unavailable.
-        """
-        gas = self.carrier_system.energy.current_year_measurements().gas
-        if gas is None:
-            return None
+        api_field = "gas"
+        energy_periods = self.carrier_system.energy.raw.get("energyPeriods", [])
+        value: float | None = None
+        for period in energy_periods:
+            if period.get("energyPeriodType") == "year1":
+                value = period.get(api_field)
+                break
+        if value is None:
+            self._attr_available = False
+            return
 
-        return (
-            gas / 91.69
-        )  # Convert kBTU to gallons (1 gallon LPG = 91,690 BTU, so divide by 91.69)
-
-    @property
-    def available(self) -> bool:
-        """Indicate whether propane data can be displayed.
-
-        Returns:
-            bool: True when a propane value is available.
-        """
-        return self.carrier_system.energy.current_year_measurements().gas is not None
+        # Convert kBTU to gallons (1 gallon LPG = 91,690 BTU, so divide by 91.69)
+        self._attr_native_value = value / 91.69
+        self._attr_available = True
 
 
-class EnergyMeasurementSensor(CarrierEntity, SensorEntity):
+class YearlyEnergyMeasurementSensor(CarrierSensor):
     """Yearly electrical energy consumption sensor for a Carrier metric."""
 
+    _attr_device_class = SensorDeviceClass.ENERGY
+    _attr_state_class = SensorStateClass.TOTAL_INCREASING
+    _attr_native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
+    _attr_suggested_display_precision = 0
+
     def __init__(
-        self, updater: CarrierDataUpdateCoordinator, system_serial: str, metric: str
+        self, coordinator: CarrierDataUpdateCoordinator, system_serial: str, metric: str
     ) -> None:
         """Initialize a yearly energy measurement sensor.
 
         Args:
-            updater: Coordinator that provides energy payloads.
+            coordinator: Coordinator that provides energy payloads.
             system_serial: Carrier system serial for this entity.
             metric: Name of the Carrier energy metric to expose.
         """
-        self.entity_description = SensorEntityDescription(
-            key=metric,
-            device_class=SensorDeviceClass.ENERGY,
-            state_class=SensorStateClass.TOTAL_INCREASING,
-            native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
-            suggested_display_precision=0,
-        )
-        super().__init__(f"{self.entity_description.key} Energy Yearly", updater, system_serial)
-
-    @property
-    def native_value(self) -> float | None:
-        """Return yearly energy value for the configured metric.
-
-        Returns:
-            float | None: Yearly kWh total for the metric, or None when unavailable.
-        """
-        return getattr(
-            self.carrier_system.energy.current_year_measurements(), self.entity_description.key
+        self.metric = metric
+        super().__init__(
+            entity_name=f"{metric.replace('_', ' ').title()} Energy Year to Date",
+            coordinator=coordinator,
+            system_serial=system_serial,
         )
 
-    @property
-    def available(self) -> bool:
-        """Indicate whether energy data can be displayed.
+    def _update_entity_attrs(self) -> None:
+        """Update yearly energy attrs from coordinator data."""
+        if self.carrier_system.energy.raw is None:
+            self._attr_available = False
+            return
 
-        Returns:
-            bool: True when a metric value is available.
-        """
-        return self.native_value is not None
+        api_field = ENERGY_METRIC_MAP.get(self.metric)
+        if api_field is None:
+            _LOGGER.debug("Unknown yearly energy metric requested: %s", self.metric)
+            self._attr_available = False
+            return
+
+        energy_periods = self.carrier_system.energy.raw.get("energyPeriods", [])
+        for period in energy_periods:
+            if period.get("energyPeriodType") == "year1":
+                value = period.get(api_field)
+                if value is not None:
+                    self._attr_native_value = value
+                    self._attr_available = True
+                    return
+        self._attr_available = False
 
 
-class DailyEnergyMeasurementSensor(CarrierEntity, SensorEntity):
+class DailyEnergyMeasurementSensor(CarrierSensor):
     """Sensor for yesterday's energy usage by Carrier metric."""
 
+    _attr_device_class = SensorDeviceClass.ENERGY
+    _attr_state_class = SensorStateClass.TOTAL_INCREASING
+    _attr_native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
+    _attr_suggested_display_precision = 1
+
     def __init__(
-        self, updater: CarrierDataUpdateCoordinator, system_serial: str, metric: str
+        self, coordinator: CarrierDataUpdateCoordinator, system_serial: str, metric: str
     ) -> None:
         """Initialize a daily energy sensor for a specific metric.
 
         Args:
-            updater: Coordinator that provides energy payloads.
+            coordinator: Coordinator that provides energy payloads.
             system_serial: Carrier system serial for this entity.
             metric: Internal Carrier metric name to expose.
         """
-        # Map metric names to API field names
-        self.metric_map = {
-            "cooling": "coolingKwh",
-            "hp_heat": "hPHeatKwh",
-            "fan": "fanKwh",
-            "electric_heat": "eHeatKwh",
-            "reheat": "reheatKwh",
-            "fan_gas": "fanGasKwh",
-            "loop_pump": "loopPumpKwh",
-        }
         self.metric = metric
-        self.entity_description = SensorEntityDescription(
-            key=f"{metric}_daily",
-            device_class=SensorDeviceClass.ENERGY,
-            state_class=SensorStateClass.TOTAL_INCREASING,
-            native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
-            suggested_display_precision=1,
+        super().__init__(
+            entity_name=f"{metric.replace('_', ' ').title()} Energy Yesterday",
+            coordinator=coordinator,
+            system_serial=system_serial,
         )
-        super().__init__(f"{metric} Energy Yesterday", updater, system_serial)
 
-    @property
-    def native_value(self) -> float | None:
-        """Return yesterday's energy consumption for this metric.
-
-        Returns:
-            float | None: Previous-day consumption in kWh, or None when raw
-                energy data is unavailable.
-        """
+    def _update_entity_attrs(self) -> None:
+        """Update daily energy attrs from coordinator data."""
         if self.carrier_system.energy.raw is None:
-            return None
+            self._attr_available = False
+            return
 
-        api_field = self.metric_map.get(self.metric)
+        api_field = ENERGY_METRIC_MAP.get(self.metric)
         if api_field is None:
             _LOGGER.debug("Unknown daily energy metric requested: %s", self.metric)
-            return None
+            self._attr_available = False
+            return
 
         energy_periods = self.carrier_system.energy.raw.get("energyPeriods", [])
         for period in energy_periods:
             if period.get("energyPeriodType") == "day1":
-                return period.get(api_field, 0)
-        return 0
-
-    @property
-    def available(self) -> bool:
-        """Indicate whether raw energy period data is available.
-
-        Returns:
-            bool: True when energy payload data is present.
-        """
-        return self.carrier_system.energy.raw is not None
+                value = period.get(api_field)
+                if value is not None:
+                    self._attr_native_value = value
+                    self._attr_available = True
+                    return
+        self._attr_available = False
 
 
-class MonthlyEnergyMeasurementSensor(CarrierEntity, SensorEntity):
+class MonthlyEnergyMeasurementSensor(CarrierSensor):
     """Sensor for last month's energy usage by Carrier metric."""
 
+    _attr_device_class = SensorDeviceClass.ENERGY
+    _attr_state_class = SensorStateClass.TOTAL_INCREASING
+    _attr_native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
+    _attr_suggested_display_precision = 0
+
     def __init__(
-        self, updater: CarrierDataUpdateCoordinator, system_serial: str, metric: str
+        self, coordinator: CarrierDataUpdateCoordinator, system_serial: str, metric: str
     ) -> None:
         """Initialize a monthly energy sensor for a specific metric.
 
         Args:
-            updater: Coordinator that provides energy payloads.
+            coordinator: Coordinator that provides energy payloads.
             system_serial: Carrier system serial for this entity.
             metric: Internal Carrier metric name to expose.
         """
-        # Map metric names to API field names
-        self.metric_map = {
-            "cooling": "coolingKwh",
-            "hp_heat": "hPHeatKwh",
-            "fan": "fanKwh",
-            "electric_heat": "eHeatKwh",
-            "reheat": "reheatKwh",
-            "fan_gas": "fanGasKwh",
-            "loop_pump": "loopPumpKwh",
-        }
         self.metric = metric
-        self.entity_description = SensorEntityDescription(
-            key=f"{metric}_monthly",
-            device_class=SensorDeviceClass.ENERGY,
-            state_class=SensorStateClass.TOTAL,
-            native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
-            suggested_display_precision=0,
+        super().__init__(
+            entity_name=f"{metric.replace('_', ' ').title()} Energy Last Month",
+            coordinator=coordinator,
+            system_serial=system_serial,
         )
-        super().__init__(f"{metric} Energy Last Month", updater, system_serial)
 
-    @property
-    def native_value(self) -> float | None:
-        """Return last month's energy consumption for this metric.
-
-        Returns:
-            float | None: Previous-month consumption in kWh, or None when raw
-                energy data is unavailable.
-        """
+    def _update_entity_attrs(self) -> None:
+        """Update monthly energy attrs from coordinator data."""
         if self.carrier_system.energy.raw is None:
-            return None
+            self._attr_available = False
+            return
 
-        api_field = self.metric_map.get(self.metric)
+        api_field = ENERGY_METRIC_MAP.get(self.metric)
         if api_field is None:
             _LOGGER.debug("Unknown monthly energy metric requested: %s", self.metric)
-            return None
+            self._attr_available = False
+            return
 
         energy_periods = self.carrier_system.energy.raw.get("energyPeriods", [])
         for period in energy_periods:
             if period.get("energyPeriodType") == "month1":
-                return period.get(api_field, 0)
-        return 0
-
-    @property
-    def available(self) -> bool:
-        """Indicate whether raw energy period data is available.
-
-        Returns:
-            bool: True when energy payload data is present.
-        """
-        return self.carrier_system.energy.raw is not None
+                value = period.get(api_field)
+                if value is not None:
+                    self._attr_native_value = value
+                    self._attr_available = True
+                    return
+        self._attr_available = False
 
 
-class ZoneTemperatureSensor(CarrierEntity, SensorEntity):
+class ZoneTemperatureSensor(CarrierZoneSensor):
     """Sensor entity that reports current temperature for a specific zone."""
 
     _attr_device_class = SensorDeviceClass.TEMPERATURE
     _attr_state_class = SensorStateClass.MEASUREMENT
 
     def __init__(
-        self, updater: CarrierDataUpdateCoordinator, system_serial: str, zone_api_id: str
+        self, coordinator: CarrierDataUpdateCoordinator, system_serial: str, zone_api_id: str
     ) -> None:
         """Initialize a zone temperature sensor.
 
         Args:
-            updater: Coordinator that provides system and zone data.
+            coordinator: Coordinator that provides system and zone data.
             system_serial: Carrier system serial tied to the zone.
             zone_api_id: Carrier API identifier for the represented zone.
         """
-        self.zone_api_id: str = zone_api_id
-        self.coordinator = updater
-        self.coordinator_context = system_serial
-        super().__init__(f"{self._config_zone.name} Temperature", updater, system_serial)
+        super().__init__(
+            entity_name="Temperature",
+            coordinator=coordinator,
+            system_serial=system_serial,
+            zone_api_id=zone_api_id,
+            unique_id_suffix="temperature",
+        )
 
-    @property
-    def native_unit_of_measurement(self) -> str | None:
-        """Return the active unit used for zone temperature values.
-
-        Returns:
-            str | None: Fahrenheit or Celsius unit constant.
-        """
+    def _update_entity_attrs(self) -> None:
+        """Update temperature attrs from coordinator data."""
         if self.carrier_system.status.temperature_unit == TemperatureUnits.FAHRENHEIT:
-            return UnitOfTemperature.FAHRENHEIT
-        return UnitOfTemperature.CELSIUS
-
-    @property
-    def native_value(self) -> float | None:
-        """Return current zone temperature.
-
-        Returns:
-            float | None: Temperature reported for the zone, or None when unavailable.
-        """
-        return self._status_zone.temperature
-
-    @property
-    def available(self) -> bool:
-        """Indicate whether temperature data can be shown.
-
-        Returns:
-            bool: True when a zone temperature value is present.
-        """
-        return self.native_value is not None
+            self._attr_native_unit_of_measurement = UnitOfTemperature.FAHRENHEIT
+        else:
+            self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
+        self._attr_native_value = self._status_zone.temperature
+        self._attr_available = self._attr_native_value is not None
 
 
-class OutdoorTemperatureSensor(CarrierEntity, SensorEntity):
+class OutdoorTemperatureSensor(CarrierSensor):
     """Sensor entity that reports outdoor ambient temperature."""
 
     _attr_device_class = SensorDeviceClass.TEMPERATURE
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_native_unit_of_measurement = UnitOfTemperature.FAHRENHEIT
 
-    def __init__(self, updater: CarrierDataUpdateCoordinator, system_serial: str) -> None:
+    def __init__(self, coordinator: CarrierDataUpdateCoordinator, system_serial: str) -> None:
         """Initialize an outdoor temperature sensor.
 
         Args:
-            updater: Coordinator that provides system telemetry.
+            coordinator: Coordinator that provides system telemetry.
             system_serial: Carrier system serial for this entity.
         """
-        super().__init__("Outdoor Temperature", updater, system_serial)
+        super().__init__(
+            entity_name="Outdoor Temperature",
+            coordinator=coordinator,
+            system_serial=system_serial,
+        )
 
-    @property
-    def native_value(self) -> float | None:
-        """Return current outdoor temperature.
-
-        Returns:
-            float | None: Outdoor temperature reported by Carrier, or None when unavailable.
-        """
-        return self.carrier_system.status.outdoor_temperature
-
-    @property
-    def available(self) -> bool:
-        """Indicate whether outdoor temperature data is available.
-
-        Returns:
-            bool: True when an outdoor temperature value exists.
-        """
-        return self.native_value is not None
+    def _update_entity_attrs(self) -> None:
+        """Update outdoor temperature attrs from coordinator data."""
+        if self.carrier_system.status.temperature_unit == TemperatureUnits.FAHRENHEIT:
+            self._attr_native_unit_of_measurement = UnitOfTemperature.FAHRENHEIT
+        else:
+            self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
+        self._attr_native_value = self.carrier_system.status.outdoor_temperature
+        self._attr_available = self._attr_native_value is not None
 
 
-class FilterUsedSensor(CarrierEntity, SensorEntity):
+class FilterUsedSensor(CarrierSensor):
     """Filter life sensor represented as a battery-style percentage."""
 
-    _attr_device_class = SensorDeviceClass.BATTERY
     _attr_native_unit_of_measurement = PERCENTAGE
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_icon = "mdi:air-filter"
 
-    def __init__(self, updater: CarrierDataUpdateCoordinator, system_serial: str) -> None:
+    def __init__(self, coordinator: CarrierDataUpdateCoordinator, system_serial: str) -> None:
         """Initialize a filter remaining-life sensor.
 
         Args:
-            updater: Coordinator that provides system telemetry.
+            coordinator: Coordinator that provides system telemetry.
             system_serial: Carrier system serial for this entity.
         """
-        super().__init__("Filter Remaining", updater, system_serial)
+        super().__init__(
+            entity_name="Filter Remaining",
+            coordinator=coordinator,
+            system_serial=system_serial,
+        )
 
-    @property
-    def native_value(self) -> float | None:
-        """Return remaining filter life as a percentage.
-
-        Returns:
-            float | None: Remaining percentage, or None when unavailable.
-        """
-        if self.carrier_system.status.filter_used is not None:
-            return 100 - self.carrier_system.status.filter_used
-        return None
-
-    @property
-    def available(self) -> bool:
-        """Indicate whether filter life can be displayed.
-
-        Returns:
-            bool: True when a filter value is available.
-        """
-        return self.native_value is not None
+    def _update_entity_attrs(self) -> None:
+        """Update filter life attrs from coordinator data."""
+        if self.carrier_system.status.filter_used is None:
+            self._attr_available = False
+            return
+        self._attr_native_value = 100 - self.carrier_system.status.filter_used
+        self._attr_available = True
 
 
-class HumidifierRemainingSensor(CarrierEntity, SensorEntity):
+class HumidifierRemainingSensor(CarrierSensor):
     """Humidifier level sensor represented as a remaining percentage."""
 
-    _attr_device_class = SensorDeviceClass.BATTERY
     _attr_native_unit_of_measurement = PERCENTAGE
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_icon = "mdi:air-filter"
 
-    def __init__(self, updater: CarrierDataUpdateCoordinator, system_serial: str) -> None:
+    def __init__(self, coordinator: CarrierDataUpdateCoordinator, system_serial: str) -> None:
         """Initialize a humidifier remaining-life sensor.
 
         Args:
-            updater: Coordinator that provides system telemetry.
+            coordinator: Coordinator that provides system telemetry.
             system_serial: Carrier system serial for this entity.
         """
-        super().__init__("Humidifier Remaining", updater, system_serial)
+        super().__init__(
+            entity_name="Humidifier Remaining",
+            coordinator=coordinator,
+            system_serial=system_serial,
+        )
 
-    @property
-    def native_value(self) -> float | None:
-        """Return remaining humidifier capacity as a percentage.
-
-        Returns:
-            float | None: Remaining percentage, or None when unavailable.
-        """
-        if self.carrier_system.status.humidity_level is not None:
-            return 100 - self.carrier_system.status.humidity_level
-        return None
-
-    @property
-    def available(self) -> bool:
-        """Indicate whether humidifier remaining data is available.
-
-        Returns:
-            bool: True when a humidifier value is available.
-        """
-        return self.native_value is not None
+    def _update_entity_attrs(self) -> None:
+        """Update humidifier remaining attrs from coordinator data."""
+        if self.carrier_system.status.humidity_level is None:
+            self._attr_available = False
+            return
+        self._attr_native_value = 100 - self.carrier_system.status.humidity_level
+        self._attr_available = True
 
 
-class UVLampRemainingSensor(CarrierEntity, SensorEntity):
+class UVLampRemainingSensor(CarrierSensor):
     """UV lamp life sensor represented as a remaining percentage."""
 
-    _attr_device_class = SensorDeviceClass.BATTERY
     _attr_native_unit_of_measurement = PERCENTAGE
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_icon = "mdi:lightbulb-fluorescent-tube-outline"
 
-    def __init__(self, updater: CarrierDataUpdateCoordinator, system_serial: str) -> None:
+    def __init__(self, coordinator: CarrierDataUpdateCoordinator, system_serial: str) -> None:
         """Initialize a UV lamp remaining-life sensor.
 
         Args:
-            updater: Coordinator that provides system telemetry.
+            coordinator: Coordinator that provides system telemetry.
             system_serial: Carrier system serial for this entity.
         """
-        super().__init__("UV Lamp Remaining", updater, system_serial)
+        super().__init__(
+            entity_name="UV Lamp Remaining",
+            coordinator=coordinator,
+            system_serial=system_serial,
+        )
 
-    @property
-    def native_value(self) -> float | None:
-        """Return remaining UV lamp life as a percentage.
-
-        Returns:
-            float | None: Remaining percentage, or None when unavailable.
-        """
-        if self.carrier_system.status.uv_lamp_level is not None:
-            return 100 - self.carrier_system.status.uv_lamp_level
-        return None
-
-    @property
-    def available(self) -> bool:
-        """Indicate whether UV lamp remaining data is available.
-
-        Returns:
-            bool: True when a UV lamp value is available.
-        """
-        return self.native_value is not None
+    def _update_entity_attrs(self) -> None:
+        """Update UV lamp remaining attrs from coordinator data."""
+        if self.carrier_system.status.uv_lamp_level is None:
+            self._attr_available = False
+            return
+        self._attr_native_value = 100 - self.carrier_system.status.uv_lamp_level
+        self._attr_available = True
 
 
-class TimestampSensor(CarrierEntity, SensorEntity):
+class TimestampSensor(CarrierSensor):
     """Timestamp sensor for coordinator refresh and websocket update moments."""
 
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_device_class = SensorDeviceClass.TIMESTAMP
 
-    def __init__(self, updater: CarrierDataUpdateCoordinator, system_serial: str, key: str) -> None:
-        """Initialize a timestamp sensor bound to one coordinator timestamp key.
+    def __init__(
+        self, coordinator: CarrierDataUpdateCoordinator, system_serial: str, timestamp_type: str
+    ) -> None:
+        """Initialize a timestamp sensor bound to one coordinator timestamp type.
 
         Args:
-            updater: Coordinator that owns timestamp fields.
+            coordinator: Coordinator that owns timestamp fields.
             system_serial: Carrier system serial for this entity.
-            key: Timestamp suffix such as "all_data", "websocket", or "energy".
+            timestamp_type: Timestamp suffix such as "all_data", "websocket", or "energy".
         """
-        super().__init__(f"updated {key.replace('_', ' ').capitalize()} at", updater, system_serial)
-        self.key = key
+        self.timestamp_type = timestamp_type
+        super().__init__(
+            entity_name=f"{timestamp_type.replace('_', ' ').title()} Last Updated",
+            coordinator=coordinator,
+            system_serial=system_serial,
+        )
 
-    @property
-    def native_value(self) -> datetime | None:
-        """Return the coordinator timestamp for this sensor key.
-
-        Returns:
-            datetime | None: Last recorded timestamp for the tracked update path.
-        """
-        return getattr(self.coordinator, f"timestamp_{self.key}")
-
-    @property
-    def available(self) -> bool:
-        """Indicate whether a timestamp value exists.
-
-        Returns:
-            bool: True when the underlying coordinator timestamp is populated.
-        """
-        return self.native_value is not None
+    def _update_entity_attrs(self) -> None:
+        """Update timestamp attrs from coordinator data."""
+        self._attr_native_value = getattr(self.coordinator, f"timestamp_{self.timestamp_type}")
+        self._attr_available = self._attr_native_value is not None
 
 
-class AirflowSensor(CarrierEntity, SensorEntity):
+class AirflowSensor(CarrierSensor):
     """Sensor entity that reports indoor airflow in CFM."""
 
     _attr_device_class = SensorDeviceClass.VOLUME_FLOW_RATE
@@ -684,37 +705,29 @@ class AirflowSensor(CarrierEntity, SensorEntity):
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_icon = "mdi:fan"
 
-    def __init__(self, updater: CarrierDataUpdateCoordinator, system_serial: str) -> None:
+    def __init__(self, coordinator: CarrierDataUpdateCoordinator, system_serial: str) -> None:
         """Initialize an airflow sensor.
 
         Args:
-            updater: Coordinator that provides system telemetry.
+            coordinator: Coordinator that provides system telemetry.
             system_serial: Carrier system serial for this entity.
         """
-        super().__init__("Airflow", updater, system_serial)
+        super().__init__(
+            entity_name="Airflow",
+            coordinator=coordinator,
+            system_serial=system_serial,
+        )
 
-    @property
-    def native_value(self) -> float | None:
-        """Return airflow in cubic feet per minute.
-
-        Returns:
-            float | None: Airflow value as an integer-converted CFM reading.
-        """
-        if self.carrier_system.status.airflow_cfm is not None:
-            return int(self.carrier_system.status.airflow_cfm)
-        return None
-
-    @property
-    def available(self) -> bool:
-        """Indicate whether airflow data can be displayed.
-
-        Returns:
-            bool: True when airflow telemetry is available.
-        """
-        return self.native_value is not None
+    def _update_entity_attrs(self) -> None:
+        """Update airflow attrs from coordinator data."""
+        if self.carrier_system.status.airflow_cfm is None:
+            self._attr_available = False
+            return
+        self._attr_native_value = int(self.carrier_system.status.airflow_cfm)
+        self._attr_available = True
 
 
-class StaticPressureSensor(CarrierEntity, SensorEntity):
+class StaticPressureSensor(CarrierSensor):
     """Sensor entity that reports system static pressure."""
 
     _attr_device_class = SensorDeviceClass.PRESSURE
@@ -722,161 +735,117 @@ class StaticPressureSensor(CarrierEntity, SensorEntity):
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_icon = "mdi:air-filter"
 
-    def __init__(self, updater: CarrierDataUpdateCoordinator, system_serial: str) -> None:
+    def __init__(self, coordinator: CarrierDataUpdateCoordinator, system_serial: str) -> None:
         """Initialize a static pressure sensor.
 
         Args:
-            updater: Coordinator that provides system telemetry.
+            coordinator: Coordinator that provides system telemetry.
             system_serial: Carrier system serial for this entity.
         """
-        super().__init__("Static Pressure", updater, system_serial)
+        super().__init__(
+            entity_name="Static Pressure",
+            coordinator=coordinator,
+            system_serial=system_serial,
+        )
 
-    @property
-    def native_value(self) -> float | None:
-        """Return current static pressure reading.
-
-        Returns:
-            float | None: Static pressure value when provided by Carrier.
-        """
-        if self.carrier_system.status.static_pressure is not None:
-            return self.carrier_system.status.static_pressure
-        return None
-
-    @property
-    def available(self) -> bool:
-        """Indicate whether static pressure data is available.
-
-        Returns:
-            bool: True when pressure telemetry exists.
-        """
-        return self.native_value is not None
+    def _update_entity_attrs(self) -> None:
+        """Update static pressure attrs from coordinator data."""
+        self._attr_native_value = self.carrier_system.status.static_pressure
+        self._attr_available = self._attr_native_value is not None
 
 
-class OutdoorUnitOperationalStatusSensor(CarrierEntity, SensorEntity):
+class OutdoorUnitOperationalStatusSensor(CarrierSensor):
     """Sensor for outdoor unit operational status and related raw details."""
 
     _attr_icon = "mdi:hvac"
 
-    def __init__(self, updater: CarrierDataUpdateCoordinator, system_serial: str) -> None:
+    def __init__(self, coordinator: CarrierDataUpdateCoordinator, system_serial: str) -> None:
         """Initialize an outdoor unit operational status sensor.
 
         Args:
-            updater: Coordinator that provides system telemetry.
+            coordinator: Coordinator that provides system telemetry.
             system_serial: Carrier system serial for this entity.
         """
-        super().__init__("ODU Status", updater, system_serial)
-        self.entity_description = SensorEntityDescription(
-            key="ODU Status", device_class=SensorDeviceClass.ENUM
+        super().__init__(
+            entity_name="ODU Status",
+            coordinator=coordinator,
+            system_serial=system_serial,
         )
 
-    @property
-    def native_value(self) -> Any | None:
-        """Return normalized outdoor unit operational status.
-
-        Numeric string payloads are mapped to "on" to improve Home Assistant
-        logbook phrasing.
-
-        Returns:
-            Any | None: Normalized status value or None when unavailable.
-        """
+    def _update_entity_attrs(self) -> None:
+        """Update outdoor operational status attrs from coordinator data."""
         value = self.carrier_system.status.outdoor_unit_operational_status
-        if value is not None:
-            if isinstance(value, str) and value.isdigit():
-                return "on"
-            return value
-        return None
-
-    @property
-    def available(self) -> bool:
-        """Indicate whether operational status data is available.
-
-        Returns:
-            bool: True when a status value can be shown.
-        """
-        return self.native_value is not None
-
-    @property
-    def extra_state_attributes(self) -> Mapping[str, Any] | None:
-        """Return raw outdoor unit attributes from the Carrier payload.
-
-        Returns:
-            Mapping[str, Any] | None: Raw outdoor-unit subsection from status data.
-        """
+        if value is None:
+            self._attr_available = False
+        elif isinstance(value, str) and value.isdigit():
+            self._attr_native_value = "on"
+            self._attr_available = True
+        else:
+            self._attr_native_value = value
+            self._attr_available = True
         status_raw = self.carrier_system.status.raw
         if status_raw is None:
-            return None
+            self._attr_extra_state_attributes = {}
+            return
         outdoor_unit_attributes = status_raw.get("odu")
         if isinstance(outdoor_unit_attributes, Mapping):
-            return outdoor_unit_attributes
-        return None
+            self._attr_extra_state_attributes = dict(outdoor_unit_attributes)
+        else:
+            self._attr_extra_state_attributes = {}
 
 
-class IndoorUnitOperationalStatusSensor(CarrierEntity, SensorEntity):
+class IndoorUnitOperationalStatusSensor(CarrierSensor):
     """Sensor for indoor unit operational status and related raw details."""
 
-    _attr_device_class = SensorDeviceClass.ENUM
     _attr_icon = "mdi:hvac"
 
-    def __init__(self, updater: CarrierDataUpdateCoordinator, system_serial: str) -> None:
+    def __init__(self, coordinator: CarrierDataUpdateCoordinator, system_serial: str) -> None:
         """Initialize an indoor unit operational status sensor.
 
         Args:
-            updater: Coordinator that provides system telemetry.
+            coordinator: Coordinator that provides system telemetry.
             system_serial: Carrier system serial for this entity.
         """
-        super().__init__("IDU Status", updater, system_serial)
+        super().__init__(
+            entity_name="IDU Status",
+            coordinator=coordinator,
+            system_serial=system_serial,
+        )
 
-    @property
-    def native_value(self) -> str | None:
-        """Return indoor unit operational status.
-
-        Returns:
-            str | None: Reported indoor unit status value.
-        """
-        if self.carrier_system.status.indoor_unit_operational_status is not None:
-            return self.carrier_system.status.indoor_unit_operational_status
-        return None
-
-    @property
-    def available(self) -> bool:
-        """Indicate whether operational status data is available.
-
-        Returns:
-            bool: True when a status value can be shown.
-        """
-        return self.native_value is not None
-
-    @property
-    def extra_state_attributes(self) -> Mapping[str, Any] | None:
-        """Return raw indoor unit attributes from the Carrier payload.
-
-        Returns:
-            Mapping[str, Any] | None: Raw indoor-unit subsection from status data.
-        """
+    def _update_entity_attrs(self) -> None:
+        """Update indoor operational status attrs from coordinator data."""
+        self._attr_native_value = self.carrier_system.status.indoor_unit_operational_status
+        self._attr_available = self._attr_native_value is not None
         status_raw = self.carrier_system.status.raw
         if status_raw is None:
-            return None
+            self._attr_extra_state_attributes = {}
+            return
         indoor_unit_attributes = status_raw.get("idu")
         if isinstance(indoor_unit_attributes, Mapping):
-            return indoor_unit_attributes
-        return None
+            self._attr_extra_state_attributes = dict(indoor_unit_attributes)
+        else:
+            self._attr_extra_state_attributes = {}
 
 
-class OutDoorUnitVarSensor(CarrierEntity, SensorEntity):
+class OutdoorUnitVarSensor(CarrierSensor):
     """Sensor for variable-capacity outdoor unit percentage output."""
 
     _attr_icon = "mdi:percent-box"
     _attr_native_unit_of_measurement = PERCENTAGE
     _attr_state_class = SensorStateClass.MEASUREMENT
 
-    def __init__(self, updater: CarrierDataUpdateCoordinator, system_serial: str) -> None:
+    def __init__(self, coordinator: CarrierDataUpdateCoordinator, system_serial: str) -> None:
         """Initialize a variable outdoor unit percentage sensor.
 
         Args:
-            updater: Coordinator that provides system telemetry.
+            coordinator: Coordinator that provides system telemetry.
             system_serial: Carrier system serial for this entity.
         """
-        super().__init__("ODU Var", updater, system_serial)
+        super().__init__(
+            entity_name="ODU Var",
+            coordinator=coordinator,
+            system_serial=system_serial,
+        )
 
     @property
     def native_value(self) -> float | None:
@@ -895,12 +864,3 @@ class OutDoorUnitVarSensor(CarrierEntity, SensorEntity):
             return float(value)
         except ValueError:
             return 0.0
-
-    @property
-    def available(self) -> bool:
-        """Indicate whether variable-capacity percentage is available.
-
-        Returns:
-            bool: True when outdoor operational status data exists.
-        """
-        return self.native_value is not None

--- a/custom_components/ha_carrier/sensor.py
+++ b/custom_components/ha_carrier/sensor.py
@@ -22,19 +22,9 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from . import ConfigEntryCarrier
 from .carrier_data_update_coordinator import CarrierDataUpdateCoordinator
 from .carrier_entity import CarrierEntity, CarrierZoneEntity
-from .util import TIMESTAMP_TYPES
+from .util import ENERGY_METRIC_MAP, TIMESTAMP_TYPES
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
-
-ENERGY_METRIC_MAP: dict[str, str] = {
-    "cooling": "coolingKwh",
-    "hp_heat": "hPHeatKwh",
-    "fan": "fanKwh",
-    "electric_heat": "eHeatKwh",
-    "reheat": "reheatKwh",
-    "fan_gas": "fanGasKwh",
-    "loop_pump": "loopPumpKwh",
-}
 
 
 async def async_setup_entry(

--- a/custom_components/ha_carrier/sensor.py
+++ b/custom_components/ha_carrier/sensor.py
@@ -847,20 +847,19 @@ class OutdoorUnitVarSensor(CarrierSensor):
             system_serial=system_serial,
         )
 
-    @property
-    def native_value(self) -> float | None:
-        """Return normalized variable outdoor unit percentage.
+    def _update_entity_attrs(self) -> None:
+        """Update outdoor unit variable rate.
 
         Non-numeric values such as ``'off'`` are treated as 0 % so the sensor
         stays available while the unit is idle rather than going unavailable.
 
-        Returns:
-            float | None: Percentage, or None when no data is present.
         """
         value = self.carrier_system.status.outdoor_unit_operational_status
         if value is None or not isinstance(value, str):
-            return None
+            self._attr_available = False
+            return
+        self._attr_available = True
         try:
-            return float(value)
+            self._attr_native_value = float(value)
         except ValueError:
-            return 0.0
+            self._attr_native_value = 0.0

--- a/custom_components/ha_carrier/sensor.py
+++ b/custom_components/ha_carrier/sensor.py
@@ -785,13 +785,10 @@ class OutdoorUnitOperationalStatusSensor(CarrierSensor):
             self._attr_available = True
         status_raw = self.carrier_system.status.raw
         if status_raw is None:
-            self._attr_extra_state_attributes = {}
             return
         outdoor_unit_attributes = status_raw.get("odu")
         if isinstance(outdoor_unit_attributes, Mapping):
             self._attr_extra_state_attributes = dict(outdoor_unit_attributes)
-        else:
-            self._attr_extra_state_attributes = {}
 
 
 class IndoorUnitOperationalStatusSensor(CarrierSensor):
@@ -858,8 +855,12 @@ class OutdoorUnitVarSensor(CarrierSensor):
         if value is None or not isinstance(value, str):
             self._attr_available = False
             return
-        self._attr_available = True
+        if isinstance(value, str) and value == "off":
+            self._attr_native_value = 0.0
+            self._attr_available = True
+            return
         try:
             self._attr_native_value = float(value)
+            self._attr_available = True
         except ValueError:
-            self._attr_native_value = 0.0
+            self._attr_available = False

--- a/custom_components/ha_carrier/util.py
+++ b/custom_components/ha_carrier/util.py
@@ -6,10 +6,42 @@ from collections.abc import Iterable, Mapping
 import logging
 from typing import Any, overload
 
+from carrier_api import System
 from homeassistant.core import callback
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 REDACTED = "**REDACTED**"
+
+HEAT_TYPES: list[str] = [
+    "hp_heat",
+    "electric_heat",
+    "reheat",
+    "loop_pump",
+]
+
+COOL_TYPES: list[str] = [
+    "cooling",
+]
+
+FAN_TYPES: list[str] = [
+    "fan",
+    "fan_gas",
+]
+
+
+def has_heat(carrier_system: System) -> bool:
+    """Return True if the Carrier system supports heat source selection."""
+    return any(getattr(carrier_system.energy, heat_type, False) is True for heat_type in HEAT_TYPES)
+
+
+def has_cool(carrier_system: System) -> bool:
+    """Return True if the Carrier system supports cool source selection."""
+    return any(getattr(carrier_system.energy, cool_type, False) is True for cool_type in COOL_TYPES)
+
+
+def has_fan(carrier_system: System) -> bool:
+    """Return True if the Carrier system supports fan mode selection."""
+    return any(getattr(carrier_system.energy, fan_type, False) is True for fan_type in FAN_TYPES)
 
 
 @overload

--- a/custom_components/ha_carrier/util.py
+++ b/custom_components/ha_carrier/util.py
@@ -28,6 +28,16 @@ FAN_TYPES: list[str] = [
     "fan_gas",
 ]
 
+ENERGY_METRIC_MAP: dict[str, str] = {
+    "cooling": "coolingKwh",
+    "hp_heat": "hPHeatKwh",
+    "fan": "fanKwh",
+    "electric_heat": "eHeatKwh",
+    "reheat": "reheatKwh",
+    "fan_gas": "fanGasKwh",
+    "loop_pump": "loopPumpKwh",
+}
+
 TIMESTAMP_TYPES: tuple[str, ...] = ("all_data", "websocket", "energy")
 
 

--- a/custom_components/ha_carrier/util.py
+++ b/custom_components/ha_carrier/util.py
@@ -28,6 +28,8 @@ FAN_TYPES: list[str] = [
     "fan_gas",
 ]
 
+TIMESTAMP_TYPES: tuple[str, ...] = ("all_data", "websocket", "energy")
+
 
 def has_heat(carrier_system: System) -> bool:
     """Return True if the Carrier system supports heat source selection."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ ignore = [
     "ANN401",   # any-type
     "ARG",      # flake8-unused-arguments
     "EM",       # flake8-errmsg
+    "ERA",      # eradicate
     "FBT",      # flake8-boolean-trap
     "PLC1901",  # {existing} can be simplified to {replacement} as an empty string is falsey; too many false positives
     "PLR0904",  # Too many public methods


### PR DESCRIPTION
## Summary

This PR modernizes the Carrier integration’s entity model and migration flow. It introduces a registry-aware migration path, moves entities onto stable unique IDs, and cleans up legacy entities so existing installs can upgrade without duplicate or orphaned entities.

The main goal is to make future renames and migrations safer while reducing entity churn for users who already have the integration installed.

## What Changed

### Migration and identity

- Added a dedicated migration module for config-entry upgrades
- Migrated the integration from config flow version 1 to 2
- Switched entity identity to stable, slugified unique IDs
- Added registry-driven mapping for existing entities during migration
- Added cleanup logic for legacy entities that should no longer exist after migration
- Preserved zone identity across renames by matching old registry entries to Carrier zone API IDs

### Shared entity structure

- Updated the shared `CarrierEntity` base class
- Introduced a shared `CarrierZoneEntity` base class for zone-scoped entities
- Centralized system and zone resolution logic
- Consolidated common entity availability and update handling
- Moved shared helper logic and maps into `util.py`

### Entity updates

- Updated `climate.py` to use the new shared base and safer state handling
- Updated `sensor.py`, `binary_sensor.py`, and `select.py` to align with the refactored entity model
- Improved handling for entity update errors so invalid payloads do not cascade into broken state
- Added guards around setpoint and mode writes to avoid invalid writes to the Carrier API
- Kept climate mode support constrained to the combinations the Carrier system actually supports

### Integration plumbing

- Updated `__init__.py` to manage setup, unload, websocket lifecycle, and migration handling more explicitly
- Improved websocket task cancellation and unload behavior
- Updated constants and versioning to reflect the migration work

## Why

The previous implementation relied too heavily on legacy naming and entity construction patterns. That made upgrades fragile:

- entity IDs could shift when names changed
- migrations could leave duplicate entities behind
- zone entities were harder to match reliably during upgrades
- entity state could become inconsistent after partial failures

This approach fixes the root cause by making entity identity stable and by using the entity registry as the source of truth during migration. That gives existing users a safer upgrade path and reduces long-term maintenance cost.

## Migration Notes

- Existing installs are migrated from config flow version 1 to 2
- Entity registry entries are remapped to the new unique-ID scheme
- Legacy entities are removed when they are superseded by migrated registry entries
- Zone entities are matched by Carrier zone API IDs instead of only by display names
- Users should expect existing entities to keep working after upgrade

## Behavior Changes

- Unique IDs are now stable and registry-aware
- Zone entities are resolved against Carrier API IDs
- Entity availability handling is more defensive
- Invalid or incomplete device payloads are less likely to break entity updates
- Climate writes now reject unsupported or invalid setpoint updates earlier

## Compatibility

- Compatible with existing config entries through migration
- Existing entity registry entries should be preserved where possible
- This change is intentionally backward-compatible at the config-entry level
