### PR TITLE
Fix Carrier API v3 typing compatibility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,11 @@
 # AGENTS
 
-Purpose
+## Purpose
+
 - Provide clear, repo-specific instructions for autonomous agents working in this repository.
 
-General Guidelines
+## General Guidelines
+
 - Follow Home Assistant developer docs: https://developers.home-assistant.io/docs/.
 - Be concise and explain coding steps briefly when making code changes; include code snippets where relevant.
 - For non-trivial edits, provide a short plan. For small, low-risk edits, implement and include a one-line summary.
@@ -11,45 +13,65 @@ General Guidelines
 - Maintain project style and Python 3.14+ compatibility. Target latest Home Assistant core.
 - If deviating from these guidelines, explicitly state which guideline is deviated from and why.
 
-Agent permissions and venv policy
+## Agent permissions and venv policy
+
 - Agents may create and use a repository-local venv at `./.venv` and should reference `./.venv/bin/python` when running commands.
 - Installing packages from repo manifests (e.g., `requirements-dev.txt`, `pyproject.toml`) into `./.venv` is allowed for running tests or local tooling; avoid unrelated network operations without explicit consent.
 
-Folder structure (repo-specific)
+## Folder structure (repo-specific)
+
 - `custom_components/ha_carrier`: integration code.
 - `README.md`: primary documentation.
 
-Project structure expectations
+## Project structure expectations
+
 - Keep code modular: separate files for entity types, services, and utilities.
 - Store constants in `const.py` and use a `config_flow.py` for configuration flows.
 - `ha_carrier` uses the external library `carrier_api` (https://github.com/dahlb/carrier_api & https://pypi.org/project/carrier-api/). This is maintained by the same maintainer as `ha_carrier`.
 - Any changes that require changes to both `ha_carrier` and `carrier_api` will require a branch and PR in both repos.
 
-Coding standards
+## Coding standards
+
 - Add typing annotations to all functions and classes (including return types).
 - Add or update docstrings for all files, classes and methods, including private methods and nested methods. Method docstrings must follow the Google Style.
+- Do not use `cast` or `assert` in the main code. They are ok in tests.
 - Preserve existing comments and keep imports at the top of files.
 - Follow existing repository style; run `./scripts/lint`.
 
-Local tooling note
-- Use the repo's `prek` and `mypy` commands inside `./.venv`. You must always run these inside `./.venv`.
+## Local tooling note
 
-Error handling & logging
+- Use the repo's `prek`, `mypy`, and `pytest` commands inside `./.venv`. You must always run these inside `./.venv`.
+- By default, run the full pytest suite. If running targeted tests, explain why.
+
+## Error handling & logging
+
 - Use Home Assistant's logging framework.
 - Catch specific exceptions (do not catch Exception directly).
 - Add robust error handling and clear debug/info logs.
 - If tests fail due to missing dev dependencies, either install them into `./.venv` (if allowed) or report exact `pip install` commands.
 
-PR & branch behavior
+## Testing
+
+- Use `pytest` and Home Assistant pytest helpers (e.g., `MockConfigEntry`).
+- Add typed, well-documented tests in `tests/` and use fixtures in `conftest.py`.
+- One test module per integration source file; achieve high coverage (target >= 80%).
+- Parameterize tests when appropriate; avoid duplicate test functions.
+
+## PR & branch behavior
+
 - Create branches or PRs only when explicitly requested. Do not open PRs autonomously.
 
-Network / install consent
+## Network / install consent
+
 - Obtain explicit consent before any network operations outside the repository not strictly needed to run local tests.
 - Package installs required for running tests are allowed when user approves.
 
-CI/CD
+## CI/CD
+
 - Use GitHub Actions for CI/CD where applicable.
 
-Conventions for changes and documentation
+## Conventions for changes and documentation
+
 - When editing code, prefer fixing root causes over surface patches.
 - Keep changes minimal and consistent with the codebase style.
+- Add tests for any changed behavior and update documentation if needed.

--- a/custom_components/ha_carrier/__init__.py
+++ b/custom_components/ha_carrier/__init__.py
@@ -118,7 +118,10 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntryCarrie
             while True:
                 try:
                     _LOGGER.debug("websocket task listening")
-                    await coordinator.api_connection.api_websocket.listener()
+                    api_websocket = coordinator.api_connection.api_websocket
+                    if api_websocket is None:
+                        raise RuntimeError("Carrier API websocket client is not initialized")
+                    await api_websocket.listener()
                     _LOGGER.debug("websocket task ending")
                     coordinator.data_flush = True
                     await coordinator.async_request_refresh()

--- a/custom_components/ha_carrier/carrier_data_update_coordinator.py
+++ b/custom_components/ha_carrier/carrier_data_update_coordinator.py
@@ -221,10 +221,11 @@ class CarrierDataUpdateCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
                 self.systems.remove(stale_system)
         if not self._websocket_initialized:
             self.websocket_data_updater = WebsocketDataUpdater(systems=self.systems)
-            self.api_connection.api_websocket.callback_add(
-                self.websocket_data_updater.message_handler
-            )
-            self.api_connection.api_websocket.callback_add(self.updated_callback)
+            api_websocket = self.api_connection.api_websocket
+            if api_websocket is None:
+                raise RuntimeError("Carrier API websocket client is not initialized")
+            api_websocket.callback_add(self.websocket_data_updater.message_handler)
+            api_websocket.callback_add(self.updated_callback)
             self._websocket_initialized = True
         if _LOGGER.isEnabledFor(logging.DEBUG):
             for system in self.systems:

--- a/custom_components/ha_carrier/climate.py
+++ b/custom_components/ha_carrier/climate.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from datetime import datetime
 from functools import partial
 import logging
 from typing import Any
@@ -124,6 +123,20 @@ class CarrierClimate(CarrierZoneEntity, ClimateEntity):
         activity_type = self._config_zone.hold_activity or self._status_zone.current_activity
         return self._config_zone.find_activity(activity_type)
 
+    @property
+    def _required_zone_api_id(self) -> str:
+        """Return this climate entity's required Carrier zone API ID.
+
+        Returns:
+            str: Carrier zone API ID.
+
+        Raises:
+            ValueError: Raised when the zone API ID is unavailable.
+        """
+        if self.zone_api_id is None:
+            raise ValueError("No zone api id defined")
+        return self.zone_api_id
+
     def _preset_mode(self) -> str | None:
         """Return the preset that best matches current zone setpoints.
 
@@ -148,7 +161,7 @@ class CarrierClimate(CarrierZoneEntity, ClimateEntity):
                     self._config_zone.name,
                     self._status_zone.current_activity,
                 )
-                return self._status_zone.current_activity
+                return self._status_zone.current_activity.value
             return current_activity.type.value
 
         _LOGGER.debug(
@@ -168,7 +181,7 @@ class CarrierClimate(CarrierZoneEntity, ClimateEntity):
                 self._config_zone.name,
                 self._status_zone.current_activity,
             )
-            return self._status_zone.current_activity
+            return self._status_zone.current_activity.value
         return current_activity.type.value
 
     def _update_entity_attrs(self) -> None:
@@ -371,11 +384,11 @@ class Thermostat(CarrierClimate):
         self._write_local_state()
 
     @property
-    def _hold_until(self) -> datetime | None:
+    def _hold_until(self) -> str | None:
         """Return hold end time based on integration hold preference.
 
         Returns:
-            datetime | None: Next schedule transition or None for an indefinite hold.
+            str | None: Next schedule transition or None for an indefinite hold.
         """
         _LOGGER.debug(
             "infinite_hold: %s; holding until: %s",
@@ -399,7 +412,7 @@ class Thermostat(CarrierClimate):
                 partial(
                     self.coordinator.api_connection.resume_schedule,
                     system_serial=self.carrier_system.profile.serial,
-                    zone_id=self.zone_api_id,
+                    zone_id=self._required_zone_api_id,
                 ),
             )
             self.coordinator.data_flush = True
@@ -414,14 +427,14 @@ class Thermostat(CarrierClimate):
             partial(
                 self.coordinator.api_connection.set_config_hold,
                 system_serial=self.carrier_system.profile.serial,
-                zone_id=self.zone_api_id,
+                zone_id=self._required_zone_api_id,
                 activity_type=activity_type,
                 hold_until=hold_until_sent,
             ),
         )
         self._config_zone.hold = True
         self._config_zone.hold_activity = activity_type
-        self._config_zone.hold_until = hold_until_sent
+        self._config_zone.hold_until = hold_until_sent or ""
         if selected_activity is not None:
             self._status_zone.heat_set_point = selected_activity.heat_set_point
             self._status_zone.cool_set_point = selected_activity.cool_set_point
@@ -446,7 +459,7 @@ class Thermostat(CarrierClimate):
             partial(
                 self.coordinator.api_connection.update_fan,
                 system_serial=self.carrier_system.profile.serial,
-                zone_id=self.zone_api_id,
+                zone_id=self._required_zone_api_id,
                 activity_type=current_activity.type,
                 fan_mode=selected_fan_mode,
             ),
@@ -499,7 +512,7 @@ class Thermostat(CarrierClimate):
             partial(
                 self.coordinator.api_connection.set_config_manual_activity,
                 system_serial=self.carrier_system.profile.serial,
-                zone_id=self.zone_api_id,
+                zone_id=self._required_zone_api_id,
                 heat_set_point=str(heat_set_point),
                 cool_set_point=str(cool_set_point),
                 fan_mode=fan_mode,
@@ -510,7 +523,7 @@ class Thermostat(CarrierClimate):
             partial(
                 self.coordinator.api_connection.set_config_hold,
                 system_serial=self.carrier_system.profile.serial,
-                zone_id=self.zone_api_id,
+                zone_id=self._required_zone_api_id,
                 activity_type=ActivityTypes.MANUAL,
                 hold_until=hold_until_sent,
             ),
@@ -518,7 +531,7 @@ class Thermostat(CarrierClimate):
 
         self._config_zone.hold = True
         self._config_zone.hold_activity = ActivityTypes.MANUAL
-        self._config_zone.hold_until = hold_until_sent
+        self._config_zone.hold_until = hold_until_sent or ""
         manual_activity.cool_set_point = cool_set_point
         manual_activity.heat_set_point = heat_set_point
         self._status_zone.cool_set_point = cool_set_point

--- a/custom_components/ha_carrier/migrate.py
+++ b/custom_components/ha_carrier/migrate.py
@@ -343,12 +343,13 @@ def _async_build_unique_id_migration_map(
             )
 
         fuel_type = carrier_system.config.fuel_type
-        _async_add_unique_id_migration(
-            migration_map,
-            system_serial,
-            f"{fuel_type.capitalize()} Yearly",
-            f"{fuel_type.capitalize()} Usage Year to Date",
-        )
+        if fuel_type is not None:
+            _async_add_unique_id_migration(
+                migration_map,
+                system_serial,
+                f"{fuel_type.capitalize()} Yearly",
+                f"{fuel_type.capitalize()} Usage Year to Date",
+            )
         _async_add_unique_id_migration(
             migration_map,
             system_serial,
@@ -430,14 +431,15 @@ def _async_build_created_unique_ids(systems: Iterable[System]) -> set[str]:
                     _async_new_unique_id(system_serial, f"{metric_title} Energy Last Month")
                 )
 
-        if getattr(carrier_system.energy, "gas", False) is True:
+        fuel_type = carrier_system.config.fuel_type
+        if getattr(carrier_system.energy, "gas", False) is True and fuel_type is not None:
             created_unique_ids.add(
                 _async_new_unique_id(
                     system_serial,
-                    f"{carrier_system.config.fuel_type.capitalize()} Usage Year to Date",
+                    f"{fuel_type.capitalize()} Usage Year to Date",
                 )
             )
-            if carrier_system.config.fuel_type == "propane":
+            if fuel_type == "propane":
                 created_unique_ids.add(
                     _async_new_unique_id(system_serial, "Propane Consumption Year to Date")
                 )

--- a/custom_components/ha_carrier/select.py
+++ b/custom_components/ha_carrier/select.py
@@ -135,7 +135,7 @@ class HeatSourceSelect(CarrierSelect):
             ),
             HeatSourceTypes.ODU_ONLY.value: HEAT_SOURCE_ODU_ONLY_LABEL,
             HeatSourceTypes.SYSTEM.value: HEAT_SOURCE_SYSTEM_LABEL,
-        }.get(self.carrier_system.config.heat_source)
+        }.get(self.carrier_system.config.heat_source or "")
         self._attr_available = self._attr_current_option is not None
 
     async def async_select_option(self, option: str) -> None:

--- a/custom_components/ha_carrier/sensor.py
+++ b/custom_components/ha_carrier/sensor.py
@@ -113,15 +113,16 @@ async def async_setup_entry(
                     ]
                 )
         gas_measurement = getattr(carrier_system.energy, "gas", False)
-        if gas_measurement is True:
+        fuel_type = carrier_system.config.fuel_type
+        if gas_measurement is True and fuel_type is not None:
             entities.append(
                 GasMeasurementSensor(
                     coordinator=coordinator,
                     system_serial=carrier_system.profile.serial,
-                    fuel_type=carrier_system.config.fuel_type,
+                    fuel_type=fuel_type,
                 )
             )
-            if carrier_system.config.fuel_type == "propane":
+            if fuel_type == "propane":
                 entities.append(
                     PropaneMeasurementSensor(
                         coordinator=coordinator, system_serial=carrier_system.profile.serial

--- a/tests/test_carrier_data_update_coordinator.py
+++ b/tests/test_carrier_data_update_coordinator.py
@@ -34,7 +34,7 @@ async def test_initial_full_refresh_preserves_systems_list_identity(
     fresh_systems = [build_carrier_system()]
     carrier_api.systems = fresh_systems
     coordinator.systems = systems
-    coordinator.api_connection = carrier_api
+    coordinator.api_connection = cast("Any", carrier_api)
     coordinator.resiliency = ResiliencyState(
         unauthorized_threshold=UNAUTHORIZED_RETRY_THRESHOLD,
         transient_threshold=TRANSIENT_FAILURE_THRESHOLD,
@@ -54,7 +54,7 @@ async def test_energy_refresh_uses_cycle_scoped_success_reset(
     """Preserve resiliency state across per-system energy successes."""
     coordinator = CarrierDataUpdateCoordinator.__new__(CarrierDataUpdateCoordinator)
     coordinator.systems = [build_carrier_system()]
-    coordinator.api_connection = carrier_api
+    coordinator.api_connection = cast("Any", carrier_api)
     coordinator.resiliency = cast(
         "Any",
         SimpleNamespace(
@@ -226,7 +226,7 @@ async def test_full_refresh_merges_new_changed_and_stale_systems(
     fresh_new = build_carrier_system(serial="NEW123", name="New")
     carrier_api.systems = [fresh_existing, fresh_new]
     coordinator.systems = [existing, stale]
-    coordinator.api_connection = carrier_api
+    coordinator.api_connection = cast("Any", carrier_api)
     coordinator.resiliency = ResiliencyState(
         unauthorized_threshold=UNAUTHORIZED_RETRY_THRESHOLD,
         transient_threshold=TRANSIENT_FAILURE_THRESHOLD,
@@ -253,7 +253,7 @@ async def test_energy_refresh_records_one_unauthorized_per_cycle(
         build_carrier_system(serial="DEF456"),
     ]
     coordinator.systems = systems
-    coordinator.api_connection = carrier_api
+    coordinator.api_connection = cast("Any", carrier_api)
     coordinator.resiliency = ResiliencyState(unauthorized_threshold=2, transient_threshold=3)
     coordinator.update_interval = None
 
@@ -279,7 +279,7 @@ async def test_energy_refresh_escalates_after_threshold(
     """Raise CarrierUnauthorizedError once the energy-cycle auth threshold is crossed."""
     coordinator = CarrierDataUpdateCoordinator.__new__(CarrierDataUpdateCoordinator)
     coordinator.systems = [build_carrier_system()]
-    coordinator.api_connection = carrier_api
+    coordinator.api_connection = cast("Any", carrier_api)
     coordinator.resiliency = ResiliencyState(unauthorized_threshold=1, transient_threshold=3)
     coordinator.update_interval = None
 


### PR DESCRIPTION
## Summary
Updates the Carrier integration for the current `carrier_api` v3 type surface and refreshes repo-specific agent guidance.

## What Changed
- Added explicit `None` guards where `carrier_api` now exposes optional websocket and fuel/heat-source values.
- Normalized Carrier enum/string handling in climate preset and hold paths.
- Kept migration and sensor entity creation from assuming fuel type is always present.
- Updated `AGENTS.md` with the repository's current structure, tooling, and `carrier_api` dependency notes.

## Why
`carrier_api` v3 tightened several model annotations, which exposed places where `ha_carrier` assumed values were always populated. The integration already treats these values as runtime invariants or optional data depending on the code path, so this PR makes those assumptions explicit and keeps mypy aligned with the real behavior.
