### PR TITLE
Add 'gas' heat type and treat loop_pump as cooling

### DIFF
--- a/custom_components/ha_carrier/util.py
+++ b/custom_components/ha_carrier/util.py
@@ -13,14 +13,16 @@ _LOGGER: logging.Logger = logging.getLogger(__name__)
 REDACTED = "**REDACTED**"
 
 HEAT_TYPES: list[str] = [
-    "hp_heat",
     "electric_heat",
-    "reheat",
+    "gas",
+    "hp_heat",
     "loop_pump",
+    "reheat",
 ]
 
 COOL_TYPES: list[str] = [
     "cooling",
+    "loop_pump",
 ]
 
 FAN_TYPES: list[str] = [
@@ -30,12 +32,13 @@ FAN_TYPES: list[str] = [
 
 ENERGY_METRIC_MAP: dict[str, str] = {
     "cooling": "coolingKwh",
-    "hp_heat": "hPHeatKwh",
-    "fan": "fanKwh",
     "electric_heat": "eHeatKwh",
-    "reheat": "reheatKwh",
     "fan_gas": "fanGasKwh",
+    "fan": "fanKwh",
+    "gas": "gasKwh",
+    "hp_heat": "hPHeatKwh",
     "loop_pump": "loopPumpKwh",
+    "reheat": "reheatKwh",
 }
 
 TIMESTAMP_TYPES: tuple[str, ...] = ("all_data", "websocket", "energy")


### PR DESCRIPTION
Add 'gas' to HEAT_TYPES and include 'loop_pump' in COOL_TYPES. 

This will allow `heat` and `heat_cool` mode again for those with gas heat.

Fixes #368 