### PR TITLE
test: Add pytest coverage and CI workflow

### DIFF
--- a/.github/workflows/post_coverage_to_pr.yml
+++ b/.github/workflows/post_coverage_to_pr.yml
@@ -1,0 +1,25 @@
+name: Post coverage Comment to PR
+
+on:
+  workflow_run:
+    workflows: ['pytest and coverage']
+    types:
+      - completed
+
+jobs:
+  test:
+    name: Post coverage Comment to PR
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    permissions:
+      pull-requests: write
+      contents: write
+      actions: read
+    steps:
+      # DO NOT run actions/checkout here, for security reasons
+      # For details, refer to https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+      - name: Post coverage Comment to PR
+        uses: py-cov-action/python-coverage-comment-action@v3
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_PR_RUN_ID: ${{ github.event.workflow_run.id }}

--- a/.github/workflows/pytest_coverage.yml
+++ b/.github/workflows/pytest_coverage.yml
@@ -10,7 +10,12 @@ on:
 jobs:
   tests:
     name: pytest and coverage report
-    if: ${{ !(github.event_name == 'pull_request' && ( contains(github.event.pull_request.labels.*.name, 'dependencies') || github.event.pull_request.user.type == 'Bot' )) }}
+    if: >-
+      ${{ !(github.event_name == 'pull_request' && (
+        contains(github.event.pull_request.labels.*.name, 'dependencies') ||
+        (github.event.pull_request.user.type == 'Bot' &&
+         !contains(github.event.pull_request.labels.*.name, 'carrier-api-auto-update'))
+      )) }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/pytest_coverage.yml
+++ b/.github/workflows/pytest_coverage.yml
@@ -1,0 +1,53 @@
+name: pytest and coverage
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  tests:
+    name: pytest and coverage report
+    if: ${{ !(github.event_name == 'pull_request' && ( contains(github.event.pull_request.labels.*.name, 'dependencies') || github.event.pull_request.user.type == 'Bot' )) }}
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+
+      - name: Setup Python 3.14 (with caching)
+        uses: actions/setup-python@v6
+        with:
+          python-version: 3.14
+          cache: 'pip'
+          cache-dependency-path: |
+            pyproject.toml
+
+      - name: Install pytest Requirements
+        run: |
+          python -m pip install --upgrade pip
+          pip install --group pytest -e .
+
+      - name: Run pytest with coverage (pytest-cov)
+        run: pytest
+
+      - name: 'Generate coverage Comment (and possibly Post to PR)'
+        id: coverage_comment
+        uses: py-cov-action/python-coverage-comment-action@v3
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 70
+
+      - name: Store PR Comment to be Posted
+        if: steps.coverage_comment.outputs.COMMENT_FILE_WRITTEN == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: python-coverage-comment-action
+          path: python-coverage-comment-action.txt
+          retention-days: 1

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ __pycache__
 .vscode
 .idea
 coverage.xml
+htmlcov/
 uv.lock
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,12 +21,27 @@ namespaces = true
 version = { attr = "custom_components.ha_carrier.const.VERSION" }
 
 [dependency-groups]
-dev = [
+ha = [
     "carrier-api==2.11.3",
     "homeassistant",
+]
+lint = [
+    { include-group = "ha" },
     "mypy",
     "prek",
     "ruff",
+]
+pytest = [
+    { include-group = "ha" },
+    "pytest",
+    "pytest-asyncio",
+    "pytest-cov",
+    "pytest-homeassistant-custom-component",
+    "pytest-timeout",
+]
+dev = [
+    { include-group = "lint" },
+    { include-group = "pytest" },
 ]
 
 [tool.mypy]
@@ -41,6 +56,10 @@ warn_unused_configs = true
 
 [[tool.mypy.overrides]]
 module = ["carrier_api.*"]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = ["pytest_homeassistant_custom_component.*"]
 ignore_missing_imports = true
 
 [tool.ruff]
@@ -128,5 +147,38 @@ max-complexity = 25
 [tool.ruff.lint.pydocstyle]
 convention = "google"
 
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = [
+    "B017",    # Don't assert blind Exception
+    "C90",     # mccabe, complexity
+    "E501",    # line too long
+    "S101",    # Use of assert detected
+    "S105",    # Possible hardcoded password
+    "S108",    # hardcoded-temp-file
+    "SLF001",  # Private member accessed
+]
+
 [tool.codespell]
 ignore-words-list = "hass"
+
+[tool.pytest.ini_options]
+addopts = """
+  --quiet
+  --timeout=20
+  --durations=10
+  -o console_output_style=progress
+  --cov=custom_components.ha_carrier
+  --cov-report=term-missing
+  --cov-report=html
+"""
+testpaths = ["tests"]
+asyncio_mode = "auto"
+
+[tool.coverage.run]
+branch = true
+source = ["custom_components.ha_carrier"]
+relative_files = true
+parallel = false
+
+[tool.coverage.report]
+show_missing = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,6 +168,7 @@ addopts = """
   --durations=10
   -o console_output_style=progress
   --cov=custom_components.ha_carrier
+  --cov-fail-under=70
   --cov-report=term-missing
   --cov-report=html
 """

--- a/scripts/test
+++ b/scripts/test
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+cd "$(dirname "$0")/.."
+
+if [ ! -x .venv/bin/python ]; then
+	echo "Missing .venv Python. Run scripts/setup first." >&2
+	exit 1
+fi
+
+.venv/bin/python -m pytest "$@"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test package for the Carrier Home Assistant integration."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -267,7 +267,22 @@ def build_carrier_system(
     has_heat_pump: bool = True,
     disconnected: bool = False,
 ) -> System:
-    """Build a realistic Carrier system from ``carrier_api`` model classes."""
+    """Build a realistic Carrier system from ``carrier_api`` model classes.
+
+    Args:
+        serial: System serial number. Defaults to ``"ABC123"``.
+        name: Human-readable system name. Defaults to ``"Home"``.
+        zone_name: Display name for the single zone. Defaults to ``"Living Room"``.
+        zone_id: Identifier assigned to the zone. Defaults to ``"1"``.
+        has_heat_pump: When ``True``, configure the outdoor unit as a variable-capacity
+            heat pump; otherwise configure it as an air conditioner. Defaults to ``True``.
+        disconnected: When ``True``, mark the status payload as disconnected so tests can
+            exercise offline behavior. Defaults to ``False``.
+
+    Returns:
+        System: A ``carrier_api`` ``System`` instance populated with realistic profile,
+        config, status, and energy payloads.
+    """
     profile = Profile(
         {
             "name": name,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,7 @@ from custom_components.ha_carrier.const import DOMAIN
 
 USERNAME = "user@example.com"
 PASSWORD = "password"
+IDENTITY_ID = "identity-123"
 
 
 class FakeCarrierWebsocket:
@@ -52,6 +53,7 @@ class FakeCarrierApiConnection:
         *,
         username: str = USERNAME,
         password: str = PASSWORD,
+        identity_id: str = IDENTITY_ID,
         systems: list[System] | None = None,
     ) -> None:
         """Initialize the fake API connection.
@@ -59,10 +61,12 @@ class FakeCarrierApiConnection:
         Args:
             username: Carrier account username.
             password: Carrier account password.
+            identity_id: Carrier account identity ID returned by user info.
             systems: Systems returned by ``load_data``.
         """
         self.username = username
         self.password = password
+        self.identity_id = identity_id
         self.systems = systems or [build_carrier_system()]
         self.api_websocket = FakeCarrierWebsocket()
         self.calls: list[tuple[str, dict[str, Any]]] = []
@@ -79,6 +83,11 @@ class FakeCarrierApiConnection:
     async def cleanup(self) -> None:
         """Record credential-validation cleanup."""
         self.cleanup_calls += 1
+
+    async def get_user_info(self) -> dict[str, Any]:
+        """Return the fake Carrier account identity payload."""
+        self.calls.append(("get_user_info", {}))
+        return {"user": {"identityId": self.identity_id}}
 
     async def get_energy(self, system_serial: str) -> dict[str, Any]:
         """Return current energy payload for a Carrier system.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,455 @@
+"""Shared pytest fixtures for Carrier Home Assistant workflow tests."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator, Callable, Iterator
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+from carrier_api import Config, Energy, Profile, Status, System
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+import custom_components
+from custom_components.ha_carrier.const import DOMAIN
+
+USERNAME = "user@example.com"
+PASSWORD = "password"
+
+
+class FakeCarrierWebsocket:
+    """Small websocket fake that records callbacks and blocks until cancelled."""
+
+    def __init__(self) -> None:
+        """Initialize websocket callback storage."""
+        self.callbacks: list[Callable[[str], Any]] = []
+
+    def callback_add(self, callback: Callable[[str], Any]) -> None:
+        """Store a websocket callback registered by the coordinator.
+
+        Args:
+            callback: Callback provided by the integration.
+        """
+        self.callbacks.append(callback)
+
+    async def listener(self) -> None:
+        """Block until Home Assistant cancels the websocket task."""
+        await asyncio.Event().wait()
+
+
+class FakeCarrierApiConnection:
+    """Carrier API fake used as the only external boundary in tests."""
+
+    def __init__(
+        self,
+        *,
+        username: str = USERNAME,
+        password: str = PASSWORD,
+        systems: list[System] | None = None,
+    ) -> None:
+        """Initialize the fake API connection.
+
+        Args:
+            username: Carrier account username.
+            password: Carrier account password.
+            systems: Systems returned by ``load_data``.
+        """
+        self.username = username
+        self.password = password
+        self.systems = systems or [build_carrier_system()]
+        self.api_websocket = FakeCarrierWebsocket()
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+        self.load_data_error: BaseException | None = None
+        self.cleanup_calls = 0
+
+    async def load_data(self) -> list[System]:
+        """Return configured systems or raise a configured load error."""
+        self.calls.append(("load_data", {}))
+        if self.load_data_error is not None:
+            raise self.load_data_error
+        return self.systems
+
+    async def cleanup(self) -> None:
+        """Record credential-validation cleanup."""
+        self.cleanup_calls += 1
+
+    async def get_energy(self, system_serial: str) -> dict[str, Any]:
+        """Return current energy payload for a Carrier system.
+
+        Args:
+            system_serial: Carrier system serial requested by the coordinator.
+
+        Returns:
+            dict[str, Any]: Carrier GraphQL-shaped energy response.
+        """
+        self.calls.append(("get_energy", {"system_serial": system_serial}))
+        system = self._system(system_serial)
+        return {"infinityEnergy": deepcopy(system.energy.raw)}
+
+    async def set_config_mode(self, *, system_serial: str, mode: Any) -> None:
+        """Record a system mode write."""
+        self.calls.append(("set_config_mode", {"system_serial": system_serial, "mode": mode}))
+
+    async def set_config_heat_humidity(self, *, system_serial: str, humidity_target: int) -> None:
+        """Record a target humidity write."""
+        self.calls.append(
+            (
+                "set_config_heat_humidity",
+                {"system_serial": system_serial, "humidity_target": humidity_target},
+            )
+        )
+
+    async def resume_schedule(self, *, system_serial: str, zone_id: str) -> None:
+        """Record a resume-schedule write."""
+        self.calls.append(("resume_schedule", {"system_serial": system_serial, "zone_id": zone_id}))
+
+    async def set_config_hold(
+        self,
+        *,
+        system_serial: str,
+        zone_id: str,
+        activity_type: Any,
+        hold_until: Any,
+    ) -> None:
+        """Record an activity hold write."""
+        self.calls.append(
+            (
+                "set_config_hold",
+                {
+                    "system_serial": system_serial,
+                    "zone_id": zone_id,
+                    "activity_type": activity_type,
+                    "hold_until": hold_until,
+                },
+            )
+        )
+
+    async def update_fan(
+        self,
+        *,
+        system_serial: str,
+        zone_id: str,
+        activity_type: Any,
+        fan_mode: Any,
+    ) -> None:
+        """Record an activity fan-mode write."""
+        self.calls.append(
+            (
+                "update_fan",
+                {
+                    "system_serial": system_serial,
+                    "zone_id": zone_id,
+                    "activity_type": activity_type,
+                    "fan_mode": fan_mode,
+                },
+            )
+        )
+
+    async def set_config_manual_activity(
+        self,
+        *,
+        system_serial: str,
+        zone_id: str,
+        heat_set_point: str,
+        cool_set_point: str,
+        fan_mode: Any,
+    ) -> None:
+        """Record a manual-activity write."""
+        self.calls.append(
+            (
+                "set_config_manual_activity",
+                {
+                    "system_serial": system_serial,
+                    "zone_id": zone_id,
+                    "heat_set_point": heat_set_point,
+                    "cool_set_point": cool_set_point,
+                    "fan_mode": fan_mode,
+                },
+            )
+        )
+
+    async def set_heat_source(self, *, system_serial: str, heat_source: Any) -> None:
+        """Record a heat-source write."""
+        self.calls.append(
+            ("set_heat_source", {"system_serial": system_serial, "heat_source": heat_source})
+        )
+
+    def _system(self, system_serial: str) -> System:
+        """Return one fake Carrier system by serial.
+
+        Args:
+            system_serial: Serial to locate.
+
+        Returns:
+            System: Matching Carrier system.
+
+        Raises:
+            ValueError: Raised when the serial is not part of the fake account.
+        """
+        for system in self.systems:
+            if system.profile.serial == system_serial:
+                return system
+        raise ValueError(f"Unknown fake Carrier system: {system_serial}")
+
+
+def _schedule_day() -> dict[str, Any]:
+    """Return one enabled Carrier schedule day."""
+    return {
+        "period": [
+            {"enabled": "on", "time": "00:00", "activity": "home"},
+            {"enabled": "on", "time": "23:59", "activity": "sleep"},
+        ]
+    }
+
+
+def _zone_raw(*, zone_id: str, name: str, occupancy_enabled: bool = True) -> dict[str, Any]:
+    """Return Carrier config-zone JSON for tests."""
+    return {
+        "id": zone_id,
+        "name": name,
+        "enabled": "on",
+        "holdActivity": "home",
+        "hold": "off",
+        "otmr": "",
+        "occEnabled": "on" if occupancy_enabled else "off",
+        "activities": [
+            {"type": "home", "id": "home", "fan": "off", "htsp": 68, "clsp": 74},
+            {"type": "away", "id": "away", "fan": "off", "htsp": 62, "clsp": 82},
+            {"type": "sleep", "id": "sleep", "fan": "off", "htsp": 66, "clsp": 76},
+            {"type": "manual", "id": "manual", "fan": "low", "htsp": 69, "clsp": 75},
+        ],
+        "program": {"day": [_schedule_day() for _ in range(7)]},
+    }
+
+
+def _status_zone_raw(*, zone_id: str, name: str, occupancy: bool = True) -> dict[str, Any]:
+    """Return Carrier status-zone JSON for tests."""
+    return {
+        "id": zone_id,
+        "name": name,
+        "enabled": "on",
+        "currentActivity": "home",
+        "rt": 70.0,
+        "rh": 45,
+        "occupancy": "occupied" if occupancy else "unoccupied",
+        "fan": "off",
+        "hold": "off",
+        "otmr": "",
+        "htsp": 68,
+        "clsp": 74,
+        "zoneconditioning": "idle",
+        "damperposition": 50,
+    }
+
+
+def build_carrier_system(
+    *,
+    serial: str = "ABC123",
+    name: str = "Home",
+    zone_name: str = "Living Room",
+    zone_id: str = "1",
+    has_heat_pump: bool = True,
+    disconnected: bool = False,
+) -> System:
+    """Build a realistic Carrier system from ``carrier_api`` model classes."""
+    profile = Profile(
+        {
+            "name": name,
+            "serial": serial,
+            "model": "Infinity",
+            "brand": "Carrier",
+            "firmware": "1.0",
+            "indoorModel": "FE4",
+            "indoorSerial": "IDU123",
+            "idutype": "furnace",
+            "idusource": "gas",
+            "outdoorModel": "25VNA",
+            "outdoorSerial": "ODU123",
+            "odutype": "varcaphp" if has_heat_pump else "ac",
+        }
+    )
+    config = Config(
+        {
+            "cfgem": "F",
+            "mode": "auto",
+            "heatsource": "system",
+            "etag": "etag",
+            "fueltype": "gas",
+            "gasunit": "therm",
+            "cfguv": "on",
+            "cfghumid": "on",
+            "humidityHome": {"rhtg": 7},
+            "vacmaxt": 82,
+            "vacmint": 60,
+            "vacfan": "off",
+            "zones": [_zone_raw(zone_id=zone_id, name=zone_name)],
+        }
+    )
+    status = Status(
+        {
+            "oat": 40,
+            "mode": "gasheat",
+            "cfgem": "F",
+            "filtrlvl": 20,
+            "humlvl": 30,
+            "humid": "on",
+            "uvlvl": 10,
+            "isDisconnected": disconnected,
+            "idu": {"cfm": 1200, "blwrpm": 500, "statpress": 0.2, "opstat": "idle"},
+            "odu": {"opstat": "idle"},
+            "utcTime": "2026-05-05T12:00:00+00:00",
+            "zones": [_status_zone_raw(zone_id=zone_id, name=zone_name)],
+        }
+    )
+    energy = Energy(
+        {
+            "energyConfig": {
+                "seer": 18,
+                "hspf": 10,
+                "cooling": {"display": True, "enabled": True},
+                "hpheat": {"display": True, "enabled": True},
+                "fan": {"display": True, "enabled": True},
+                "eheat": {"display": False, "enabled": False},
+                "reheat": {"display": False, "enabled": False},
+                "fangas": {"display": False, "enabled": False},
+                "gas": {"display": True, "enabled": True},
+                "looppump": {"display": False, "enabled": False},
+            },
+            "energyPeriods": [
+                {
+                    "energyPeriodType": "year1",
+                    "coolingKwh": 100,
+                    "hPHeatKwh": 80,
+                    "fanKwh": 12,
+                    "gasKwh": 300,
+                },
+                {
+                    "energyPeriodType": "day1",
+                    "coolingKwh": 1,
+                    "hPHeatKwh": 2,
+                    "fanKwh": 3,
+                    "gasKwh": 4,
+                },
+                {
+                    "energyPeriodType": "month1",
+                    "coolingKwh": 10,
+                    "hPHeatKwh": 20,
+                    "fanKwh": 30,
+                    "gasKwh": 40,
+                },
+            ],
+        }
+    )
+    return System(profile=profile, status=status, config=config, energy=energy)
+
+
+def entity_id_for_unique_id(hass: HomeAssistant, domain: str, unique_id: str) -> str:
+    """Return the entity ID registered for an integration unique ID.
+
+    Args:
+        hass: Home Assistant instance.
+        domain: Entity platform domain.
+        unique_id: Integration unique ID to resolve.
+
+    Returns:
+        str: Registered entity ID.
+
+    Raises:
+        AssertionError: Raised when the unique ID was not registered.
+    """
+    entity_id = er.async_get(hass).async_get_entity_id(domain, DOMAIN, unique_id)
+    assert entity_id is not None
+    return entity_id
+
+
+@pytest.fixture(autouse=True)
+def auto_enable_custom_integrations(
+    enable_custom_integrations: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Enable loading custom integrations in Home Assistant pytest."""
+    components_path = str(Path(__file__).parents[1] / "custom_components")
+    monkeypatch.setattr(custom_components, "__path__", [components_path])
+
+
+@pytest.fixture
+def carrier_api() -> FakeCarrierApiConnection:
+    """Return the default fake Carrier API connection."""
+    return FakeCarrierApiConnection()
+
+
+@pytest.fixture
+def patch_carrier_api(
+    carrier_api: FakeCarrierApiConnection,
+) -> Iterator[FakeCarrierApiConnection]:
+    """Patch Carrier API constructors across integration modules.
+
+    Args:
+        carrier_api: Fake connection to return from every constructor.
+
+    Yields:
+        FakeCarrierApiConnection: The patched fake API object.
+    """
+
+    def build_connection(*, username: str, password: str) -> FakeCarrierApiConnection:
+        """Return the test fake while recording supplied credentials."""
+        carrier_api.username = username
+        carrier_api.password = password
+        return carrier_api
+
+    with (
+        patch("custom_components.ha_carrier.ApiConnectionGraphql", build_connection),
+        patch("custom_components.ha_carrier.config_flow.ApiConnectionGraphql", build_connection),
+        patch("custom_components.ha_carrier.migrate.ApiConnectionGraphql", build_connection),
+    ):
+        yield carrier_api
+
+
+@pytest.fixture
+async def setup_integration(
+    hass: HomeAssistant,
+    patch_carrier_api: FakeCarrierApiConnection,
+) -> AsyncIterator[Callable[..., Any]]:
+    """Return a helper that sets up a Carrier config entry through Home Assistant."""
+    entries: list[ConfigEntry] = []
+
+    async def _setup(
+        *,
+        options: dict[str, Any] | None = None,
+        version: int = 2,
+    ) -> ConfigEntry:
+        """Set up one Carrier config entry.
+
+        Args:
+            options: Config entry options.
+            version: Config entry version.
+
+        Returns:
+            ConfigEntry: Config entry loaded by Home Assistant.
+        """
+        config_entry = MockConfigEntry(
+            domain=DOMAIN,
+            title=USERNAME,
+            unique_id=USERNAME,
+            data={CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD},
+            options=options or {},
+            version=version,
+        )
+        config_entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+        entries.append(config_entry)
+        return config_entry
+
+    yield _setup
+
+    for entry in entries:
+        await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -1,0 +1,37 @@
+"""Workflow tests for Carrier binary sensor platform registration."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from homeassistant.core import HomeAssistant
+import pytest
+
+from .conftest import entity_id_for_unique_id
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("domain", "unique_id", "expected_state"),
+    [
+        ("binary_sensor", "abc123_online", "on"),
+        ("binary_sensor", "abc123_humidifier_running", "on"),
+        ("binary_sensor", "abc123_zone_1_occupancy", "on"),
+    ],
+)
+async def test_binary_sensor_platform_registers_expected_entities(
+    hass: HomeAssistant,
+    setup_integration: Callable[..., Any],
+    domain: str,
+    unique_id: str,
+    expected_state: str,
+) -> None:
+    """Register system and zone binary sensors with representative states."""
+    await setup_integration()
+
+    entity_id = entity_id_for_unique_id(hass, domain, unique_id)
+    state = hass.states.get(entity_id)
+
+    assert state is not None
+    assert state.state == expected_state

--- a/tests/test_carrier_data_update_coordinator.py
+++ b/tests/test_carrier_data_update_coordinator.py
@@ -6,7 +6,9 @@ from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import patch
 
+from gql.transport.exceptions import TransportServerError
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.update_coordinator import UpdateFailed
 import pytest
 
 from custom_components.ha_carrier.carrier_data_update_coordinator import (
@@ -169,3 +171,156 @@ async def test_recoverable_write_communication_error_reconciles_and_raises_ha_er
         await coordinator.async_perform_api_call("set mode", request)
 
     assert reconciled is True
+
+
+@pytest.mark.asyncio
+async def test_update_data_translates_unauthorized_refresh_to_reauth() -> None:
+    """Escalate a fresh unauthorized refresh failure to HA reauthentication."""
+    coordinator = CarrierDataUpdateCoordinator.__new__(CarrierDataUpdateCoordinator)
+    coordinator.data_flush = True
+
+    async def fake_full_refresh() -> None:
+        """Raise an escalated Carrier auth failure."""
+        raise CarrierUnauthorizedError("unauthorized")
+
+    with (
+        patch.object(coordinator, "_async_full_refresh", fake_full_refresh),
+        pytest.raises(Exception) as exc_info,
+    ):
+        await coordinator._async_update_data()
+
+    assert exc_info.type.__name__ == "ConfigEntryAuthFailed"
+    assert coordinator.data_flush is True
+
+
+@pytest.mark.asyncio
+async def test_update_data_keeps_plain_unauthorized_server_error_retryable() -> None:
+    """Keep non-escalated unauthorized transport errors on HA retry cadence."""
+    coordinator = CarrierDataUpdateCoordinator.__new__(CarrierDataUpdateCoordinator)
+    coordinator.data_flush = True
+    coordinator.update_interval = None
+
+    async def fake_full_refresh() -> None:
+        """Raise a 401 transport response before resiliency escalation."""
+        raise TransportServerError("unauthorized", code=401)
+
+    with (
+        patch.object(coordinator, "_async_full_refresh", fake_full_refresh),
+        pytest.raises(UpdateFailed, match="temporarily rejected"),
+    ):
+        await coordinator._async_update_data()
+
+    assert coordinator.data_flush is True
+    assert coordinator.update_interval is not None
+
+
+@pytest.mark.asyncio
+async def test_full_refresh_merges_new_changed_and_stale_systems(
+    carrier_api: FakeCarrierApiConnection,
+) -> None:
+    """Merge fresh full-refresh systems in place and remove stale systems."""
+    coordinator = CarrierDataUpdateCoordinator.__new__(CarrierDataUpdateCoordinator)
+    existing = build_carrier_system(serial="ABC123", name="Old")
+    stale = build_carrier_system(serial="STALE", name="Stale")
+    fresh_existing = build_carrier_system(serial="ABC123", name="Updated")
+    fresh_new = build_carrier_system(serial="NEW123", name="New")
+    carrier_api.systems = [fresh_existing, fresh_new]
+    coordinator.systems = [existing, stale]
+    coordinator.api_connection = carrier_api
+    coordinator.resiliency = ResiliencyState(
+        unauthorized_threshold=UNAUTHORIZED_RETRY_THRESHOLD,
+        transient_threshold=TRANSIENT_FAILURE_THRESHOLD,
+    )
+    coordinator._websocket_initialized = False
+
+    await coordinator._async_full_refresh()
+
+    assert coordinator.systems[0] is existing
+    assert coordinator.systems[0].profile.name == "Updated"
+    assert [system.profile.serial for system in coordinator.systems] == ["ABC123", "NEW123"]
+    assert len(carrier_api.api_websocket.callbacks) == 2
+    assert coordinator.data_flush is False
+
+
+@pytest.mark.asyncio
+async def test_energy_refresh_records_one_unauthorized_per_cycle(
+    carrier_api: FakeCarrierApiConnection,
+) -> None:
+    """Preserve prior energy and escalate only one auth count per energy cycle."""
+    coordinator = CarrierDataUpdateCoordinator.__new__(CarrierDataUpdateCoordinator)
+    systems = [
+        build_carrier_system(serial="ABC123"),
+        build_carrier_system(serial="DEF456"),
+    ]
+    coordinator.systems = systems
+    coordinator.api_connection = carrier_api
+    coordinator.resiliency = ResiliencyState(unauthorized_threshold=2, transient_threshold=3)
+    coordinator.update_interval = None
+
+    async def fake_retry(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        """Raise unauthorized for every per-system energy request."""
+        raise TransportServerError("unauthorized", code=401)
+
+    with patch(
+        "custom_components.ha_carrier.carrier_data_update_coordinator.async_call_with_retry",
+        fake_retry,
+    ):
+        await coordinator._async_energy_refresh()
+
+    assert coordinator.resiliency.consecutive_unauthorized == 1
+    assert coordinator.update_interval is not None
+    assert systems[0].energy.raw is not None
+
+
+@pytest.mark.asyncio
+async def test_energy_refresh_escalates_after_threshold(
+    carrier_api: FakeCarrierApiConnection,
+) -> None:
+    """Raise CarrierUnauthorizedError once the energy-cycle auth threshold is crossed."""
+    coordinator = CarrierDataUpdateCoordinator.__new__(CarrierDataUpdateCoordinator)
+    coordinator.systems = [build_carrier_system()]
+    coordinator.api_connection = carrier_api
+    coordinator.resiliency = ResiliencyState(unauthorized_threshold=1, transient_threshold=3)
+    coordinator.update_interval = None
+
+    async def fake_retry(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        """Raise unauthorized for the energy request."""
+        raise TransportServerError("unauthorized", code=401)
+
+    with (
+        patch(
+            "custom_components.ha_carrier.carrier_data_update_coordinator.async_call_with_retry",
+            fake_retry,
+        ),
+        pytest.raises(CarrierUnauthorizedError),
+    ):
+        await coordinator._async_energy_refresh()
+
+
+@pytest.mark.asyncio
+async def test_updated_callback_records_timestamp_and_notifies_listeners() -> None:
+    """Handle websocket callbacks by timestamping and notifying listeners."""
+    coordinator = CarrierDataUpdateCoordinator.__new__(CarrierDataUpdateCoordinator)
+    coordinator.systems = [build_carrier_system()]
+    notified = False
+
+    def fake_update_listeners() -> None:
+        """Record listener notification."""
+        nonlocal notified
+        notified = True
+
+    with patch.object(coordinator, "async_update_listeners", fake_update_listeners):
+        await coordinator.updated_callback("{}")
+
+    assert coordinator.timestamp_websocket is not None
+    assert notified is True
+
+
+def test_system_returns_matching_system_or_none() -> None:
+    """Look up tracked systems by Carrier serial."""
+    coordinator = CarrierDataUpdateCoordinator.__new__(CarrierDataUpdateCoordinator)
+    system = build_carrier_system(serial="ABC123")
+    coordinator.systems = [system]
+
+    assert coordinator.system("ABC123") is system
+    assert coordinator.system("missing") is None

--- a/tests/test_carrier_data_update_coordinator.py
+++ b/tests/test_carrier_data_update_coordinator.py
@@ -1,0 +1,165 @@
+"""Pytest workflow tests for the Carrier data update coordinator."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import patch
+
+from homeassistant.exceptions import HomeAssistantError
+import pytest
+
+from custom_components.ha_carrier.carrier_data_update_coordinator import (
+    CarrierDataUpdateCoordinator,
+)
+from custom_components.ha_carrier.const import (
+    TRANSIENT_FAILURE_THRESHOLD,
+    UNAUTHORIZED_RETRY_THRESHOLD,
+)
+from custom_components.ha_carrier.exceptions import CarrierUnauthorizedError
+from custom_components.ha_carrier.resiliency import ResiliencyState
+
+from .conftest import FakeCarrierApiConnection, build_carrier_system
+
+
+@pytest.mark.asyncio
+async def test_initial_full_refresh_preserves_systems_list_identity(
+    carrier_api: FakeCarrierApiConnection,
+) -> None:
+    """Mutate the systems list in place when initially loading systems."""
+    coordinator = CarrierDataUpdateCoordinator.__new__(CarrierDataUpdateCoordinator)
+    systems: list[Any] = []
+    fresh_systems = [build_carrier_system()]
+    carrier_api.systems = fresh_systems
+    coordinator.systems = systems
+    coordinator.api_connection = carrier_api
+    coordinator.resiliency = ResiliencyState(
+        unauthorized_threshold=UNAUTHORIZED_RETRY_THRESHOLD,
+        transient_threshold=TRANSIENT_FAILURE_THRESHOLD,
+    )
+    coordinator._websocket_initialized = True
+
+    await coordinator._async_full_refresh()
+
+    assert coordinator.systems is systems
+    assert coordinator.systems == fresh_systems
+
+
+@pytest.mark.asyncio
+async def test_energy_refresh_uses_cycle_scoped_success_reset(
+    carrier_api: FakeCarrierApiConnection,
+) -> None:
+    """Preserve resiliency state across per-system energy successes."""
+    coordinator = CarrierDataUpdateCoordinator.__new__(CarrierDataUpdateCoordinator)
+    coordinator.systems = [build_carrier_system()]
+    coordinator.api_connection = carrier_api
+    coordinator.resiliency = cast("Any", SimpleNamespace(reset_unauthorized=lambda: None))
+    calls: list[dict[str, Any]] = []
+
+    async def fake_retry(*_args: Any, **kwargs: Any) -> dict[str, Any]:
+        """Record retry options and return an energy payload."""
+        calls.append(kwargs)
+        return {"infinityEnergy": carrier_api.systems[0].energy.raw}
+
+    with patch(
+        "custom_components.ha_carrier.carrier_data_update_coordinator.async_call_with_retry",
+        fake_retry,
+    ):
+        await coordinator._async_energy_refresh()
+
+    assert calls[0]["reset_state_on_success"] is False
+
+
+@pytest.mark.asyncio
+async def test_update_attempts_refresh_when_previous_auth_count_is_escalated() -> None:
+    """Require a fresh failed read before converting an old auth streak to reauth."""
+    coordinator = CarrierDataUpdateCoordinator.__new__(CarrierDataUpdateCoordinator)
+    coordinator.resiliency = ResiliencyState(
+        unauthorized_threshold=UNAUTHORIZED_RETRY_THRESHOLD,
+        transient_threshold=TRANSIENT_FAILURE_THRESHOLD,
+        consecutive_unauthorized=UNAUTHORIZED_RETRY_THRESHOLD,
+    )
+    coordinator.data_flush = True
+    coordinator.systems = [build_carrier_system()]
+    full_refresh_called = False
+
+    async def fake_full_refresh(self: CarrierDataUpdateCoordinator) -> None:
+        """Simulate a successful full refresh that clears resiliency state."""
+        nonlocal full_refresh_called
+        full_refresh_called = True
+        self.resiliency.reset()
+        self.data_flush = False
+
+    with (
+        patch.object(CarrierDataUpdateCoordinator, "_async_full_refresh", fake_full_refresh),
+        patch.object(
+            CarrierDataUpdateCoordinator,
+            "mapped_system_data",
+            staticmethod(lambda _system: {"serial": "ABC123"}),
+        ),
+    ):
+        data = await coordinator._async_update_data()
+
+    assert full_refresh_called is True
+    assert coordinator.resiliency.consecutive_unauthorized == 0
+    assert data == [{"serial": "ABC123"}]
+
+
+@pytest.mark.asyncio
+async def test_successful_write_reconciliation_clears_escalated_auth_state() -> None:
+    """Let a successful reconciliation refresh clear a write auth streak."""
+    coordinator = CarrierDataUpdateCoordinator.__new__(CarrierDataUpdateCoordinator)
+    coordinator.resiliency = ResiliencyState(
+        unauthorized_threshold=UNAUTHORIZED_RETRY_THRESHOLD,
+        transient_threshold=TRANSIENT_FAILURE_THRESHOLD,
+        consecutive_unauthorized=UNAUTHORIZED_RETRY_THRESHOLD,
+    )
+    coordinator.data_flush = False
+    coordinator.update_interval = None
+
+    async def fake_refresh(self: CarrierDataUpdateCoordinator) -> None:
+        """Simulate a successful reconciliation refresh."""
+        self.resiliency.reset()
+
+    with patch.object(CarrierDataUpdateCoordinator, "async_refresh", fake_refresh):
+        await coordinator._async_reconcile_failed_write(
+            "test write",
+            CarrierUnauthorizedError("unauthorized"),
+        )
+
+    assert coordinator.resiliency.consecutive_unauthorized == 0
+
+
+@pytest.mark.asyncio
+async def test_recoverable_write_communication_error_reconciles_and_raises_ha_error() -> None:
+    """Surface exhausted write communication failures as Home Assistant errors."""
+    coordinator = CarrierDataUpdateCoordinator.__new__(CarrierDataUpdateCoordinator)
+    coordinator.resiliency = ResiliencyState(unauthorized_threshold=3, transient_threshold=3)
+    reconciled = False
+
+    async def request() -> None:
+        """Raise a retryable write timeout."""
+        raise TimeoutError("timeout")
+
+    async def fake_reconcile(
+        self: CarrierDataUpdateCoordinator,
+        operation_name: str,
+        error: BaseException | None = None,
+    ) -> None:
+        """Record reconciliation after the failed write."""
+        nonlocal reconciled
+        assert operation_name == "set mode"
+        assert isinstance(error, TimeoutError)
+        reconciled = True
+
+    with (
+        patch.object(
+            CarrierDataUpdateCoordinator,
+            "_async_reconcile_failed_write",
+            fake_reconcile,
+        ),
+        pytest.raises(HomeAssistantError, match="timed out"),
+    ):
+        await coordinator.async_perform_api_call("set mode", request)
+
+    assert reconciled is True

--- a/tests/test_carrier_data_update_coordinator.py
+++ b/tests/test_carrier_data_update_coordinator.py
@@ -53,7 +53,13 @@ async def test_energy_refresh_uses_cycle_scoped_success_reset(
     coordinator = CarrierDataUpdateCoordinator.__new__(CarrierDataUpdateCoordinator)
     coordinator.systems = [build_carrier_system()]
     coordinator.api_connection = carrier_api
-    coordinator.resiliency = cast("Any", SimpleNamespace(reset_unauthorized=lambda: None))
+    coordinator.resiliency = cast(
+        "Any",
+        SimpleNamespace(
+            reset_unauthorized=lambda: None,
+            reset_transient=lambda: None,
+        ),
+    )
     calls: list[dict[str, Any]] = []
 
     async def fake_retry(*_args: Any, **kwargs: Any) -> dict[str, Any]:

--- a/tests/test_carrier_data_update_coordinator.py
+++ b/tests/test_carrier_data_update_coordinator.py
@@ -7,7 +7,7 @@ from typing import Any, cast
 from unittest.mock import patch
 
 from gql.transport.exceptions import TransportServerError
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
 from homeassistant.helpers.update_coordinator import UpdateFailed
 import pytest
 
@@ -185,7 +185,7 @@ async def test_update_data_translates_unauthorized_refresh_to_reauth() -> None:
 
     with (
         patch.object(coordinator, "_async_full_refresh", fake_full_refresh),
-        pytest.raises(Exception) as exc_info,
+        pytest.raises(ConfigEntryAuthFailed) as exc_info,
     ):
         await coordinator._async_update_data()
 

--- a/tests/test_carrier_entity.py
+++ b/tests/test_carrier_entity.py
@@ -1,0 +1,32 @@
+"""Workflow tests for shared Carrier entity behavior."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+
+from custom_components.ha_carrier.carrier_entity import CarrierZoneEntity
+
+from .conftest import build_carrier_system
+
+
+def test_zone_entity_resolves_zone_name_from_coordinator_systems() -> None:
+    """Resolve a zone display name from coordinator system data."""
+    system = build_carrier_system(zone_name="Bedroom", zone_id="2")
+    coordinator = cast(
+        "Any",
+        SimpleNamespace(system=lambda system_serial: system if system_serial == "ABC123" else None),
+    )
+
+    assert CarrierZoneEntity.resolve_zone_name(coordinator, "ABC123", "2") == "Bedroom"
+
+
+def test_zone_entity_raises_when_zone_cannot_be_resolved() -> None:
+    """Raise a clear error when a zone ID is missing from coordinator data."""
+    system = build_carrier_system(zone_name="Bedroom", zone_id="2")
+    coordinator = cast("Any", SimpleNamespace(system=lambda system_serial: system))
+
+    with pytest.raises(ValueError, match="Config Zone not found: missing"):
+        CarrierZoneEntity.resolve_zone_name(coordinator, "ABC123", "missing")

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -5,13 +5,16 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any
 
+from carrier_api import FanModes
 from homeassistant.components.climate import (
     ATTR_HVAC_MODE,
     ATTR_PRESET_MODE,
     DOMAIN as CLIMATE_DOMAIN,
+    SERVICE_SET_FAN_MODE,
     HVACMode,
 )
 from homeassistant.components.climate.const import (
+    ATTR_FAN_MODE,
     ATTR_HUMIDITY,
     ATTR_TARGET_TEMP_HIGH,
     ATTR_TARGET_TEMP_LOW,
@@ -22,11 +25,12 @@ from homeassistant.components.climate.const import (
 )
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 import pytest
 
 from custom_components.ha_carrier.const import FAN_AUTO
 
-from .conftest import FakeCarrierApiConnection, entity_id_for_unique_id
+from .conftest import FakeCarrierApiConnection, build_carrier_system, entity_id_for_unique_id
 
 
 @pytest.mark.asyncio
@@ -95,3 +99,107 @@ async def test_climate_services_call_carrier_api_and_update_local_state(
     assert [call[0] for call in carrier_api.calls if call[0] != "load_data"][
         -len(expected_calls) :
     ] == (expected_calls)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("carrier_mode", "conditioning", "fan", "expected_mode", "expected_action"),
+    [
+        ("cool", "cooling", FanModes.OFF, HVACMode.COOL, "cooling"),
+        ("heat", "gasheat", FanModes.OFF, HVACMode.HEAT, "heating"),
+        ("off", "idle", FanModes.OFF, HVACMode.OFF, "off"),
+        ("fanonly", "idle", FanModes.LOW, HVACMode.FAN_ONLY, "fan"),
+        ("unknown", "vent", FanModes.LOW, "unknown", "fan"),
+    ],
+)
+async def test_climate_platform_maps_hvac_modes_and_actions(
+    hass: HomeAssistant,
+    carrier_api: FakeCarrierApiConnection,
+    setup_integration: Callable[..., Any],
+    carrier_mode: str,
+    conditioning: str,
+    fan: FanModes,
+    expected_mode: str,
+    expected_action: str,
+) -> None:
+    """Map Carrier system modes and zone conditioning to HA climate attributes."""
+    carrier_api.systems = [build_carrier_system()]
+    system = carrier_api.systems[0]
+    system.config.mode = carrier_mode
+    system.status.zones[0].conditioning = conditioning
+    system.status.zones[0].fan = fan
+
+    await setup_integration()
+
+    entity_id = entity_id_for_unique_id(hass, CLIMATE_DOMAIN, "abc123_zone_1_thermostat")
+    state = hass.states.get(entity_id)
+
+    assert state is not None
+    assert state.state == expected_mode
+    assert state.attributes["hvac_action"] == expected_action
+
+
+@pytest.mark.asyncio
+async def test_climate_resume_preset_refreshes_remote_state(
+    hass: HomeAssistant,
+    carrier_api: FakeCarrierApiConnection,
+    setup_integration: Callable[..., Any],
+) -> None:
+    """Resume scheduled programming through the Carrier API and request refresh."""
+    await setup_integration()
+    entity_id = entity_id_for_unique_id(hass, CLIMATE_DOMAIN, "abc123_zone_1_thermostat")
+
+    await hass.services.async_call(
+        CLIMATE_DOMAIN,
+        SERVICE_SET_PRESET_MODE,
+        {ATTR_ENTITY_ID: entity_id, ATTR_PRESET_MODE: "resume"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert "resume_schedule" in [call[0] for call in carrier_api.calls]
+
+
+@pytest.mark.asyncio
+async def test_climate_fan_mode_service_updates_current_activity(
+    hass: HomeAssistant,
+    carrier_api: FakeCarrierApiConnection,
+    setup_integration: Callable[..., Any],
+) -> None:
+    """Write the active activity fan mode through the Carrier API."""
+    await setup_integration()
+    entity_id = entity_id_for_unique_id(hass, CLIMATE_DOMAIN, "abc123_zone_1_thermostat")
+
+    await hass.services.async_call(
+        CLIMATE_DOMAIN,
+        SERVICE_SET_FAN_MODE,
+        {ATTR_ENTITY_ID: entity_id, ATTR_FAN_MODE: "high"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert carrier_api.calls[-1][0] == "update_fan"
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.attributes["fan_mode"] == "high"
+
+
+@pytest.mark.asyncio
+async def test_climate_fan_mode_requires_current_activity(
+    hass: HomeAssistant,
+    carrier_api: FakeCarrierApiConnection,
+    setup_integration: Callable[..., Any],
+) -> None:
+    """Raise a HA error when Carrier omits the current activity profile."""
+    carrier_api.systems = [build_carrier_system()]
+    carrier_api.systems[0].config.zones[0].activities.clear()
+    await setup_integration()
+    entity_id = entity_id_for_unique_id(hass, CLIMATE_DOMAIN, "abc123_zone_1_thermostat")
+
+    with pytest.raises(HomeAssistantError, match="Current activity unavailable"):
+        await hass.services.async_call(
+            CLIMATE_DOMAIN,
+            SERVICE_SET_FAN_MODE,
+            {ATTR_ENTITY_ID: entity_id, ATTR_FAN_MODE: "high"},
+            blocking=True,
+        )

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -1,0 +1,97 @@
+"""Workflow tests for Carrier climate entities and service writes."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from homeassistant.components.climate import (
+    ATTR_HVAC_MODE,
+    ATTR_PRESET_MODE,
+    DOMAIN as CLIMATE_DOMAIN,
+    HVACMode,
+)
+from homeassistant.components.climate.const import (
+    ATTR_HUMIDITY,
+    ATTR_TARGET_TEMP_HIGH,
+    ATTR_TARGET_TEMP_LOW,
+    SERVICE_SET_HUMIDITY,
+    SERVICE_SET_HVAC_MODE,
+    SERVICE_SET_PRESET_MODE,
+    SERVICE_SET_TEMPERATURE,
+)
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant
+import pytest
+
+from custom_components.ha_carrier.const import FAN_AUTO
+
+from .conftest import FakeCarrierApiConnection, entity_id_for_unique_id
+
+
+@pytest.mark.asyncio
+async def test_climate_platform_registers_zone_thermostat(
+    hass: HomeAssistant,
+    setup_integration: Callable[..., Any],
+) -> None:
+    """Register a zone thermostat with the expected initial HVAC state."""
+    await setup_integration()
+
+    entity_id = entity_id_for_unique_id(hass, CLIMATE_DOMAIN, "abc123_zone_1_thermostat")
+    state = hass.states.get(entity_id)
+
+    assert state is not None
+    assert state.state == HVACMode.HEAT_COOL
+    assert state.attributes["current_temperature"] == 21.1
+    assert FAN_AUTO in state.attributes["fan_modes"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("service", "data", "expected_calls"),
+    [
+        (
+            SERVICE_SET_HVAC_MODE,
+            {ATTR_HVAC_MODE: HVACMode.COOL},
+            ["set_config_mode"],
+        ),
+        (
+            SERVICE_SET_PRESET_MODE,
+            {ATTR_PRESET_MODE: "away"},
+            ["set_config_hold"],
+        ),
+        (
+            SERVICE_SET_TEMPERATURE,
+            {ATTR_TARGET_TEMP_LOW: 20, ATTR_TARGET_TEMP_HIGH: 24},
+            ["set_config_manual_activity", "set_config_hold"],
+        ),
+        (
+            SERVICE_SET_HUMIDITY,
+            {ATTR_HUMIDITY: 43},
+            ["set_config_heat_humidity"],
+        ),
+    ],
+)
+async def test_climate_services_call_carrier_api_and_update_local_state(
+    hass: HomeAssistant,
+    carrier_api: FakeCarrierApiConnection,
+    setup_integration: Callable[..., Any],
+    service: str,
+    data: dict[str, Any],
+    expected_calls: list[str],
+) -> None:
+    """Exercise representative thermostat service workflows through HA."""
+    await setup_integration()
+    entity_id = entity_id_for_unique_id(hass, CLIMATE_DOMAIN, "abc123_zone_1_thermostat")
+
+    await hass.services.async_call(
+        CLIMATE_DOMAIN,
+        service,
+        {ATTR_ENTITY_ID: entity_id, **data},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert [call[0] for call in carrier_api.calls if call[0] != "load_data"][
+        -len(expected_calls) :
+    ] == (expected_calls)

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -125,6 +125,113 @@ async def test_reauth_flow_updates_password(
 
 
 @pytest.mark.asyncio
+async def test_reauth_flow_updates_username_and_reuses_blank_password(
+    hass: HomeAssistant,
+    patch_carrier_api: FakeCarrierApiConnection,
+) -> None:
+    """Validate a new username and keep the existing password when blank."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title=USERNAME,
+        unique_id=IDENTITY_ID,
+        data={CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD},
+    )
+    config_entry.add_to_hass(hass)
+    new_username = "new@example.com"
+
+    form = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_REAUTH, "entry_id": config_entry.entry_id},
+        data=config_entry.data,
+    )
+    result = await hass.config_entries.flow.async_configure(
+        form["flow_id"],
+        user_input={CONF_USERNAME: new_username},
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    assert config_entry.title == new_username
+    assert config_entry.data == {CONF_USERNAME: new_username, CONF_PASSWORD: PASSWORD}
+    assert patch_carrier_api.username == new_username
+    assert patch_carrier_api.password == PASSWORD
+
+
+def test_reconfigure_updates_username_and_reuses_blank_password(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reconfigure can update username while keeping the saved password."""
+    reconfigure_entry = SimpleNamespace(
+        entry_id="entry-1",
+        unique_id=IDENTITY_ID,
+        data={CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD},
+        title=USERNAME,
+    )
+    updates: list[dict[str, Any]] = []
+
+    async def async_validate_credentials(
+        username: str,
+        password: str,
+    ) -> tuple[dict[str, str], str | None]:
+        """Return a validated identity for the submitted credentials.
+
+        Args:
+            username: Submitted Carrier account username.
+            password: Submitted Carrier account password.
+
+        Returns:
+            tuple[dict[str, str], str | None]: No errors and the existing identity ID.
+        """
+        assert username == "new@example.com"
+        assert password == PASSWORD
+        return {}, IDENTITY_ID
+
+    async def async_set_unique_id(unique_id: str) -> None:
+        """Set the flow unique ID without requiring a Home Assistant instance.
+
+        Args:
+            unique_id: Validated Carrier identity ID.
+        """
+        flow.context["unique_id"] = unique_id
+
+    def async_update_reload_and_abort(*args: Any, **kwargs: Any) -> dict[str, str]:
+        """Capture the requested reconfigure updates.
+
+        Args:
+            *args: Positional Home Assistant flow arguments.
+            **kwargs: Keyword Home Assistant flow arguments.
+
+        Returns:
+            dict[str, str]: Minimal flow result.
+        """
+        updates.append({"args": args, **kwargs})
+        return {"type": "abort", "reason": "reconfigure_successful"}
+
+    flow = config_flow.CarrierConfigFlow()
+    flow.context = {"source": "reconfigure", "entry_id": "entry-1"}
+
+    monkeypatch.setattr(config_flow, "_async_validate_credentials", async_validate_credentials)
+    monkeypatch.setattr(flow, "_get_reconfigure_entry", lambda: reconfigure_entry)
+    monkeypatch.setattr(flow, "async_set_unique_id", async_set_unique_id)
+    monkeypatch.setattr(flow, "async_update_reload_and_abort", async_update_reload_and_abort)
+
+    result = _run_async(flow.async_step_reconfigure({CONF_USERNAME: "new@example.com"}))
+
+    assert result["type"] == "abort"
+    assert updates == [
+        {
+            "args": (reconfigure_entry,),
+            "unique_id": IDENTITY_ID,
+            "title": "new@example.com",
+            "data_updates": {
+                CONF_USERNAME: "new@example.com",
+                CONF_PASSWORD: PASSWORD,
+            },
+        }
+    ]
+
+
+@pytest.mark.asyncio
 async def test_options_flow_updates_infinite_hold_option(hass: HomeAssistant) -> None:
     """Create options data from the Carrier options flow."""
     config_entry = MockConfigEntry(

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -10,6 +10,7 @@ from typing import Any
 from aiohttp import ClientError
 from carrier_api import AuthError, BaseError
 from homeassistant import config_entries, data_entry_flow
+from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -122,6 +123,7 @@ async def test_reauth_flow_updates_password(
     assert result["reason"] == "reauth_successful"
     assert config_entry.data[CONF_PASSWORD] == PASSWORD
     assert patch_carrier_api.password == PASSWORD
+    await _async_unload_loaded_entry(hass, config_entry)
 
 
 @pytest.mark.asyncio
@@ -155,6 +157,7 @@ async def test_reauth_flow_updates_username_and_reuses_blank_password(
     assert config_entry.data == {CONF_USERNAME: new_username, CONF_PASSWORD: PASSWORD}
     assert patch_carrier_api.username == new_username
     assert patch_carrier_api.password == PASSWORD
+    await _async_unload_loaded_entry(hass, config_entry)
 
 
 def test_reconfigure_updates_username_and_reuses_blank_password(
@@ -330,3 +333,19 @@ def _run_async[T](awaitable: Coroutine[Any, Any, T]) -> T:
         T: Awaitable result.
     """
     return asyncio.run(awaitable)
+
+
+async def _async_unload_loaded_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+) -> None:
+    """Unload a reloaded config entry before test harness teardown.
+
+    Args:
+        hass: Home Assistant test instance.
+        config_entry: Config entry that may have been reloaded by the flow.
+    """
+    await hass.async_block_till_done()
+    if config_entry.state is ConfigEntryState.LOADED:
+        assert await hass.config_entries.async_unload(config_entry.entry_id)
+        await hass.async_block_till_done()

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -25,7 +25,7 @@ from custom_components.ha_carrier.const import (
     ERROR_UNKNOWN,
 )
 
-from .conftest import PASSWORD, USERNAME, FakeCarrierApiConnection
+from .conftest import IDENTITY_ID, PASSWORD, USERNAME, FakeCarrierApiConnection
 
 
 @pytest.mark.asyncio
@@ -43,6 +43,7 @@ async def test_user_flow_creates_entry_after_successful_validation(
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == USERNAME
     assert result["data"] == {CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD}
+    assert result["result"].unique_id == IDENTITY_ID
     assert patch_carrier_api.cleanup_calls == 1
 
 
@@ -52,7 +53,7 @@ async def test_user_flow_aborts_duplicate_account(
     patch_carrier_api: FakeCarrierApiConnection,
 ) -> None:
     """Abort a user flow when the Carrier username is already configured."""
-    config_entry = MockConfigEntry(domain=DOMAIN, unique_id=USERNAME, data={})
+    config_entry = MockConfigEntry(domain=DOMAIN, unique_id=IDENTITY_ID, data={})
     config_entry.add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
@@ -102,7 +103,7 @@ async def test_reauth_flow_updates_password(
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         title=USERNAME,
-        unique_id=USERNAME,
+        unique_id=IDENTITY_ID,
         data={CONF_USERNAME: USERNAME, CONF_PASSWORD: "old"},
     )
     config_entry.add_to_hass(hass)

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,224 @@
+"""Workflow tests for Carrier config and options flows."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Coroutine
+from types import SimpleNamespace
+from typing import Any
+
+from aiohttp import ClientError
+from carrier_api import AuthError, BaseError
+from homeassistant import config_entries, data_entry_flow
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.ha_carrier import config_flow
+from custom_components.ha_carrier.const import (
+    CONF_INFINITE_HOLDS,
+    DOMAIN,
+    ERROR_AUTH,
+    ERROR_CANNOT_CONNECT,
+    ERROR_UNKNOWN,
+)
+
+from .conftest import PASSWORD, USERNAME, FakeCarrierApiConnection
+
+
+@pytest.mark.asyncio
+async def test_user_flow_creates_entry_after_successful_validation(
+    hass: HomeAssistant,
+    patch_carrier_api: FakeCarrierApiConnection,
+) -> None:
+    """Validate credentials and create a config entry from the user flow."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_USER},
+        data={CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD},
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == USERNAME
+    assert result["data"] == {CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD}
+    assert patch_carrier_api.cleanup_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_user_flow_aborts_duplicate_account(
+    hass: HomeAssistant,
+    patch_carrier_api: FakeCarrierApiConnection,
+) -> None:
+    """Abort a user flow when the Carrier username is already configured."""
+    config_entry = MockConfigEntry(domain=DOMAIN, unique_id=USERNAME, data={})
+    config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_USER},
+        data={CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD},
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("error", "expected_error"),
+    [
+        (AuthError("unauthorized"), ERROR_AUTH),
+        (ClientError("temporary"), ERROR_CANNOT_CONNECT),
+        (BaseError("unexpected"), ERROR_UNKNOWN),
+    ],
+)
+async def test_user_flow_maps_validation_errors(
+    hass: HomeAssistant,
+    patch_carrier_api: FakeCarrierApiConnection,
+    error: BaseException,
+    expected_error: str,
+) -> None:
+    """Map Carrier credential validation failures to flow error keys."""
+    patch_carrier_api.load_data_error = error
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_USER},
+        data={CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": expected_error}
+
+
+@pytest.mark.asyncio
+async def test_reauth_flow_updates_password(
+    hass: HomeAssistant,
+    patch_carrier_api: FakeCarrierApiConnection,
+) -> None:
+    """Validate a new password and update the existing config entry."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title=USERNAME,
+        unique_id=USERNAME,
+        data={CONF_USERNAME: USERNAME, CONF_PASSWORD: "old"},
+    )
+    config_entry.add_to_hass(hass)
+
+    form = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_REAUTH, "entry_id": config_entry.entry_id},
+        data=config_entry.data,
+    )
+    result = await hass.config_entries.flow.async_configure(
+        form["flow_id"],
+        user_input={CONF_PASSWORD: PASSWORD},
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    assert config_entry.data[CONF_PASSWORD] == PASSWORD
+    assert patch_carrier_api.password == PASSWORD
+
+
+@pytest.mark.asyncio
+async def test_options_flow_updates_infinite_hold_option(hass: HomeAssistant) -> None:
+    """Create options data from the Carrier options flow."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title=USERNAME,
+        data={CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD},
+        options={CONF_INFINITE_HOLDS: True},
+    )
+    config_entry.add_to_hass(hass)
+
+    form = await hass.config_entries.options.async_init(config_entry.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        form["flow_id"],
+        user_input={CONF_INFINITE_HOLDS: False},
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"] == {CONF_INFINITE_HOLDS: False}
+
+
+def test_reauth_rejects_credentials_for_different_unconfigured_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test reauth rejects credentials for a different unconfigured Carrier account."""
+
+    async def async_validate_credentials(
+        username: str,
+        password: str,
+    ) -> tuple[dict[str, str], str | None]:
+        """Return a validated identity that does not belong to the reauth entry.
+
+        Args:
+            username: Submitted Carrier account username.
+            password: Submitted Carrier account password.
+
+        Returns:
+            tuple[dict[str, str], str | None]: No errors and a mismatched identity ID.
+        """
+        return {}, "new-identity"
+
+    async def async_set_unique_id(unique_id: str) -> None:
+        """Set the flow unique ID without requiring a Home Assistant instance.
+
+        Args:
+            unique_id: Validated Carrier identity ID.
+        """
+        flow.context["unique_id"] = unique_id
+
+    def async_update_reload_and_abort(*args: Any, **kwargs: Any) -> None:
+        """Fail if reauth tries to retarget the entry to a new identity.
+
+        Args:
+            *args: Positional Home Assistant flow arguments.
+            **kwargs: Keyword Home Assistant flow arguments.
+        """
+        pytest.fail("reauth retargeted the existing config entry")
+
+    flow = config_flow.CarrierConfigFlow()
+    flow.context = {"source": "reauth", "entry_id": "entry-1"}
+    flow._reauth_entry_data = {
+        CONF_USERNAME: "old@example.com",
+        CONF_PASSWORD: "old-password",
+    }
+    reauth_entry = SimpleNamespace(
+        entry_id="entry-1",
+        unique_id="saved-identity",
+        data=flow._reauth_entry_data,
+        title="old@example.com",
+    )
+
+    monkeypatch.setattr(config_flow, "_async_validate_credentials", async_validate_credentials)
+    monkeypatch.setattr(flow, "_get_reauth_entry", lambda: reauth_entry)
+    monkeypatch.setattr(flow, "async_set_unique_id", async_set_unique_id)
+    monkeypatch.setattr(flow, "async_update_reload_and_abort", async_update_reload_and_abort)
+
+    with pytest.raises(data_entry_flow.AbortFlow) as abort_flow:
+        _run_async(
+            flow.async_step_reauth_confirm(
+                {
+                    CONF_USERNAME: "new@example.com",
+                    CONF_PASSWORD: "new-password",
+                }
+            )
+        )
+
+    assert abort_flow.value.reason == "unique_id_mismatch"
+
+
+def _run_async[T](awaitable: Coroutine[Any, Any, T]) -> T:
+    """Run an awaitable in a fresh event loop.
+
+    Args:
+        awaitable: Awaitable test target.
+
+    Returns:
+        T: Awaitable result.
+    """
+    return asyncio.run(awaitable)

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,28 @@
+"""Workflow tests for Carrier diagnostics output."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+import pytest
+
+from custom_components.ha_carrier.diagnostics import async_get_config_entry_diagnostics
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_redacts_config_entry_and_includes_device_entities(
+    hass: HomeAssistant,
+    setup_integration: Callable[..., Any],
+) -> None:
+    """Build diagnostics from a loaded entry with redacted sensitive data."""
+    config_entry = await setup_integration()
+
+    diagnostics = await async_get_config_entry_diagnostics(hass, config_entry)
+
+    assert diagnostics["entry"]["data"][CONF_USERNAME] == "**REDACTED**"
+    assert diagnostics["entry"]["data"][CONF_PASSWORD] == "**REDACTED**"
+    assert diagnostics["ABC123"]["mapped_data"]["serial"] == "**REDACTED**"
+    assert diagnostics["ABC123"]["device"]["entities"]

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,34 @@
+"""Workflow tests for Carrier integration setup and unload."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+import pytest
+
+from .conftest import FakeCarrierApiConnection
+
+
+@pytest.mark.asyncio
+async def test_setup_entry_loads_platforms_and_unload_cancels_websocket(
+    hass: HomeAssistant,
+    carrier_api: FakeCarrierApiConnection,
+    setup_integration: Callable[..., Any],
+) -> None:
+    """Set up the config entry through HA and unload the websocket task cleanly."""
+    config_entry = await setup_integration()
+
+    assert config_entry.state is ConfigEntryState.LOADED
+    assert config_entry.runtime_data.systems == carrier_api.systems
+    assert config_entry.runtime_data.websocket_task is not None
+    assert config_entry.runtime_data.api_connection.api_websocket.callbacks
+    coordinator = config_entry.runtime_data
+
+    assert await hass.config_entries.async_unload(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.NOT_LOADED
+    assert coordinator.websocket_task is None

--- a/tests/test_integration_workflows.py
+++ b/tests/test_integration_workflows.py
@@ -102,6 +102,13 @@ async def test_options_workflow_reloads_and_unloads_without_lingering_coordinato
     assert config_entry.runtime_data is not first_coordinator
     assert first_coordinator.websocket_task is None
 
+    current_coordinator = config_entry.runtime_data
+    assert await hass.config_entries.async_unload(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.NOT_LOADED
+    assert current_coordinator.websocket_task is None
+
 
 @pytest.mark.asyncio
 async def test_scheduled_refresh_uses_energy_path_and_unload_cancels_future_refresh(

--- a/tests/test_integration_workflows.py
+++ b/tests/test_integration_workflows.py
@@ -1,0 +1,274 @@
+"""End-to-end Home Assistant workflow tests for Carrier integration behavior."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from datetime import timedelta
+from inspect import isawaitable
+
+from aiohttp import ClientError
+from homeassistant import config_entries
+from homeassistant.components.climate import (
+    ATTR_HVAC_MODE,
+    DOMAIN as CLIMATE_DOMAIN,
+    SERVICE_SET_HVAC_MODE,
+    HVACMode,
+)
+from homeassistant.components.select import (
+    ATTR_OPTION,
+    DOMAIN as SELECT_DOMAIN,
+    SERVICE_SELECT_OPTION,
+)
+from homeassistant.config_entries import ConfigEntry, ConfigEntryState
+from homeassistant.const import ATTR_ENTITY_ID, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.update_coordinator import UpdateFailed
+from homeassistant.util import dt as dt_util
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry, async_fire_time_changed
+
+from custom_components.ha_carrier import async_migrate_entry
+from custom_components.ha_carrier.const import (
+    CONF_INFINITE_HOLDS,
+    DEFAULT_UPDATE_INTERVAL_MINUTES,
+    DOMAIN,
+    HEAT_SOURCE_ODU_ONLY_LABEL,
+)
+
+from .conftest import (
+    IDENTITY_ID,
+    PASSWORD,
+    USERNAME,
+    FakeCarrierApiConnection,
+    entity_id_for_unique_id,
+)
+
+
+@pytest.mark.asyncio
+async def test_reauth_workflow_reloads_and_unloads_without_lingering_coordinator(
+    hass: HomeAssistant,
+    patch_carrier_api: FakeCarrierApiConnection,
+) -> None:
+    """Run setup, reauth, reload, and unload as one HA lifecycle workflow."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title=USERNAME,
+        unique_id=IDENTITY_ID,
+        data={CONF_USERNAME: USERNAME, CONF_PASSWORD: "old"},
+    )
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    form = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_REAUTH, "entry_id": config_entry.entry_id},
+        data=config_entry.data,
+    )
+    result = await hass.config_entries.flow.async_configure(
+        form["flow_id"],
+        user_input={CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD},
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    assert config_entry.state is ConfigEntryState.LOADED
+    assert config_entry.data[CONF_PASSWORD] == PASSWORD
+    await _async_unload_loaded_entry(hass, config_entry)
+
+
+@pytest.mark.asyncio
+async def test_options_workflow_reloads_and_unloads_without_lingering_coordinator(
+    hass: HomeAssistant,
+    setup_integration: Callable[..., Awaitable[ConfigEntry]],
+) -> None:
+    """Run setup, options update, reload, and unload as one HA lifecycle workflow."""
+    config_entry = await setup_integration(options={CONF_INFINITE_HOLDS: True})
+    first_coordinator = config_entry.runtime_data
+
+    form = await hass.config_entries.options.async_init(config_entry.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        form["flow_id"],
+        user_input={CONF_INFINITE_HOLDS: False},
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert config_entry.options[CONF_INFINITE_HOLDS] is False
+    assert config_entry.state is ConfigEntryState.LOADED
+    assert config_entry.runtime_data is not first_coordinator
+    assert first_coordinator.websocket_task is None
+
+
+@pytest.mark.asyncio
+async def test_scheduled_refresh_uses_energy_path_and_unload_cancels_future_refresh(
+    hass: HomeAssistant,
+    carrier_api: FakeCarrierApiConnection,
+    setup_integration: Callable[..., Awaitable[ConfigEntry]],
+) -> None:
+    """Advance HA time through a scheduled refresh and then unload cleanly."""
+    config_entry = await setup_integration()
+    carrier_api.calls.clear()
+
+    async_fire_time_changed(
+        hass,
+        dt_util.utcnow() + timedelta(minutes=DEFAULT_UPDATE_INTERVAL_MINUTES),
+    )
+    await hass.async_block_till_done()
+
+    assert [call[0] for call in carrier_api.calls] == ["get_energy"]
+    coordinator = config_entry.runtime_data
+    await _async_unload_loaded_entry(hass, config_entry)
+
+    carrier_api.calls.clear()
+    async_fire_time_changed(
+        hass,
+        dt_util.utcnow() + timedelta(minutes=DEFAULT_UPDATE_INTERVAL_MINUTES),
+    )
+    await hass.async_block_till_done()
+
+    assert coordinator.websocket_task is None
+    assert carrier_api.calls == []
+
+
+@pytest.mark.asyncio
+async def test_refresh_failure_and_recovery_update_poll_interval_in_ha_workflow(
+    hass: HomeAssistant,
+    carrier_api: FakeCarrierApiConnection,
+    setup_integration: Callable[..., Awaitable[ConfigEntry]],
+) -> None:
+    """Exercise HA coordinator refresh failure and recovery interval changes."""
+    config_entry = await setup_integration()
+    coordinator = config_entry.runtime_data
+    coordinator.data_flush = True
+    carrier_api.load_data_error = ClientError("temporary")
+
+    await coordinator.async_refresh()
+
+    assert coordinator.last_exception is not None
+    assert isinstance(coordinator.last_exception, UpdateFailed)
+    assert coordinator.update_interval == timedelta(minutes=1)
+
+    carrier_api.load_data_error = None
+    await coordinator.async_refresh()
+
+    assert coordinator.last_update_success is True
+    assert coordinator.update_interval == timedelta(minutes=DEFAULT_UPDATE_INTERVAL_MINUTES)
+
+
+@pytest.mark.asyncio
+async def test_websocket_callback_updates_timestamp_and_survives_entry_unload(
+    hass: HomeAssistant,
+    carrier_api: FakeCarrierApiConnection,
+    setup_integration: Callable[..., Awaitable[ConfigEntry]],
+) -> None:
+    """Drive registered websocket callbacks and then unload the HA entry."""
+    config_entry = await setup_integration()
+    coordinator = config_entry.runtime_data
+
+    for callback in carrier_api.api_websocket.callbacks:
+        result = callback("{}")
+        if isawaitable(result):
+            await result
+    await hass.async_block_till_done()
+
+    assert coordinator.timestamp_websocket is not None
+    await _async_unload_loaded_entry(hass, config_entry)
+    assert coordinator.websocket_task is None
+
+
+@pytest.mark.asyncio
+async def test_service_workflow_still_writes_after_config_entry_reload(
+    hass: HomeAssistant,
+    carrier_api: FakeCarrierApiConnection,
+    setup_integration: Callable[..., Awaitable[ConfigEntry]],
+) -> None:
+    """Call HA services before and after a config-entry reload."""
+    config_entry = await setup_integration()
+    climate_entity_id = entity_id_for_unique_id(hass, CLIMATE_DOMAIN, "abc123_zone_1_thermostat")
+    select_entity_id = entity_id_for_unique_id(hass, SELECT_DOMAIN, "abc123_heat_source")
+
+    await hass.services.async_call(
+        CLIMATE_DOMAIN,
+        SERVICE_SET_HVAC_MODE,
+        {ATTR_ENTITY_ID: climate_entity_id, ATTR_HVAC_MODE: HVACMode.COOL},
+        blocking=True,
+    )
+    assert carrier_api.calls[-1][0] == "set_config_mode"
+
+    assert await hass.config_entries.async_reload(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        SELECT_DOMAIN,
+        SERVICE_SELECT_OPTION,
+        {ATTR_ENTITY_ID: select_entity_id, ATTR_OPTION: HEAT_SOURCE_ODU_ONLY_LABEL},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert carrier_api.calls[-1][0] == "set_heat_source"
+    assert hass.states.get(climate_entity_id) is not None
+    assert hass.states.get(select_entity_id) is not None
+
+
+@pytest.mark.asyncio
+async def test_registry_migration_workflow_preserves_entities_through_setup(
+    hass: HomeAssistant,
+    patch_carrier_api: FakeCarrierApiConnection,
+) -> None:
+    """Migrate legacy registry IDs, set up HA, and verify no stale IDs remain."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=1,
+        unique_id=USERNAME,
+        data={CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD},
+    )
+    config_entry.add_to_hass(hass)
+    ent_reg = er.async_get(hass)
+    legacy_sensor = ent_reg.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        "ABC123_Outdoor Temperature",
+        config_entry=config_entry,
+    )
+    legacy_climate = ent_reg.async_get_or_create(
+        "climate",
+        DOMAIN,
+        "ABC123_Living Room",
+        config_entry=config_entry,
+    )
+
+    assert await async_migrate_entry(hass, config_entry)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.version == 3
+    assert config_entry.unique_id == IDENTITY_ID
+    migrated_sensor = ent_reg.async_get(legacy_sensor.entity_id)
+    migrated_climate = ent_reg.async_get(legacy_climate.entity_id)
+    assert migrated_sensor is not None
+    assert migrated_sensor.unique_id == "abc123_outdoor_temperature"
+    assert migrated_climate is not None
+    assert migrated_climate.unique_id == "abc123_zone_1_thermostat"
+    assert ent_reg.async_get_entity_id("sensor", DOMAIN, "ABC123_Outdoor Temperature") is None
+    assert ent_reg.async_get_entity_id("climate", DOMAIN, "ABC123_Living Room") is None
+
+
+async def _async_unload_loaded_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+) -> None:
+    """Unload a loaded Carrier entry and let HA settle pending tasks.
+
+    Args:
+        hass: Home Assistant test instance.
+        config_entry: Config entry to unload when still loaded.
+    """
+    await hass.async_block_till_done()
+    if config_entry.state is ConfigEntryState.LOADED:
+        assert await hass.config_entries.async_unload(config_entry.entry_id)
+        await hass.async_block_till_done()

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -9,10 +9,11 @@ from homeassistant.helpers import entity_registry as er
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
+from custom_components.ha_carrier import async_migrate_entry
 from custom_components.ha_carrier.const import DOMAIN
-from custom_components.ha_carrier.migrate import migrate_1_to_2
+from custom_components.ha_carrier.migrate import migrate_1_to_2, migrate_2_to_3
 
-from .conftest import PASSWORD, USERNAME, FakeCarrierApiConnection
+from .conftest import IDENTITY_ID, PASSWORD, USERNAME, FakeCarrierApiConnection
 
 
 @pytest.mark.asyncio
@@ -73,3 +74,114 @@ async def test_migration_defers_version_update_when_live_data_cannot_load(
 
     assert config_entry.version == 1
     assert ent_reg.async_get(entry.entity_id) is not None
+
+
+@pytest.mark.asyncio
+async def test_migration_updates_config_entry_unique_id_to_identity_id(
+    hass: HomeAssistant,
+    patch_carrier_api: FakeCarrierApiConnection,
+) -> None:
+    """Migrate v2 username-keyed config entries to Carrier identity IDs."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=2,
+        unique_id=USERNAME,
+        data={CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD},
+    )
+    config_entry.add_to_hass(hass)
+
+    assert await migrate_2_to_3(hass, config_entry)
+
+    assert config_entry.version == 3
+    assert config_entry.unique_id == IDENTITY_ID
+    assert patch_carrier_api.cleanup_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_migration_defers_identity_update_when_user_info_cannot_load(
+    hass: HomeAssistant,
+    patch_carrier_api: FakeCarrierApiConnection,
+) -> None:
+    """Keep v2 entries unchanged when Carrier identity lookup fails."""
+    patch_carrier_api.load_data_error = ClientError("offline")
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=2,
+        unique_id=USERNAME,
+        data={CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD},
+    )
+    config_entry.add_to_hass(hass)
+
+    assert await migrate_2_to_3(hass, config_entry)
+
+    assert config_entry.version == 2
+    assert config_entry.unique_id == USERNAME
+    assert patch_carrier_api.cleanup_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_migration_defers_identity_update_when_identity_id_is_missing(
+    hass: HomeAssistant,
+    patch_carrier_api: FakeCarrierApiConnection,
+) -> None:
+    """Keep v2 entries unchanged when Carrier omits identityId."""
+    patch_carrier_api.identity_id = ""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=2,
+        unique_id=USERNAME,
+        data={CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD},
+    )
+    config_entry.add_to_hass(hass)
+
+    assert await migrate_2_to_3(hass, config_entry)
+
+    assert config_entry.version == 2
+    assert config_entry.unique_id == USERNAME
+
+
+@pytest.mark.asyncio
+async def test_migration_rejects_conflicting_identity_id(
+    hass: HomeAssistant,
+    patch_carrier_api: FakeCarrierApiConnection,
+) -> None:
+    """Reject v2 migration when another entry already owns the identity ID."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=2,
+        unique_id=USERNAME,
+        data={CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD},
+    )
+    config_entry.add_to_hass(hass)
+    conflicting_entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=3,
+        unique_id=IDENTITY_ID,
+        data={CONF_USERNAME: "other@example.com", CONF_PASSWORD: PASSWORD},
+    )
+    conflicting_entry.add_to_hass(hass)
+
+    assert not await migrate_2_to_3(hass, config_entry)
+
+    assert config_entry.version == 2
+    assert config_entry.unique_id == USERNAME
+
+
+@pytest.mark.asyncio
+async def test_migration_chains_v1_to_v3(
+    hass: HomeAssistant,
+    patch_carrier_api: FakeCarrierApiConnection,
+) -> None:
+    """Run v1 config entries through entity and identity migrations."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=1,
+        unique_id=USERNAME,
+        data={CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD},
+    )
+    config_entry.add_to_hass(hass)
+
+    assert await async_migrate_entry(hass, config_entry)
+
+    assert config_entry.version == 3
+    assert config_entry.unique_id == IDENTITY_ID

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -1,0 +1,75 @@
+"""Workflow tests for Carrier config entry migration."""
+
+from __future__ import annotations
+
+from aiohttp import ClientError
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.ha_carrier.const import CONFIG_FLOW_VERSION, DOMAIN
+from custom_components.ha_carrier.migrate import migrate_1_to_2
+
+from .conftest import PASSWORD, USERNAME, FakeCarrierApiConnection
+
+
+@pytest.mark.asyncio
+async def test_migration_updates_system_and_zone_unique_ids(
+    hass: HomeAssistant,
+    patch_carrier_api: FakeCarrierApiConnection,
+) -> None:
+    """Migrate legacy v1 entity registry IDs to v2 unique IDs."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=1,
+        data={CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD},
+    )
+    config_entry.add_to_hass(hass)
+    ent_reg = er.async_get(hass)
+    ent_reg.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        "ABC123_Outdoor Temperature",
+        config_entry=config_entry,
+    )
+    ent_reg.async_get_or_create(
+        "climate",
+        DOMAIN,
+        "ABC123_Living Room",
+        config_entry=config_entry,
+    )
+
+    assert await migrate_1_to_2(hass, config_entry)
+
+    assert config_entry.version == CONFIG_FLOW_VERSION
+    assert ent_reg.async_get_entity_id("sensor", DOMAIN, "abc123_outdoor_temperature")
+    assert ent_reg.async_get_entity_id("climate", DOMAIN, "abc123_zone_1_thermostat")
+
+
+@pytest.mark.asyncio
+async def test_migration_defers_version_update_when_live_data_cannot_load(
+    hass: HomeAssistant,
+    patch_carrier_api: FakeCarrierApiConnection,
+) -> None:
+    """Keep migration non-destructive when Carrier data cannot be loaded."""
+    patch_carrier_api.load_data_error = ClientError("offline")
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=1,
+        data={CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD},
+    )
+    config_entry.add_to_hass(hass)
+    ent_reg = er.async_get(hass)
+    entry = ent_reg.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        "ABC123_Unknown Legacy Entity",
+        config_entry=config_entry,
+    )
+
+    assert await migrate_1_to_2(hass, config_entry)
+
+    assert config_entry.version == 1
+    assert ent_reg.async_get(entry.entity_id) is not None

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -9,7 +9,7 @@ from homeassistant.helpers import entity_registry as er
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.ha_carrier.const import CONFIG_FLOW_VERSION, DOMAIN
+from custom_components.ha_carrier.const import DOMAIN
 from custom_components.ha_carrier.migrate import migrate_1_to_2
 
 from .conftest import PASSWORD, USERNAME, FakeCarrierApiConnection
@@ -43,7 +43,7 @@ async def test_migration_updates_system_and_zone_unique_ids(
 
     assert await migrate_1_to_2(hass, config_entry)
 
-    assert config_entry.version == CONFIG_FLOW_VERSION
+    assert config_entry.version == 2
     assert ent_reg.async_get_entity_id("sensor", DOMAIN, "abc123_outdoor_temperature")
     assert ent_reg.async_get_entity_id("climate", DOMAIN, "abc123_zone_1_thermostat")
 

--- a/tests/test_resiliency.py
+++ b/tests/test_resiliency.py
@@ -1,0 +1,100 @@
+"""Workflow tests for Carrier retry and resiliency helpers."""
+
+from __future__ import annotations
+
+import logging
+
+from aiohttp import ClientError
+from gql.transport.exceptions import TransportServerError
+import pytest
+
+from custom_components.ha_carrier.exceptions import CarrierUnauthorizedError
+from custom_components.ha_carrier.resiliency import (
+    ResiliencyState,
+    RetryPolicy,
+    async_call_with_retry,
+    compute_backoff_delay,
+)
+
+
+@pytest.fixture
+def retry_policy() -> RetryPolicy:
+    """Return a deterministic retry policy for tests."""
+    return RetryPolicy(
+        name="test",
+        max_attempts=3,
+        base_delay=0,
+        max_delay=0,
+        jitter_fraction=0,
+        retry_on_unauthorized=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_retry_helper_retries_transient_failure_then_resets_state(
+    retry_policy: RetryPolicy,
+) -> None:
+    """Retry transient failures and clear counters after a later success."""
+    state = ResiliencyState(unauthorized_threshold=3, transient_threshold=3)
+    attempts = 0
+
+    async def operation() -> str:
+        """Fail once with a transient error, then succeed."""
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise ClientError("temporary")
+        return "ok"
+
+    result = await async_call_with_retry(
+        operation,
+        policy=retry_policy,
+        state=state,
+        operation_name="test operation",
+        logger=logging.getLogger(__name__),
+    )
+
+    assert result == "ok"
+    assert attempts == 2
+    assert state.consecutive_transient == 0
+
+
+@pytest.mark.asyncio
+async def test_retry_helper_escalates_repeated_unauthorized_failures(
+    retry_policy: RetryPolicy,
+) -> None:
+    """Raise CarrierUnauthorizedError after unauthorized failures cross threshold."""
+    state = ResiliencyState(unauthorized_threshold=2, transient_threshold=3)
+
+    async def operation() -> None:
+        """Always raise an unauthorized Carrier transport error."""
+        raise TransportServerError("unauthorized", code=401)
+
+    with pytest.raises(CarrierUnauthorizedError):
+        await async_call_with_retry(
+            operation,
+            policy=retry_policy,
+            state=state,
+            operation_name="test operation",
+            logger=logging.getLogger(__name__),
+        )
+
+    assert state.consecutive_unauthorized == 2
+
+
+@pytest.mark.parametrize(
+    ("attempt", "expected"),
+    [(0, 1.0), (1, 2.0), (2, 4.0), (5, 4.0)],
+)
+def test_compute_backoff_delay_caps_exponential_delay(attempt: int, expected: float) -> None:
+    """Cap exponential backoff at the policy maximum."""
+    policy = RetryPolicy(
+        name="test",
+        max_attempts=None,
+        base_delay=1.0,
+        max_delay=4.0,
+        jitter_fraction=0,
+        retry_on_unauthorized=False,
+    )
+
+    assert compute_backoff_delay(policy, attempt) == expected

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -1,0 +1,59 @@
+"""Workflow tests for Carrier select entities."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from homeassistant.components.select import (
+    ATTR_OPTION,
+    DOMAIN as SELECT_DOMAIN,
+    SERVICE_SELECT_OPTION,
+)
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant
+import pytest
+
+from custom_components.ha_carrier.const import HEAT_SOURCE_ODU_ONLY_LABEL
+
+from .conftest import FakeCarrierApiConnection, entity_id_for_unique_id
+
+
+@pytest.mark.asyncio
+async def test_select_platform_registers_heat_source_select(
+    hass: HomeAssistant,
+    setup_integration: Callable[..., Any],
+) -> None:
+    """Register a heat-source select entity for heat-capable systems."""
+    await setup_integration()
+
+    entity_id = entity_id_for_unique_id(hass, SELECT_DOMAIN, "abc123_heat_source")
+    state = hass.states.get(entity_id)
+
+    assert state is not None
+    assert state.state == "system in control"
+    assert HEAT_SOURCE_ODU_ONLY_LABEL in state.attributes["options"]
+
+
+@pytest.mark.asyncio
+async def test_select_option_calls_carrier_api_and_updates_local_state(
+    hass: HomeAssistant,
+    carrier_api: FakeCarrierApiConnection,
+    setup_integration: Callable[..., Any],
+) -> None:
+    """Write a selected heat source through Home Assistant services."""
+    await setup_integration()
+    entity_id = entity_id_for_unique_id(hass, SELECT_DOMAIN, "abc123_heat_source")
+
+    await hass.services.async_call(
+        SELECT_DOMAIN,
+        SERVICE_SELECT_OPTION,
+        {ATTR_ENTITY_ID: entity_id, ATTR_OPTION: HEAT_SOURCE_ODU_ONLY_LABEL},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert carrier_api.calls[-1][0] == "set_heat_source"
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == HEAT_SOURCE_ODU_ONLY_LABEL

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,0 +1,42 @@
+"""Workflow tests for Carrier sensor platform registration."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from homeassistant.core import HomeAssistant
+import pytest
+
+from .conftest import entity_id_for_unique_id
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("unique_id", "expected_state"),
+    [
+        ("abc123_outdoor_temperature", "4.44444444444444"),
+        ("abc123_filter_remaining", "80"),
+        ("abc123_airflow", "1200"),
+        ("abc123_static_pressure", "0.049817781666667"),
+        ("abc123_zone_1_temperature", "21.1111111111111"),
+        ("abc123_zone_1_humidity", "45"),
+        ("abc123_cooling_energy_year_to_date", "100"),
+        ("abc123_cooling_energy_yesterday", "1"),
+        ("abc123_cooling_energy_last_month", "10"),
+    ],
+)
+async def test_sensor_platform_registers_representative_state_sensors(
+    hass: HomeAssistant,
+    setup_integration: Callable[..., Any],
+    unique_id: str,
+    expected_state: str,
+) -> None:
+    """Register representative system, zone, timestamp, and energy sensors."""
+    await setup_integration()
+
+    entity_id = entity_id_for_unique_id(hass, "sensor", unique_id)
+    state = hass.states.get(entity_id)
+
+    assert state is not None
+    assert state.state == expected_state

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -8,7 +8,7 @@ from typing import Any
 from homeassistant.core import HomeAssistant
 import pytest
 
-from .conftest import entity_id_for_unique_id
+from .conftest import FakeCarrierApiConnection, build_carrier_system, entity_id_for_unique_id
 
 
 @pytest.mark.asyncio
@@ -36,6 +36,65 @@ async def test_sensor_platform_registers_representative_state_sensors(
     await setup_integration()
 
     entity_id = entity_id_for_unique_id(hass, "sensor", unique_id)
+    state = hass.states.get(entity_id)
+
+    assert state is not None
+    assert state.state == expected_state
+
+
+@pytest.mark.asyncio
+async def test_sensor_platform_registers_propane_and_lifecycle_sensors(
+    hass: HomeAssistant,
+    carrier_api: FakeCarrierApiConnection,
+    setup_integration: Callable[..., Any],
+) -> None:
+    """Register optional propane, humidifier, UV, and variable-capacity sensors."""
+    carrier_api.systems = [build_carrier_system()]
+    system = carrier_api.systems[0]
+    system.config.fuel_type = "propane"
+    system.config.gas_unit = "gallon"
+
+    await setup_integration()
+
+    expected_states = {
+        "abc123_propane_consumption_year_to_date": "12.3854677194896",
+        "abc123_propane_usage_year_to_date": "3.33141984548898",
+        "abc123_humidifier_remaining": "70",
+        "abc123_uv_lamp_remaining": "90",
+        "abc123_odu_var": "unavailable",
+        "abc123_idu_status": "idle",
+    }
+    for unique_id, expected_state in expected_states.items():
+        entity_id = entity_id_for_unique_id(hass, "sensor", unique_id)
+        state = hass.states.get(entity_id)
+
+        assert state is not None
+        assert state.state == expected_state
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("outdoor_status", "expected_state"),
+    [
+        ("42", "on"),
+        ("off", "off"),
+        ("standby", "standby"),
+    ],
+)
+async def test_sensor_platform_maps_outdoor_operational_status_variants(
+    hass: HomeAssistant,
+    carrier_api: FakeCarrierApiConnection,
+    setup_integration: Callable[..., Any],
+    outdoor_status: str,
+    expected_state: str,
+) -> None:
+    """Map numeric and text outdoor-unit statuses to stable sensor states."""
+    carrier_api.systems = [build_carrier_system()]
+    carrier_api.systems[0].status.outdoor_unit_operational_status = outdoor_status
+
+    await setup_integration()
+
+    entity_id = entity_id_for_unique_id(hass, "sensor", "abc123_odu_status")
     state = hass.states.get(entity_id)
 
     assert state is not None

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,47 @@
+"""Pytest coverage for Carrier utility helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from aiohttp import ClientError
+from gql.transport.exceptions import TransportServerError
+import pytest
+
+from custom_components.ha_carrier.util import (
+    async_redact_data,
+    is_transient_transport_error,
+    is_unauthorized_error,
+)
+
+
+@pytest.mark.parametrize(
+    ("classifier", "nested_error"),
+    [
+        (is_unauthorized_error, TransportServerError("unauthorized", code=401)),
+        (is_transient_transport_error, ClientError("temporary")),
+    ],
+)
+def test_exception_classifiers_inspect_context_when_cause_exists(
+    classifier: Callable[[BaseException], bool],
+    nested_error: BaseException,
+) -> None:
+    """Find classified errors on the context branch of an exception graph."""
+    error = RuntimeError("root")
+    error.__cause__ = ValueError("non-matching cause")
+    error.__context__ = nested_error
+
+    assert classifier(error) is True
+
+
+def test_async_redact_data_recursively_redacts_mappings_and_lists() -> None:
+    """Redact sensitive keys while preserving unrelated nested payload data."""
+    payload = {"username": "user", "nested": [{"password": "secret", "mode": "auto"}]}
+
+    redacted = async_redact_data(payload, {"username", "password"})
+
+    assert redacted == {
+        "username": "**REDACTED**",
+        "nested": [{"password": "**REDACTED**", "mode": "auto"}],
+    }
+    assert payload["username"] == "user"


### PR DESCRIPTION
## Summary
Adds a pytest-based Home Assistant test harness for the Carrier integration, including coverage reporting and GitHub Actions workflows. The branch covers config flows, migration behavior, entities, coordinator resiliency, diagnostics, services, and end-to-end integration workflows.

## What Changed
- Added pytest dependency groups, pytest configuration, coverage settings, and a repo-local `scripts/test` runner.
- Added shared Home Assistant and Carrier API fixtures in `tests/conftest.py` using `pytest-homeassistant-custom-component`.
- Added focused test modules for integration setup, config flow, migration, coordinator behavior, entity platforms, diagnostics, resiliency, and utility helpers.
- Added integration workflow coverage for reload/unload behavior, websocket callbacks, service calls, reauth cleanup, and refresh recovery.
- Added GitHub Actions workflows for pytest coverage and PR coverage comments, with dependency/bot PR filtering.
- Ignored generated `htmlcov/` coverage output.

## Why
This gives the integration repeatable regression coverage for the recent identity, reauth, reconfigure, migration, and resiliency work without relying on bespoke mocks. The workflow also makes coverage visible in CI so future changes have a clear validation surface.

## Validation
- `./scripts/test`
