### PR TITLE
fix: read gas usage from gasKwh API field

### DIFF
--- a/custom_components/ha_carrier/sensor.py
+++ b/custom_components/ha_carrier/sensor.py
@@ -287,7 +287,7 @@ class GasMeasurementSensor(CarrierSensor):
             self._attr_available = False
             return
 
-        api_field = "gas"
+        api_field = "gasKwh"
         energy_periods = self.carrier_system.energy.raw.get("energyPeriods", [])
         value: float | None = None
         for period in energy_periods:
@@ -295,6 +295,11 @@ class GasMeasurementSensor(CarrierSensor):
                 value = period.get(api_field)
                 break
         if value is None:
+            _LOGGER.debug(
+                "%s missing in year1 energyPeriod for system %s; marking unavailable",
+                api_field,
+                self._system_serial,
+            )
             self._attr_available = False
             return
 
@@ -344,7 +349,7 @@ class PropaneMeasurementSensor(CarrierSensor):
             self._attr_available = False
             return
 
-        api_field = "gas"
+        api_field = "gasKwh"
         energy_periods = self.carrier_system.energy.raw.get("energyPeriods", [])
         value: float | None = None
         for period in energy_periods:
@@ -352,6 +357,11 @@ class PropaneMeasurementSensor(CarrierSensor):
                 value = period.get(api_field)
                 break
         if value is None:
+            _LOGGER.debug(
+                "%s missing in year1 energyPeriod for system %s; marking unavailable",
+                api_field,
+                self._system_serial,
+            )
             self._attr_available = False
             return
 


### PR DESCRIPTION
## Summary

`GasMeasurementSensor` and `PropaneMeasurementSensor` read `period.get("gas")`, but the Carrier API field name is `gasKwh`. As a result, both sensors are permanently `unavailable` after the v2 refactor for any installation with a natural-gas or propane fuel type. Other yearly sensors (cooling, hp_heat, fan, fan_gas, …) already use the correct camelCase API field names via `ENERGY_METRIC_MAP` and work normally — gas/propane were the only sensors that bypassed that pattern and used the wrong literal.

This PR changes the literal `"gas"` → `"gasKwh"` in both classes, restoring the v1 behavior (v1 went through `current_year_measurements().gas`, which `carrier_api`'s `EnergyMeasurement` maps from `gasKwh`).

Also adds a `_LOGGER.debug(...)` line on the `value is None` branch in both classes so silent unavailability is traceable from logs (currently the failure is invisible even at debug level).

Fixes #366

## Evidence

`carrier_api` maps the field: https://github.com/dahlb/carrier_api/blob/main/src/carrier_api/energy.py#L17 — `self.gas = safely_get_json_value(..., "gasKwh", int)`.

Live diagnostics dump from a 2-system install (post-#364), trimmed to the year1 periods:

```json
[
  {
    "energyPeriodType": "year1",
    "gasKwh": 14043,
    "coolingKwh": 52,
    "hPHeatKwh": 1413,
    "fanKwh": 91,
    "fanGasKwh": 45,
    "has_plain_gas_key": false
  },
  {
    "energyPeriodType": "year1",
    "gasKwh": 12070,
    "coolingKwh": 68,
    "hPHeatKwh": 117,
    "fanKwh": 87,
    "fanGasKwh": 27,
    "has_plain_gas_key": false
  }
]
```

`gasKwh` is populated; the bare `gas` key does not exist.

## Risk / scope

- 2 lines of behavior change; conversion math, units, and availability gating are unchanged.
- Affects only `GasMeasurementSensor` and `PropaneMeasurementSensor`.
- No migration impact — unique IDs, entity IDs, friendly names, and unit-of-measurement are untouched. Installations that have been silently broken since #364 will simply start reporting values on next coordinator update.
- `_LOGGER.debug` lines reference `self._system_serial`, which is set in the shared `CarrierEntity.__init__` (carrier_entity.py:39), so attribute access is safe.

## Testing

- Confirmed against a live install (`ha_carrier` 2.20.0, `carrier-api` 2.11.2, HA Core 2026.4.4): the diagnostics dump shows `gasKwh` values for both systems. With `api_field = "gas"` the sensors are unavailable; with `api_field = "gasKwh"` they will resolve to the populated values via the existing conversion paths.
- Python `ast.parse` clean.
- I did not add a unit test because there is currently no test scaffold around `_update_entity_attrs` in this repo. Happy to add one if you'd like a fixture-based test against a sample `energyPeriods` payload.

## Checklist

- [x] Commit message follows Semantic Commit Messages convention (`fix:` prefix).
- [x] Single logical change.
- [x] Linked to the corresponding issue.