### PR TITLE
Use carrier_api as_dict serializer

### DIFF
--- a/custom_components/ha_carrier/carrier_data_update_coordinator.py
+++ b/custom_components/ha_carrier/carrier_data_update_coordinator.py
@@ -440,13 +440,7 @@ class CarrierDataUpdateCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
             TypeError: Raised when the Carrier model returns a non-mapping
                 payload unexpectedly.
         """
-        as_dict = getattr(system, "as_dict", None)
-        if callable(as_dict):
-            mapped_data = as_dict()
-        else:
-            # carrier_api < 2.12 exposed the mapping payload through a
-            # non-standard direct __repr__ call.
-            mapped_data = system.__repr__()
+        mapped_data = system.as_dict()
         if not isinstance(mapped_data, Mapping):
             raise TypeError("carrier_api System serializer returned a non-mapping payload")
         return dict(mapped_data)

--- a/custom_components/ha_carrier/carrier_data_update_coordinator.py
+++ b/custom_components/ha_carrier/carrier_data_update_coordinator.py
@@ -434,19 +434,21 @@ class CarrierDataUpdateCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
             system: Carrier system object to map.
 
         Returns:
-            dict[str, Any]: System mapping emitted by the Carrier model helper.
+            dict[str, Any]: System mapping emitted by the Carrier model serializer.
 
         Raises:
             TypeError: Raised when the Carrier model returns a non-mapping
                 payload unexpectedly.
         """
-        # carrier_api.System.__repr__ intentionally returns a dict-like payload,
-        # while Python's built-in repr(system) expects __repr__ to return a str.
-        # Call the model helper directly so we keep a mapping for recursive
-        # redaction instead of flattening sensitive keys into an opaque string.
-        mapped_data = system.__repr__()
+        as_dict = getattr(system, "as_dict", None)
+        if callable(as_dict):
+            mapped_data = as_dict()
+        else:
+            # carrier_api < 2.12 exposed the mapping payload through a
+            # non-standard direct __repr__ call.
+            mapped_data = system.__repr__()
         if not isinstance(mapped_data, Mapping):
-            raise TypeError("carrier_api System.__repr__ returned a non-mapping payload")
+            raise TypeError("carrier_api System serializer returned a non-mapping payload")
         return dict(mapped_data)
 
     async def updated_callback(self, _message: str) -> None:

--- a/custom_components/ha_carrier/manifest.json
+++ b/custom_components/ha_carrier/manifest.json
@@ -14,7 +14,7 @@
     "carrier_api"
   ],
   "requirements": [
-    "carrier-api==2.11.3"
+    "carrier-api==3.0.0"
   ],
   "version": "2.22.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ namespaces = true
 version = { attr = "custom_components.ha_carrier.const.VERSION" }
 
 [dependency-groups]
-dev = [
+ha = [
     "carrier-api==3.0.0",
     "homeassistant",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ version = { attr = "custom_components.ha_carrier.const.VERSION" }
 
 [dependency-groups]
 dev = [
-    "carrier-api==2.11.3",
+    "carrier-api==3.0.0",
     "homeassistant",
     "mypy",
     "prek",


### PR DESCRIPTION
## Summary
Updates Carrier system serialization to use the new `carrier_api.System.as_dict()` helper when it is available. This keeps `ha_carrier` compatible with the upcoming `carrier_api` change that makes `System.__repr__()` return a string.

## What Changed
- Changed `CarrierDataUpdateCoordinator.mapped_system_data()` to use `system.as_dict()` for mapped payloads used by coordinator data, debug logging, diagnostics, and redaction.
- Updated the defensive `TypeError` message to describe the serializer contract rather than the old `__repr__` implementation detail.

## Why
`carrier_api` PR 102 introduces `as_dict()` as the supported model serialization API and restores Python's normal `__repr__()` contract. Without this change, `ha_carrier` would receive a string from `System.__repr__()` after updating `carrier_api`, causing mapped-system redaction and coordinator payload handling to fail.

## Validation
- `./.venv/bin/ruff check custom_components/ha_carrier/carrier_data_update_coordinator.py`
- `./.venv/bin/mypy .`

## Related
- Refs dahlb/carrier_api#102
