### PR TITLE
Allow Carrier username changes and reconfigure

### DIFF
--- a/custom_components/ha_carrier/__init__.py
+++ b/custom_components/ha_carrier/__init__.py
@@ -22,7 +22,7 @@ from .const import (
     WEBSOCKET_RETRY_MAX_DELAY_SECONDS,
 )
 from .exceptions import CarrierUnauthorizedError
-from .migrate import migrate_1_to_2
+from .migrate import migrate_1_to_2, migrate_2_to_3
 from .resiliency import RetryPolicy, compute_backoff_delay
 from .util import WEBSOCKET_RECOVERABLE_EXCEPTIONS, async_redact_data, is_unauthorized_error
 
@@ -216,18 +216,22 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntryCarr
     if config_entry.version == CONFIG_FLOW_VERSION:
         return True
 
-    if config_entry.version != 1:
+    if config_entry.version not in {1, 2}:
         _LOGGER.error(
             "Unable to migrate Carrier config entry from version %s", config_entry.version
         )
         return False
 
     if config_entry.version == 1:
-        return await migrate_1_to_2(hass=hass, config_entry=config_entry)
+        if not await migrate_1_to_2(hass=hass, config_entry=config_entry):
+            return False
+        if config_entry.version != 2:
+            return True
 
     if config_entry.version == 2:
-        return True
-    return False
+        return await migrate_2_to_3(hass=hass, config_entry=config_entry)
+
+    return config_entry.version == CONFIG_FLOW_VERSION
 
 
 async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntryCarrier) -> bool:

--- a/custom_components/ha_carrier/config_flow.py
+++ b/custom_components/ha_carrier/config_flow.py
@@ -205,11 +205,7 @@ class CarrierConfigFlow(ConfigFlow, domain=DOMAIN):
                         errors=errors,
                     )
                 existing_entry = await self.async_set_unique_id(identity_id)
-                if not self._allows_legacy_reauth_unique_id_transition(
-                    reconfigure_entry,
-                    identity_id,
-                ):
-                    self._abort_if_unique_id_mismatch()
+                self._abort_if_unique_id_mismatch()
                 if (
                     existing_entry is not None
                     and existing_entry.entry_id != reconfigure_entry.entry_id

--- a/custom_components/ha_carrier/config_flow.py
+++ b/custom_components/ha_carrier/config_flow.py
@@ -1,13 +1,14 @@
 """UI-driven setup, reauth, and options flow for the Carrier integration."""
 
+from __future__ import annotations
+
 import logging
 from typing import Any
 
 from aiohttp import ClientError
 from carrier_api import ApiConnectionGraphql, AuthError, BaseError
 from gql.transport.exceptions import TransportError
-from homeassistant import config_entries
-from homeassistant.config_entries import ConfigFlowResult
+from homeassistant.config_entries import ConfigEntry, ConfigFlow, ConfigFlowResult, OptionsFlow
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
@@ -27,7 +28,10 @@ from .util import is_transient_transport_error, is_unauthorized_error
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
 
-async def _async_validate_credentials(username: str, password: str) -> dict[str, str]:
+async def _async_validate_credentials(
+    username: str,
+    password: str,
+) -> tuple[dict[str, str], str | None]:
     """Validate Carrier credentials with a single API request.
 
     Args:
@@ -35,22 +39,24 @@ async def _async_validate_credentials(username: str, password: str) -> dict[str,
         password: Carrier account password.
 
     Returns:
-        dict[str, str]: Flow errors keyed by field name, or an empty dict on success.
+        tuple[dict[str, str], str | None]: Flow errors keyed by field name and
+            the Carrier identity ID when validation succeeds.
     """
     api_connection: ApiConnectionGraphql | None = None
     try:
         api_connection = ApiConnectionGraphql(username=username, password=password)
         await api_connection.load_data()
+        user_info = await api_connection.get_user_info()
     except (AuthError, BaseError, ClientError, TransportError, OSError, TimeoutError) as error:
         if is_unauthorized_error(error):
-            return {"base": ERROR_AUTH}
+            return {"base": ERROR_AUTH}, None
         if is_transient_transport_error(error):
             _LOGGER.debug(
                 "Transient transport error validating Carrier credentials", exc_info=error
             )
-            return {"base": ERROR_CANNOT_CONNECT}
+            return {"base": ERROR_CANNOT_CONNECT}, None
         _LOGGER.exception("Unexpected error validating Carrier credentials")
-        return {"base": ERROR_UNKNOWN}
+        return {"base": ERROR_UNKNOWN}, None
     finally:
         if api_connection is not None:
             try:
@@ -59,14 +65,235 @@ async def _async_validate_credentials(username: str, password: str) -> dict[str,
                 _LOGGER.exception(
                     "Failed to clean up Carrier API connection after credential validation"
                 )
+    if not isinstance(user_info, dict) or not user_info:
+        _LOGGER.error("Carrier API did not return user info for validated credentials")
+        return {"base": ERROR_UNKNOWN}, None
+    user_details = user_info.get("user")
+    if not isinstance(user_details, dict) or not user_details:
+        _LOGGER.warning("Carrier API did not return a user section for validated credentials")
+        return {"base": ERROR_UNKNOWN}, None
+    identity_id = user_details.get("identityId")
+    if not isinstance(identity_id, str) or not identity_id:
+        _LOGGER.error("Carrier API did not return an identity ID for validated credentials")
+        return {"base": ERROR_UNKNOWN}, None
 
-    return {}
+    return {}, identity_id
 
 
-class OptionFlowHandler(config_entries.OptionsFlow):
+class CarrierConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Authenticate a Carrier account and create or update a config entry."""
+
+    VERSION = CONFIG_FLOW_VERSION
+
+    data: dict[str, Any]
+    _reauth_entry_data: dict[str, Any]
+
+    def __init__(self) -> None:
+        """Initialize mutable state used while the flow runs."""
+        self.data = {}
+        self._reauth_entry_data = {}
+
+    @staticmethod
+    def _credentials_schema(
+        username: str | None = None,
+        *,
+        require_password: bool,
+    ) -> vol.Schema:
+        """Build a Carrier credential form schema.
+
+        Args:
+            username: Existing Carrier account username to show as the default.
+            require_password: Whether the password field must be submitted.
+
+        Returns:
+            vol.Schema: Credential form schema for the requested flow.
+        """
+        schema: dict[vol.Marker, type[str]] = {}
+        if username is None:
+            schema[vol.Required(CONF_USERNAME)] = str
+        else:
+            schema[vol.Required(CONF_USERNAME, default=username)] = str
+
+        password_marker: vol.Marker
+        if require_password:
+            password_marker = vol.Required(CONF_PASSWORD)
+        else:
+            password_marker = vol.Optional(CONF_PASSWORD)
+        schema[password_marker] = str
+
+        return vol.Schema(schema)
+
+    async def async_step_user(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
+        """Handle username/password input and validate Carrier credentials.
+
+        Args:
+            user_input: Submitted credentials for the Carrier account.
+
+        Returns:
+            ConfigFlowResult: Form response with errors or a created config entry.
+        """
+        errors: dict[str, str] = {}
+        data_schema = self._credentials_schema(require_password=True)
+
+        if user_input is not None:
+            username = user_input[CONF_USERNAME]
+            password = user_input[CONF_PASSWORD]
+            errors, identity_id = await _async_validate_credentials(username, password)
+
+            if not errors:
+                if identity_id is None:
+                    return self.async_show_form(
+                        step_id="user",
+                        data_schema=data_schema,
+                        errors={"base": ERROR_UNKNOWN},
+                    )
+                await self.async_set_unique_id(identity_id)
+                self._abort_if_unique_id_configured()
+                self.data.update(user_input)
+                return self.async_create_entry(title=username, data=self.data)
+
+        return self.async_show_form(step_id="user", data_schema=data_schema, errors=errors)
+
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Validate credentials and update an existing Carrier config entry.
+
+        Args:
+            user_input: Submitted credentials for the existing Carrier config entry.
+
+        Returns:
+            ConfigFlowResult: Form response with errors or a completed reconfigure result.
+        """
+        errors: dict[str, str] = {}
+        reconfigure_entry = self._get_reconfigure_entry()
+        entry_username = reconfigure_entry.data.get(CONF_USERNAME)
+        entry_username = entry_username if isinstance(entry_username, str) else ""
+
+        if user_input is not None:
+            username = user_input[CONF_USERNAME]
+            password = user_input.get(CONF_PASSWORD) or reconfigure_entry.data[CONF_PASSWORD]
+
+            errors, identity_id = await _async_validate_credentials(username, password)
+
+            if not errors:
+                if identity_id is None:
+                    errors = {"base": ERROR_UNKNOWN}
+                    return self.async_show_form(
+                        step_id="reconfigure",
+                        data_schema=self._credentials_schema(
+                            entry_username,
+                            require_password=False,
+                        ),
+                        description_placeholders={"username": entry_username},
+                        errors=errors,
+                    )
+                await self.async_set_unique_id(identity_id)
+                self._abort_if_unique_id_mismatch()
+                return self.async_update_reload_and_abort(
+                    reconfigure_entry,
+                    unique_id=identity_id,
+                    title=username,
+                    data_updates={CONF_USERNAME: username, CONF_PASSWORD: password},
+                )
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=self._credentials_schema(
+                entry_username,
+                require_password=False,
+            ),
+            description_placeholders={"username": entry_username},
+            errors=errors,
+        )
+
+    async def async_step_reauth(self, entry_data: dict[str, Any]) -> ConfigFlowResult:
+        """Start reauthentication for an existing Carrier config entry.
+
+        Args:
+            entry_data: Existing config entry data that triggered reauth.
+
+        Returns:
+            ConfigFlowResult: Response for the reauth confirmation step.
+        """
+        self._reauth_entry_data = dict(self._get_reauth_entry().data)
+        self._reauth_entry_data.update(entry_data)
+
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Validate new credentials and update the existing config entry.
+
+        Args:
+            user_input: Submitted credentials for the existing Carrier config entry.
+
+        Returns:
+            ConfigFlowResult: Form response with errors or a completed reauth result.
+        """
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            username = user_input[CONF_USERNAME]
+            password = user_input.get(CONF_PASSWORD) or self._reauth_entry_data[CONF_PASSWORD]
+            reauth_entry = self._get_reauth_entry()
+
+            errors, identity_id = await _async_validate_credentials(username, password)
+
+            if not errors:
+                if identity_id is None:
+                    errors = {"base": ERROR_UNKNOWN}
+                    return self.async_show_form(
+                        step_id="reauth_confirm",
+                        data_schema=self._credentials_schema(
+                            self._reauth_entry_data.get(CONF_USERNAME, ""),
+                            require_password=False,
+                        ),
+                        description_placeholders={
+                            "username": self._reauth_entry_data.get(CONF_USERNAME, "")
+                        },
+                        errors=errors,
+                    )
+                existing_entry = await self.async_set_unique_id(identity_id)
+                self._abort_if_unique_id_mismatch()
+                if existing_entry is not None and existing_entry.entry_id != reauth_entry.entry_id:
+                    self._abort_if_unique_id_configured()
+                return self.async_update_reload_and_abort(
+                    reauth_entry,
+                    unique_id=identity_id,
+                    title=username,
+                    data_updates={CONF_USERNAME: username, CONF_PASSWORD: password},
+                )
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=self._credentials_schema(
+                self._reauth_entry_data.get(CONF_USERNAME, ""),
+                require_password=False,
+            ),
+            description_placeholders={"username": self._reauth_entry_data.get(CONF_USERNAME, "")},
+            errors=errors,
+        )
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry: ConfigEntry) -> CarrierOptionsFlow:
+        """Return the options flow handler for this integration entry.
+
+        Args:
+            config_entry: Config entry requesting options management.
+
+        Returns:
+            CarrierOptionsFlow: Options flow implementation for this integration.
+        """
+        return CarrierOptionsFlow(config_entry)
+
+
+class CarrierOptionsFlow(OptionsFlow):
     """Handle options updates for an existing Carrier config entry."""
 
-    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+    def __init__(self, config_entry: ConfigEntry) -> None:
         """Build the options schema presented to the user.
 
         Args:
@@ -95,106 +322,3 @@ class OptionFlowHandler(config_entries.OptionsFlow):
             return self.async_create_entry(title="", data=user_input)
 
         return self.async_show_form(step_id="init", data_schema=self.schema)
-
-
-@config_entries.HANDLERS.register(DOMAIN)
-class ConfigFlowHandler(config_entries.ConfigFlow):
-    """Authenticate a Carrier account and create or update a config entry."""
-
-    VERSION = CONFIG_FLOW_VERSION
-
-    @staticmethod
-    @callback
-    def async_get_options_flow(config_entry: config_entries.ConfigEntry) -> OptionFlowHandler:
-        """Return the options flow handler for this integration entry.
-
-        Args:
-            config_entry: Config entry requesting options management.
-
-        Returns:
-            OptionFlowHandler: Options flow implementation for this integration.
-        """
-        return OptionFlowHandler(config_entry)
-
-    def __init__(self) -> None:
-        """Initialize mutable state used while the flow runs."""
-        self.data: dict[str, Any] = {}
-        self._reauth_username: str | None = None
-
-    async def async_step_user(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
-        """Handle username/password input and validate Carrier credentials.
-
-        Args:
-            user_input: Submitted credentials for the Carrier account.
-
-        Returns:
-            ConfigFlowResult: Form response with errors or a created config entry.
-        """
-        errors: dict[str, str] = {}
-        data_schema = vol.Schema(
-            {
-                vol.Required(CONF_USERNAME): str,
-                vol.Required(CONF_PASSWORD): str,
-            }
-        )
-
-        if user_input is not None:
-            username = user_input[CONF_USERNAME]
-            password = user_input[CONF_PASSWORD]
-            await self.async_set_unique_id(username)
-            self._abort_if_unique_id_configured()
-            errors = await _async_validate_credentials(username, password)
-
-            if not errors:
-                self.data.update(user_input)
-                return self.async_create_entry(title=username, data=self.data)
-
-        return self.async_show_form(step_id="user", data_schema=data_schema, errors=errors)
-
-    async def async_step_reauth(self, entry_data: dict[str, Any]) -> ConfigFlowResult:
-        """Start reauthentication for an existing Carrier config entry.
-
-        Args:
-            entry_data: Existing config entry data that triggered reauth.
-
-        Returns:
-            ConfigFlowResult: Response for the reauth confirmation step.
-        """
-        username = entry_data.get(CONF_USERNAME) or self._get_reauth_entry().data.get(CONF_USERNAME)
-        if not isinstance(username, str) or not username:
-            return self.async_abort(reason="reauth_missing_username")
-
-        self._reauth_username = username
-        return await self.async_step_reauth_confirm()
-
-    async def async_step_reauth_confirm(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Validate new credentials and update the existing config entry.
-
-        Args:
-            user_input: Submitted password for the existing Carrier username.
-
-        Returns:
-            ConfigFlowResult: Form response with errors or a completed reauth result.
-        """
-        if not isinstance(self._reauth_username, str) or not self._reauth_username:
-            return self.async_abort(reason="reauth_missing_username")
-        errors: dict[str, str] = {}
-
-        if user_input is not None:
-            password = user_input[CONF_PASSWORD]
-            errors = await _async_validate_credentials(self._reauth_username, password)
-
-            if not errors:
-                return self.async_update_reload_and_abort(
-                    self._get_reauth_entry(),
-                    data_updates={CONF_PASSWORD: password},
-                )
-
-        return self.async_show_form(
-            step_id="reauth_confirm",
-            data_schema=vol.Schema({vol.Required(CONF_PASSWORD): str}),
-            description_placeholders={"username": self._reauth_username},
-            errors=errors,
-        )

--- a/custom_components/ha_carrier/config_flow.py
+++ b/custom_components/ha_carrier/config_flow.py
@@ -23,7 +23,7 @@ from .const import (
     ERROR_CANNOT_CONNECT,
     ERROR_UNKNOWN,
 )
-from .util import is_transient_transport_error, is_unauthorized_error
+from .util import async_get_carrier_identity_id, is_transient_transport_error, is_unauthorized_error
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -45,8 +45,7 @@ async def _async_validate_credentials(
     api_connection: ApiConnectionGraphql | None = None
     try:
         api_connection = ApiConnectionGraphql(username=username, password=password)
-        await api_connection.load_data()
-        user_info = await api_connection.get_user_info()
+        identity_id = await async_get_carrier_identity_id(api_connection)
     except (AuthError, BaseError, ClientError, TransportError, OSError, TimeoutError) as error:
         if is_unauthorized_error(error):
             return {"base": ERROR_AUTH}, None
@@ -65,15 +64,7 @@ async def _async_validate_credentials(
                 _LOGGER.exception(
                     "Failed to clean up Carrier API connection after credential validation"
                 )
-    if not isinstance(user_info, dict) or not user_info:
-        _LOGGER.error("Carrier API did not return user info for validated credentials")
-        return {"base": ERROR_UNKNOWN}, None
-    user_details = user_info.get("user")
-    if not isinstance(user_details, dict) or not user_details:
-        _LOGGER.warning("Carrier API did not return a user section for validated credentials")
-        return {"base": ERROR_UNKNOWN}, None
-    identity_id = user_details.get("identityId")
-    if not isinstance(identity_id, str) or not identity_id:
+    if identity_id is None:
         _LOGGER.error("Carrier API did not return an identity ID for validated credentials")
         return {"base": ERROR_UNKNOWN}, None
 
@@ -92,6 +83,31 @@ class CarrierConfigFlow(ConfigFlow, domain=DOMAIN):
         """Initialize mutable state used while the flow runs."""
         self.data = {}
         self._reauth_entry_data = {}
+
+    @staticmethod
+    def _allows_legacy_reauth_unique_id_transition(
+        reauth_entry: ConfigEntry,
+        identity_id: str,
+    ) -> bool:
+        """Return whether reauth may replace a legacy username unique ID.
+
+        Args:
+            reauth_entry: Existing config entry being reauthenticated.
+            identity_id: Carrier identity ID returned for the new credentials.
+
+        Returns:
+            bool: True when the entry still uses its saved username as the
+                unique ID and should be allowed to migrate to ``identityId``
+                during reauth.
+        """
+        entry_unique_id = reauth_entry.unique_id
+        entry_username = reauth_entry.data.get(CONF_USERNAME)
+        return (
+            isinstance(entry_unique_id, str)
+            and isinstance(entry_username, str)
+            and entry_unique_id == entry_username
+            and entry_unique_id != identity_id
+        )
 
     @staticmethod
     def _credentials_schema(
@@ -188,8 +204,17 @@ class CarrierConfigFlow(ConfigFlow, domain=DOMAIN):
                         description_placeholders={"username": entry_username},
                         errors=errors,
                     )
-                await self.async_set_unique_id(identity_id)
-                self._abort_if_unique_id_mismatch()
+                existing_entry = await self.async_set_unique_id(identity_id)
+                if not self._allows_legacy_reauth_unique_id_transition(
+                    reconfigure_entry,
+                    identity_id,
+                ):
+                    self._abort_if_unique_id_mismatch()
+                if (
+                    existing_entry is not None
+                    and existing_entry.entry_id != reconfigure_entry.entry_id
+                ):
+                    self._abort_if_unique_id_configured()
                 return self.async_update_reload_and_abort(
                     reconfigure_entry,
                     unique_id=identity_id,
@@ -256,7 +281,11 @@ class CarrierConfigFlow(ConfigFlow, domain=DOMAIN):
                         errors=errors,
                     )
                 existing_entry = await self.async_set_unique_id(identity_id)
-                self._abort_if_unique_id_mismatch()
+                if not self._allows_legacy_reauth_unique_id_transition(
+                    reauth_entry,
+                    identity_id,
+                ):
+                    self._abort_if_unique_id_mismatch()
                 if existing_entry is not None and existing_entry.entry_id != reauth_entry.entry_id:
                     self._abort_if_unique_id_configured()
                 return self.async_update_reload_and_abort(

--- a/custom_components/ha_carrier/const.py
+++ b/custom_components/ha_carrier/const.py
@@ -8,7 +8,7 @@ VERSION: str = "2.21.1"
 DOMAIN: str = "ha_carrier"
 
 # Integration Setting Constants
-CONFIG_FLOW_VERSION: int = 2
+CONFIG_FLOW_VERSION: int = 3
 PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
     Platform.SENSOR,

--- a/custom_components/ha_carrier/migrate.py
+++ b/custom_components/ha_carrier/migrate.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Mapping
 import logging
+from typing import Any
 
 from aiohttp import ClientError
 from carrier_api import ApiConnectionGraphql, AuthError, BaseError, System
@@ -610,10 +611,126 @@ async def migrate_1_to_2(hass: HomeAssistant, config_entry: ConfigEntry) -> bool
             [entry.entity_id for entry in unmatched_entries],
         )
     if systems_loaded:
-        hass.config_entries.async_update_entry(config_entry, version=CONFIG_FLOW_VERSION)
-        _LOGGER.info("Carrier config entry migration to version %s complete", CONFIG_FLOW_VERSION)
+        hass.config_entries.async_update_entry(config_entry, version=2)
+        _LOGGER.info("Carrier config entry migration to version 2 complete")
     else:
         _LOGGER.warning(
             "Carrier migration deferred due to data-load failure; will retry on next startup"
         )
+    return True
+
+
+async def migrate_2_to_3(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+    """Migrate a Carrier config entry from version 2 to version 3.
+
+    Version 3 replaces username-based config-entry unique IDs with Carrier's
+    stable account ``identityId``. Entries that are already not keyed by their
+    saved username are treated as already migrated and only receive the version
+    bump.
+
+    Args:
+        hass: Home Assistant instance.
+        config_entry: Version 2 Carrier config entry being migrated.
+
+    Returns:
+        bool: True when the migration completed or was safely deferred.
+    """
+    username: str = config_entry.data[CONF_USERNAME]
+    if config_entry.unique_id is not None and config_entry.unique_id != username:
+        hass.config_entries.async_update_entry(
+            config_entry,
+            version=CONFIG_FLOW_VERSION,
+        )
+        _LOGGER.info("Carrier config entry migration to version %s complete", CONFIG_FLOW_VERSION)
+        return True
+
+    api_connection: ApiConnectionGraphql | None = None
+    try:
+        api_connection = ApiConnectionGraphql(
+            username=username,
+            password=config_entry.data[CONF_PASSWORD],
+        )
+        await api_connection.load_data()
+        user_info: dict[str, Any] = await api_connection.get_user_info()
+    except (
+        AuthError,
+        BaseError,
+        ClientError,
+        TimeoutError,
+        OSError,
+        TransportError,
+    ) as error:
+        _LOGGER.warning(
+            "Unable to load Carrier user identity for config entry migration; "
+            "will retry on next startup. %s: %s",
+            type(error).__name__,
+            error,
+        )
+        return True
+    finally:
+        if api_connection is not None:
+            try:
+                await api_connection.cleanup()
+            except (
+                AuthError,
+                BaseError,
+                ClientError,
+                TimeoutError,
+                OSError,
+                TransportError,
+            ):
+                _LOGGER.exception(
+                    "Failed to clean up Carrier API connection after config entry migration."
+                )
+    if not isinstance(user_info, dict) or not user_info:
+        _LOGGER.warning(
+            "Carrier API did not return user info for config entry migration; "
+            "will retry on next startup"
+        )
+        return True
+    user_details = user_info.get("user")
+    if not isinstance(user_details, dict) or not user_details:
+        _LOGGER.warning(
+            "Carrier API did not return a user section for config entry migration; "
+            "will retry on next startup"
+        )
+        return True
+    identity_id = user_details.get("identityId")
+    if not isinstance(identity_id, str) or not identity_id:
+        _LOGGER.warning(
+            "Carrier API did not return an identity ID for config entry migration; "
+            "will retry on next startup"
+        )
+        return True
+
+    conflicting_entry = next(
+        (
+            entry
+            for entry in hass.config_entries.async_entries(config_entry.domain)
+            if entry.entry_id != config_entry.entry_id and entry.unique_id == identity_id
+        ),
+        None,
+    )
+    if conflicting_entry is not None:
+        _LOGGER.error(
+            "Unable to migrate Carrier config entry %s to identity ID %s because entry %s "
+            "already uses that unique ID",
+            config_entry.entry_id,
+            identity_id,
+            conflicting_entry.entry_id,
+        )
+        return False
+
+    old_unique_id = config_entry.unique_id
+    hass.config_entries.async_update_entry(
+        config_entry,
+        unique_id=identity_id,
+        version=CONFIG_FLOW_VERSION,
+    )
+    _LOGGER.info(
+        "Migrated Carrier config entry %s unique ID from %s to Carrier identity ID %s",
+        config_entry.entry_id,
+        old_unique_id,
+        identity_id,
+    )
     return True

--- a/custom_components/ha_carrier/migrate.py
+++ b/custom_components/ha_carrier/migrate.py
@@ -696,24 +696,20 @@ async def migrate_2_to_3(hass: HomeAssistant, config_entry: ConfigEntry) -> bool
     )
     if conflicting_entry is not None:
         _LOGGER.error(
-            "Unable to migrate Carrier config entry %s to identity ID %s because entry %s "
-            "already uses that unique ID",
+            "Unable to migrate Carrier config entry %s to Carrier identity ID because entry %s "
+            "already uses that identity",
             config_entry.entry_id,
-            identity_id,
             conflicting_entry.entry_id,
         )
         return False
 
-    old_unique_id = config_entry.unique_id
     hass.config_entries.async_update_entry(
         config_entry,
         unique_id=identity_id,
         version=3,
     )
     _LOGGER.info(
-        "Migrated Carrier config entry %s unique ID from %s to Carrier identity ID %s",
+        "Migrated Carrier config entry %s from legacy unique ID to Carrier identity ID",
         config_entry.entry_id,
-        old_unique_id,
-        identity_id,
     )
     return True

--- a/custom_components/ha_carrier/migrate.py
+++ b/custom_components/ha_carrier/migrate.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Mapping
 import logging
-from typing import Any
 
 from aiohttp import ClientError
 from carrier_api import ApiConnectionGraphql, AuthError, BaseError, System
@@ -16,8 +15,7 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_registry import EntityRegistry, RegistryEntry
 from homeassistant.util import slugify
 
-from .const import CONFIG_FLOW_VERSION
-from .util import ENERGY_METRIC_MAP, TIMESTAMP_TYPES, has_heat
+from .util import ENERGY_METRIC_MAP, TIMESTAMP_TYPES, async_get_carrier_identity_id, has_heat
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -639,9 +637,9 @@ async def migrate_2_to_3(hass: HomeAssistant, config_entry: ConfigEntry) -> bool
     if config_entry.unique_id is not None and config_entry.unique_id != username:
         hass.config_entries.async_update_entry(
             config_entry,
-            version=CONFIG_FLOW_VERSION,
+            version=3,
         )
-        _LOGGER.info("Carrier config entry migration to version %s complete", CONFIG_FLOW_VERSION)
+        _LOGGER.info("Carrier config entry migration to version %s complete", 3)
         return True
 
     api_connection: ApiConnectionGraphql | None = None
@@ -650,8 +648,7 @@ async def migrate_2_to_3(hass: HomeAssistant, config_entry: ConfigEntry) -> bool
             username=username,
             password=config_entry.data[CONF_PASSWORD],
         )
-        await api_connection.load_data()
-        user_info: dict[str, Any] = await api_connection.get_user_info()
+        identity_id = await async_get_carrier_identity_id(api_connection)
     except (
         AuthError,
         BaseError,
@@ -682,21 +679,7 @@ async def migrate_2_to_3(hass: HomeAssistant, config_entry: ConfigEntry) -> bool
                 _LOGGER.exception(
                     "Failed to clean up Carrier API connection after config entry migration."
                 )
-    if not isinstance(user_info, dict) or not user_info:
-        _LOGGER.warning(
-            "Carrier API did not return user info for config entry migration; "
-            "will retry on next startup"
-        )
-        return True
-    user_details = user_info.get("user")
-    if not isinstance(user_details, dict) or not user_details:
-        _LOGGER.warning(
-            "Carrier API did not return a user section for config entry migration; "
-            "will retry on next startup"
-        )
-        return True
-    identity_id = user_details.get("identityId")
-    if not isinstance(identity_id, str) or not identity_id:
+    if identity_id is None:
         _LOGGER.warning(
             "Carrier API did not return an identity ID for config entry migration; "
             "will retry on next startup"
@@ -725,7 +708,7 @@ async def migrate_2_to_3(hass: HomeAssistant, config_entry: ConfigEntry) -> bool
     hass.config_entries.async_update_entry(
         config_entry,
         unique_id=identity_id,
-        version=CONFIG_FLOW_VERSION,
+        version=3,
     )
     _LOGGER.info(
         "Migrated Carrier config entry %s unique ID from %s to Carrier identity ID %s",

--- a/custom_components/ha_carrier/migrate.py
+++ b/custom_components/ha_carrier/migrate.py
@@ -639,7 +639,7 @@ async def migrate_2_to_3(hass: HomeAssistant, config_entry: ConfigEntry) -> bool
             config_entry,
             version=3,
         )
-        _LOGGER.info("Carrier config entry migration to version %s complete", 3)
+        _LOGGER.info("Carrier config entry migration to version 3 complete")
         return True
 
     api_connection: ApiConnectionGraphql | None = None

--- a/custom_components/ha_carrier/translations/en.json
+++ b/custom_components/ha_carrier/translations/en.json
@@ -11,8 +11,17 @@
       },
       "reauth_confirm": {
         "title": "Carrier Auth",
-        "description": "Re-enter your Carrier password for {username}.",
+        "description": "Update the Carrier username or password for {username}. Leave the password blank to keep the saved password.",
         "data": {
+          "username": "Username",
+          "password": "Password"
+        }
+      },
+      "reconfigure": {
+        "title": "Carrier Auth",
+        "description": "Update the saved Carrier credentials for {username}. Leave the password blank to keep the saved password.",
+        "data": {
+          "username": "Username",
           "password": "Password"
         }
       }
@@ -24,7 +33,7 @@
     },
     "abort": {
       "reauth_successful": "Re-authentication was successful.",
-      "reauth_missing_username": "Unable to start re-authentication because the existing Carrier username is missing.",
+      "reconfigure_successful": "Reconfiguration was successful.",
       "already_configured": "This Carrier account is already configured."
     }
   },

--- a/custom_components/ha_carrier/util.py
+++ b/custom_components/ha_carrier/util.py
@@ -14,7 +14,7 @@ import logging
 from typing import Any, overload
 
 from aiohttp import ClientError
-from carrier_api import AuthError, BaseError, System
+from carrier_api import ApiConnectionGraphql, AuthError, BaseError, System
 from gql.transport.exceptions import TransportError, TransportProtocolError, TransportServerError
 from homeassistant.core import callback
 
@@ -85,6 +85,32 @@ WEBSOCKET_RECOVERABLE_EXCEPTIONS: tuple[type[BaseException], ...] = (
     TransportServerError,
 )
 """Exceptions the websocket reconnect loop should treat as recoverable."""
+
+
+async def async_get_carrier_identity_id(api_connection: ApiConnectionGraphql) -> str | None:
+    """Return the Carrier identity ID for an authenticated API connection.
+
+    Args:
+        api_connection: Connected Carrier API client to query.
+
+    Returns:
+        str | None: Non-empty Carrier ``identityId`` when the response shape is
+            valid, otherwise ``None``.
+    """
+    await api_connection.load_data()
+    user_info = await api_connection.get_user_info()
+    if not isinstance(user_info, dict) or not user_info:
+        return None
+
+    user_details = user_info.get("user")
+    if not isinstance(user_details, dict) or not user_details:
+        return None
+
+    identity_id = user_details.get("identityId")
+    if not isinstance(identity_id, str) or not identity_id:
+        return None
+
+    return identity_id
 
 
 def has_heat(carrier_system: System) -> bool:

--- a/custom_components/ha_carrier/util.py
+++ b/custom_components/ha_carrier/util.py
@@ -90,12 +90,26 @@ WEBSOCKET_RECOVERABLE_EXCEPTIONS: tuple[type[BaseException], ...] = (
 async def async_get_carrier_identity_id(api_connection: ApiConnectionGraphql) -> str | None:
     """Return the Carrier identity ID for an authenticated API connection.
 
+    ``async_get_carrier_identity_id`` calls ``api_connection.load_data`` and
+    ``api_connection.get_user_info`` on the supplied client. ``None`` is only
+    returned when the response payload is missing or has an unexpected shape;
+    transport and authentication failures raised by those calls propagate to
+    the caller.
+
     Args:
         api_connection: Connected Carrier API client to query.
 
     Returns:
         str | None: Non-empty Carrier ``identityId`` when the response shape is
             valid, otherwise ``None``.
+
+    Raises:
+        AuthError: Credentials were rejected by the Carrier API.
+        BaseError: The Carrier API client reported a non-auth error.
+        ClientError: The underlying HTTP client failed.
+        TransportError: The GraphQL transport layer reported an error.
+        OSError: A socket-level error occurred while talking to Carrier.
+        TimeoutError: The request timed out before a response arrived.
     """
     await api_connection.load_data()
     user_info = await api_connection.get_user_info()


### PR DESCRIPTION
## Summary
Allows Carrier account credentials to be updated without creating a duplicate integration entry by moving config-entry identity from the mutable username to Carrier's stable `identityId`.

## What Changed
- Uses Carrier `identityId` as the config-entry unique ID for new setup flows.
- Adds a version 2 to 3 config-entry migration that replaces legacy username unique IDs with `identityId` when Carrier user data can be loaded.
- Adds reconfigure support so the saved username and password can be updated from the config entry.
- Expands reauth to accept username and password updates while preserving the saved password when left blank.
- Centralizes Carrier identity lookup in `util.py` and updates translation strings for the new reauth/reconfigure flows.

## Why
Carrier accounts can change usernames, so using the username as the durable Home Assistant unique ID can block legitimate credential updates or make the same account look like a new account. Carrier's `identityId` is a better account key and lets existing entries survive username changes.

## Validation
- `./scripts/lint`
- `./.venv/bin/python -m compileall custom_components/ha_carrier`
