### PR TITLE
Use Carrier API exception taxonomy

### DIFF
--- a/custom_components/ha_carrier/__init__.py
+++ b/custom_components/ha_carrier/__init__.py
@@ -3,8 +3,7 @@
 import asyncio
 import logging
 
-from carrier_api import ApiConnectionGraphql
-from gql.transport.exceptions import TransportServerError
+from carrier_api import ApiConnectionGraphql, CarrierApiConnectionError
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
@@ -188,8 +187,8 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntryCarrie
     except CarrierUnauthorizedError as error:
         _LOGGER.exception("Carrier unauthorized during setup")
         raise ConfigEntryAuthFailed("Carrier API rejected credentials during setup.") from error
-    except TransportServerError as error:
-        _LOGGER.exception("Carrier transport error during setup")
+    except CarrierApiConnectionError as error:
+        _LOGGER.exception("Carrier connection error during setup")
         raise ConfigEntryNotReady(error) from error
     except (
         asyncio.CancelledError,

--- a/custom_components/ha_carrier/carrier_data_update_coordinator.py
+++ b/custom_components/ha_carrier/carrier_data_update_coordinator.py
@@ -7,9 +7,8 @@ import functools
 import logging
 from typing import Any, NoReturn
 
-from carrier_api import ApiConnectionGraphql, AuthError, BaseError, Energy, System
+from carrier_api import ApiConnectionGraphql, CarrierApiError, Energy, System
 from carrier_api.api_websocket_data_updater import WebsocketDataUpdater
-from gql.transport.exceptions import TransportServerError
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
 from homeassistant.helpers.debounce import Debouncer
@@ -158,7 +157,7 @@ class CarrierDataUpdateCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
         except RECOVERABLE_REFRESH_EXCEPTIONS as error:
             self.data_flush = True
             self.update_interval = timedelta(minutes=1)
-            if isinstance(error, TransportServerError) and is_unauthorized_error(error):
+            if is_unauthorized_error(error):
                 _LOGGER.info(
                     "Carrier %s returned unauthorized without crossing the reauth threshold.",
                     refresh_context,
@@ -407,7 +406,7 @@ class CarrierDataUpdateCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
             raise HomeAssistantError(
                 "Failed to communicate with Carrier service — operation could not be completed."
             ) from error
-        except (AuthError, BaseError) as error:
+        except CarrierApiError as error:
             await self._async_reconcile_failed_write(operation_name, error)
             raise HomeAssistantError(
                 "Carrier rejected the request. Check the requested setting and try again."

--- a/custom_components/ha_carrier/carrier_data_update_coordinator.py
+++ b/custom_components/ha_carrier/carrier_data_update_coordinator.py
@@ -289,9 +289,9 @@ class CarrierDataUpdateCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
     async def _async_handle_failed_write(
         self,
         operation_name: str,
-        error: Exception,
+        error: CarrierUnauthorizedError,
     ) -> NoReturn:
-        """Recover from an exhausted retryable write and raise a HA error.
+        """Recover from an exhausted unauthorized write and raise a HA error.
 
         Forces a refresh so entity state is reconciled with the Carrier backend
         before surfacing the failure to the user. If reconciliation succeeds,
@@ -301,27 +301,19 @@ class CarrierDataUpdateCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
 
         Args:
             operation_name: Friendly name for the write operation that failed.
-            error: Exception raised by the Carrier API client. Either a
-                CarrierUnauthorizedError (already escalated by the helper) or
-                a TimeoutError that exhausted retries.
+            error: Unauthorized error raised after retry handling.
 
         Raises:
-            HomeAssistantError: Raised with a message tailored to the failure type.
+            HomeAssistantError: Raised with a retry-later message.
         """
-        is_unauthorized = isinstance(error, CarrierUnauthorizedError)
         await self._async_reconcile_failed_write(operation_name, error)
 
-        if is_unauthorized:
-            # The write crossed the auth threshold, but reconciliation may have
-            # already cleared stale counters. Reauth is left to a fresh failed
-            # refresh so one recovered write outage does not force credentials
-            # invalid.
-            raise HomeAssistantError(
-                "Carrier rejected repeated write attempts. Try again shortly."
-            ) from error
-
+        # The write crossed the auth threshold, but reconciliation may have
+        # already cleared stale counters. Reauth is left to a fresh failed
+        # refresh so one recovered write outage does not force credentials
+        # invalid.
         raise HomeAssistantError(
-            "Carrier timed out while applying the request. Try again shortly."
+            "Carrier rejected repeated write attempts. Try again shortly."
         ) from error
 
     async def _async_reconcile_failed_write(
@@ -398,9 +390,6 @@ class CarrierDataUpdateCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
             SystemExit,
         ):
             raise
-        except TimeoutError as error:
-            await self._async_handle_failed_write(operation_name, error)
-            raise AssertionError("unreachable after failed write handling") from error
         except RECOVERABLE_WRITE_COMMUNICATION_EXCEPTIONS as error:
             await self._async_reconcile_failed_write(operation_name, error)
             raise HomeAssistantError(

--- a/custom_components/ha_carrier/config_flow.py
+++ b/custom_components/ha_carrier/config_flow.py
@@ -44,7 +44,7 @@ async def _async_validate_credentials(
     try:
         api_connection = ApiConnectionGraphql(username=username, password=password)
         identity_id = await async_get_carrier_identity_id(api_connection)
-    except CarrierApiError as error:
+    except (CarrierApiError, TimeoutError, OSError) as error:
         if is_unauthorized_error(error):
             return {"base": ERROR_AUTH}, None
         if is_transient_transport_error(error):
@@ -58,7 +58,7 @@ async def _async_validate_credentials(
         if api_connection is not None:
             try:
                 await api_connection.cleanup()
-            except CarrierApiError:
+            except CarrierApiError, TimeoutError, OSError:
                 _LOGGER.exception(
                     "Failed to clean up Carrier API connection after credential validation"
                 )

--- a/custom_components/ha_carrier/config_flow.py
+++ b/custom_components/ha_carrier/config_flow.py
@@ -44,7 +44,7 @@ async def _async_validate_credentials(
     try:
         api_connection = ApiConnectionGraphql(username=username, password=password)
         identity_id = await async_get_carrier_identity_id(api_connection)
-    except (CarrierApiError, TimeoutError, OSError) as error:
+    except CarrierApiError as error:
         if is_unauthorized_error(error):
             return {"base": ERROR_AUTH}, None
         if is_transient_transport_error(error):
@@ -58,7 +58,7 @@ async def _async_validate_credentials(
         if api_connection is not None:
             try:
                 await api_connection.cleanup()
-            except CarrierApiError, TimeoutError, OSError:
+            except CarrierApiError:
                 _LOGGER.exception(
                     "Failed to clean up Carrier API connection after credential validation"
                 )

--- a/custom_components/ha_carrier/config_flow.py
+++ b/custom_components/ha_carrier/config_flow.py
@@ -5,9 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from aiohttp import ClientError
-from carrier_api import ApiConnectionGraphql, AuthError, BaseError
-from gql.transport.exceptions import TransportError
+from carrier_api import ApiConnectionGraphql, CarrierApiError
 from homeassistant.config_entries import ConfigEntry, ConfigFlow, ConfigFlowResult, OptionsFlow
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import callback
@@ -46,7 +44,7 @@ async def _async_validate_credentials(
     try:
         api_connection = ApiConnectionGraphql(username=username, password=password)
         identity_id = await async_get_carrier_identity_id(api_connection)
-    except (AuthError, BaseError, ClientError, TransportError, OSError, TimeoutError) as error:
+    except CarrierApiError as error:
         if is_unauthorized_error(error):
             return {"base": ERROR_AUTH}, None
         if is_transient_transport_error(error):
@@ -60,7 +58,7 @@ async def _async_validate_credentials(
         if api_connection is not None:
             try:
                 await api_connection.cleanup()
-            except AuthError, BaseError, ClientError, TransportError, OSError, TimeoutError:
+            except CarrierApiError:
                 _LOGGER.exception(
                     "Failed to clean up Carrier API connection after credential validation"
                 )

--- a/custom_components/ha_carrier/manifest.json
+++ b/custom_components/ha_carrier/manifest.json
@@ -14,7 +14,7 @@
     "carrier_api"
   ],
   "requirements": [
-    "carrier-api==3.0.0"
+    "carrier-api==3.1.0"
   ],
   "version": "2.23.3"
 }

--- a/custom_components/ha_carrier/migrate.py
+++ b/custom_components/ha_carrier/migrate.py
@@ -574,11 +574,7 @@ async def migrate_1_to_2(hass: HomeAssistant, config_entry: ConfigEntry) -> bool
         )
         systems = await api_connection.load_data()
         systems_loaded = True
-    except (
-        CarrierApiError,
-        TimeoutError,
-        OSError,
-    ):
+    except CarrierApiError:
         _LOGGER.warning(
             "Unable to load Carrier data for config entry migration; "
             "continuing without destructive entity registry cleanup",
@@ -646,11 +642,7 @@ async def migrate_2_to_3(hass: HomeAssistant, config_entry: ConfigEntry) -> bool
             password=config_entry.data[CONF_PASSWORD],
         )
         identity_id = await async_get_carrier_identity_id(api_connection)
-    except (
-        CarrierApiError,
-        TimeoutError,
-        OSError,
-    ) as error:
+    except CarrierApiError as error:
         _LOGGER.warning(
             "Unable to load Carrier user identity for config entry migration; "
             "will retry on next startup. %s: %s",
@@ -662,11 +654,7 @@ async def migrate_2_to_3(hass: HomeAssistant, config_entry: ConfigEntry) -> bool
         if api_connection is not None:
             try:
                 await api_connection.cleanup()
-            except (
-                CarrierApiError,
-                TimeoutError,
-                OSError,
-            ):
+            except CarrierApiError:
                 _LOGGER.exception(
                     "Failed to clean up Carrier API connection after config entry migration."
                 )

--- a/custom_components/ha_carrier/migrate.py
+++ b/custom_components/ha_carrier/migrate.py
@@ -5,9 +5,7 @@ from __future__ import annotations
 from collections.abc import Iterable, Mapping
 import logging
 
-from aiohttp import ClientError
-from carrier_api import ApiConnectionGraphql, AuthError, BaseError, System
-from gql.transport.exceptions import TransportError
+from carrier_api import ApiConnectionGraphql, CarrierApiError, System
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
@@ -576,14 +574,7 @@ async def migrate_1_to_2(hass: HomeAssistant, config_entry: ConfigEntry) -> bool
         )
         systems = await api_connection.load_data()
         systems_loaded = True
-    except (
-        AuthError,
-        BaseError,
-        ClientError,
-        TimeoutError,
-        OSError,
-        TransportError,
-    ):
+    except CarrierApiError:
         _LOGGER.warning(
             "Unable to load Carrier data for config entry migration; "
             "continuing without destructive entity registry cleanup",
@@ -651,14 +642,7 @@ async def migrate_2_to_3(hass: HomeAssistant, config_entry: ConfigEntry) -> bool
             password=config_entry.data[CONF_PASSWORD],
         )
         identity_id = await async_get_carrier_identity_id(api_connection)
-    except (
-        AuthError,
-        BaseError,
-        ClientError,
-        TimeoutError,
-        OSError,
-        TransportError,
-    ) as error:
+    except CarrierApiError as error:
         _LOGGER.warning(
             "Unable to load Carrier user identity for config entry migration; "
             "will retry on next startup. %s: %s",
@@ -670,14 +654,7 @@ async def migrate_2_to_3(hass: HomeAssistant, config_entry: ConfigEntry) -> bool
         if api_connection is not None:
             try:
                 await api_connection.cleanup()
-            except (
-                AuthError,
-                BaseError,
-                ClientError,
-                TimeoutError,
-                OSError,
-                TransportError,
-            ):
+            except CarrierApiError:
                 _LOGGER.exception(
                     "Failed to clean up Carrier API connection after config entry migration."
                 )

--- a/custom_components/ha_carrier/migrate.py
+++ b/custom_components/ha_carrier/migrate.py
@@ -574,7 +574,11 @@ async def migrate_1_to_2(hass: HomeAssistant, config_entry: ConfigEntry) -> bool
         )
         systems = await api_connection.load_data()
         systems_loaded = True
-    except CarrierApiError:
+    except (
+        CarrierApiError,
+        TimeoutError,
+        OSError,
+    ):
         _LOGGER.warning(
             "Unable to load Carrier data for config entry migration; "
             "continuing without destructive entity registry cleanup",
@@ -642,7 +646,11 @@ async def migrate_2_to_3(hass: HomeAssistant, config_entry: ConfigEntry) -> bool
             password=config_entry.data[CONF_PASSWORD],
         )
         identity_id = await async_get_carrier_identity_id(api_connection)
-    except CarrierApiError as error:
+    except (
+        CarrierApiError,
+        TimeoutError,
+        OSError,
+    ) as error:
         _LOGGER.warning(
             "Unable to load Carrier user identity for config entry migration; "
             "will retry on next startup. %s: %s",
@@ -654,7 +662,11 @@ async def migrate_2_to_3(hass: HomeAssistant, config_entry: ConfigEntry) -> bool
         if api_connection is not None:
             try:
                 await api_connection.cleanup()
-            except CarrierApiError:
+            except (
+                CarrierApiError,
+                TimeoutError,
+                OSError,
+            ):
                 _LOGGER.exception(
                     "Failed to clean up Carrier API connection after config entry migration."
                 )

--- a/custom_components/ha_carrier/migrate.py
+++ b/custom_components/ha_carrier/migrate.py
@@ -566,6 +566,7 @@ async def migrate_1_to_2(hass: HomeAssistant, config_entry: ConfigEntry) -> bool
         bool: True when entity registry migration and config entry version
             update succeed.
     """
+    api_connection: ApiConnectionGraphql | None = None
     systems_loaded = False
     try:
         api_connection = ApiConnectionGraphql(
@@ -581,6 +582,14 @@ async def migrate_1_to_2(hass: HomeAssistant, config_entry: ConfigEntry) -> bool
             exc_info=True,
         )
         systems = []
+    finally:
+        if api_connection is not None:
+            try:
+                await api_connection.cleanup()
+            except CarrierApiError:
+                _LOGGER.exception(
+                    "Failed to clean up Carrier API connection after config entry migration."
+                )
 
     if systems_loaded and not systems:
         _LOGGER.warning(

--- a/custom_components/ha_carrier/util.py
+++ b/custom_components/ha_carrier/util.py
@@ -58,6 +58,8 @@ TRANSIENT_TRANSPORT_EXCEPTIONS: tuple[type[BaseException], ...] = (
     CarrierApiConnectionError,
     CarrierApiTokenRefreshError,
     CarrierApiWebsocketError,
+    TimeoutError,
+    OSError,
 )
 
 # Exceptions a coordinator refresh may recover from on a later interval.
@@ -105,6 +107,8 @@ async def async_get_carrier_identity_id(api_connection: ApiConnectionGraphql) ->
     Raises:
         CarrierApiAuthError: Credentials were rejected by the Carrier API.
         CarrierApiError: The Carrier API client reported a non-auth error.
+        OSError: A socket-level error occurred while talking to Carrier.
+        TimeoutError: The request timed out before a response arrived.
     """
     await api_connection.load_data()
     user_info = await api_connection.get_user_info()

--- a/custom_components/ha_carrier/util.py
+++ b/custom_components/ha_carrier/util.py
@@ -58,8 +58,6 @@ TRANSIENT_TRANSPORT_EXCEPTIONS: tuple[type[BaseException], ...] = (
     CarrierApiConnectionError,
     CarrierApiTokenRefreshError,
     CarrierApiWebsocketError,
-    TimeoutError,
-    OSError,
 )
 
 # Exceptions a coordinator refresh may recover from on a later interval.
@@ -108,8 +106,6 @@ async def async_get_carrier_identity_id(api_connection: ApiConnectionGraphql) ->
     Raises:
         CarrierApiAuthError: Credentials were rejected by the Carrier API.
         CarrierApiError: The Carrier API client reported a non-auth error.
-        OSError: A socket-level error occurred while talking to Carrier.
-        TimeoutError: The request timed out before a response arrived.
     """
     await api_connection.load_data()
     user_info = await api_connection.get_user_info()

--- a/custom_components/ha_carrier/util.py
+++ b/custom_components/ha_carrier/util.py
@@ -1,11 +1,4 @@
-"""Utility helpers shared across Carrier integration modules.
-
-`TransportServerError` is intentionally not a transient transport exception
-because 401 server responses must be classified by `is_unauthorized_error`
-before retry logic considers communication recovery. Call-site recoverable
-exception tuples include `TransportServerError` explicitly where server errors
-should still be reconciled or retried on a later interval.
-"""
+"""Utility helpers shared across Carrier integration modules."""
 
 from __future__ import annotations
 
@@ -13,9 +6,15 @@ from collections.abc import Iterable, Mapping
 import logging
 from typing import Any, overload
 
-from aiohttp import ClientError
-from carrier_api import ApiConnectionGraphql, AuthError, BaseError, System
-from gql.transport.exceptions import TransportError, TransportProtocolError, TransportServerError
+from carrier_api import (
+    ApiConnectionGraphql,
+    CarrierApiAuthError,
+    CarrierApiConnectionError,
+    CarrierApiError,
+    CarrierApiTokenRefreshError,
+    CarrierApiWebsocketError,
+    System,
+)
 from homeassistant.core import callback
 
 from .exceptions import CarrierUnauthorizedError
@@ -56,34 +55,27 @@ TIMESTAMP_TYPES: tuple[str, ...] = ("all_data", "websocket", "energy")
 
 # Transport-layer exceptions that should retry with backoff.
 TRANSIENT_TRANSPORT_EXCEPTIONS: tuple[type[BaseException], ...] = (
-    ClientError,
-    TimeoutError,
-    OSError,
-    TransportProtocolError,
+    CarrierApiConnectionError,
+    CarrierApiTokenRefreshError,
+    CarrierApiWebsocketError,
 )
 
 # Exceptions a coordinator refresh may recover from on a later interval.
 RECOVERABLE_REFRESH_EXCEPTIONS: tuple[type[BaseException], ...] = (
     *TRANSIENT_TRANSPORT_EXCEPTIONS,
-    TransportError,
-    TransportServerError,
-    AuthError,
-    BaseError,
+    CarrierApiAuthError,
+    CarrierApiError,
 )
 
 # Transport exceptions a write should report as communication failures.
 RECOVERABLE_WRITE_COMMUNICATION_EXCEPTIONS: tuple[type[BaseException], ...] = (
     *TRANSIENT_TRANSPORT_EXCEPTIONS,
-    TransportError,
-    TransportServerError,
 )
 
 # Exceptions the websocket reconnect loop should treat as recoverable.
 WEBSOCKET_RECOVERABLE_EXCEPTIONS: tuple[type[BaseException], ...] = (
     CarrierUnauthorizedError,
     *TRANSIENT_TRANSPORT_EXCEPTIONS,
-    TransportError,
-    TransportServerError,
 )
 
 # Carrier websocket payload/data-shape errors that should trigger reconciliation.
@@ -111,12 +103,8 @@ async def async_get_carrier_identity_id(api_connection: ApiConnectionGraphql) ->
             valid, otherwise ``None``.
 
     Raises:
-        AuthError: Credentials were rejected by the Carrier API.
-        BaseError: The Carrier API client reported a non-auth error.
-        ClientError: The underlying HTTP client failed.
-        TransportError: The GraphQL transport layer reported an error.
-        OSError: A socket-level error occurred while talking to Carrier.
-        TimeoutError: The request timed out before a response arrived.
+        CarrierApiAuthError: Credentials were rejected by the Carrier API.
+        CarrierApiError: The Carrier API client reported a non-auth error.
     """
     await api_connection.load_data()
     user_info = await api_connection.get_user_info()
@@ -228,12 +216,8 @@ def is_unauthorized_error(error: BaseException) -> bool:
         bool: True when the error or one of its causes is a 401.
     """
     for current in _iter_exception_chain(error):
-        if isinstance(current, CarrierUnauthorizedError | AuthError):
+        if isinstance(current, CarrierUnauthorizedError | CarrierApiAuthError):
             return True
-        if isinstance(current, TransportServerError):
-            status_code = getattr(current, "code", None) or getattr(current, "status", None)
-            if status_code == 401:
-                return True
     return False
 
 

--- a/custom_components/ha_carrier/util.py
+++ b/custom_components/ha_carrier/util.py
@@ -77,6 +77,7 @@ RECOVERABLE_WRITE_COMMUNICATION_EXCEPTIONS: tuple[type[BaseException], ...] = (
 # Exceptions the websocket reconnect loop should treat as recoverable.
 WEBSOCKET_RECOVERABLE_EXCEPTIONS: tuple[type[BaseException], ...] = (
     CarrierUnauthorizedError,
+    CarrierApiAuthError,
     *TRANSIENT_TRANSPORT_EXCEPTIONS,
 )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ version = { attr = "custom_components.ha_carrier.const.VERSION" }
 
 [dependency-groups]
 ha = [
-    "carrier-api==3.0.0",
+    "carrier-api==3.1.0",
     "homeassistant",
 ]
 lint = [

--- a/tests/test_carrier_data_update_coordinator.py
+++ b/tests/test_carrier_data_update_coordinator.py
@@ -6,7 +6,7 @@ from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import patch
 
-from gql.transport.exceptions import TransportServerError
+from carrier_api import CarrierApiAuthError, CarrierApiGraphqlError
 from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
 from homeassistant.helpers.update_coordinator import UpdateFailed
 import pytest
@@ -174,6 +174,41 @@ async def test_recoverable_write_communication_error_reconciles_and_raises_ha_er
 
 
 @pytest.mark.asyncio
+async def test_carrier_api_write_rejection_reconciles_and_raises_ha_error() -> None:
+    """Surface Carrier API business rejections as Home Assistant errors."""
+    coordinator = CarrierDataUpdateCoordinator.__new__(CarrierDataUpdateCoordinator)
+    coordinator.resiliency = ResiliencyState(unauthorized_threshold=3, transient_threshold=3)
+    reconciled = False
+
+    async def request() -> None:
+        """Raise a Carrier API GraphQL rejection."""
+        raise CarrierApiGraphqlError("rejected")
+
+    async def fake_reconcile(
+        self: CarrierDataUpdateCoordinator,
+        operation_name: str,
+        error: BaseException | None = None,
+    ) -> None:
+        """Record reconciliation after the failed write."""
+        nonlocal reconciled
+        assert operation_name == "set mode"
+        assert isinstance(error, CarrierApiGraphqlError)
+        reconciled = True
+
+    with (
+        patch.object(
+            CarrierDataUpdateCoordinator,
+            "_async_reconcile_failed_write",
+            fake_reconcile,
+        ),
+        pytest.raises(HomeAssistantError, match="Carrier rejected the request"),
+    ):
+        await coordinator.async_perform_api_call("set mode", request)
+
+    assert reconciled is True
+
+
+@pytest.mark.asyncio
 async def test_update_data_translates_unauthorized_refresh_to_reauth() -> None:
     """Escalate a fresh unauthorized refresh failure to HA reauthentication."""
     coordinator = CarrierDataUpdateCoordinator.__new__(CarrierDataUpdateCoordinator)
@@ -202,7 +237,7 @@ async def test_update_data_keeps_plain_unauthorized_server_error_retryable() -> 
 
     async def fake_full_refresh() -> None:
         """Raise a 401 transport response before resiliency escalation."""
-        raise TransportServerError("unauthorized", code=401)
+        raise CarrierApiAuthError("unauthorized")
 
     with (
         patch.object(coordinator, "_async_full_refresh", fake_full_refresh),
@@ -259,7 +294,7 @@ async def test_energy_refresh_records_one_unauthorized_per_cycle(
 
     async def fake_retry(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
         """Raise unauthorized for every per-system energy request."""
-        raise TransportServerError("unauthorized", code=401)
+        raise CarrierApiAuthError("unauthorized")
 
     with patch(
         "custom_components.ha_carrier.carrier_data_update_coordinator.async_call_with_retry",
@@ -285,7 +320,7 @@ async def test_energy_refresh_escalates_after_threshold(
 
     async def fake_retry(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
         """Raise unauthorized for the energy request."""
-        raise TransportServerError("unauthorized", code=401)
+        raise CarrierApiAuthError("unauthorized")
 
     with (
         patch(

--- a/tests/test_carrier_data_update_coordinator.py
+++ b/tests/test_carrier_data_update_coordinator.py
@@ -250,27 +250,6 @@ async def test_update_data_keeps_plain_unauthorized_server_error_retryable() -> 
 
 
 @pytest.mark.asyncio
-async def test_update_data_maps_raw_timeout_refresh_to_update_failed() -> None:
-    """Keep raw refresh timeouts on the Home Assistant retry cadence."""
-    coordinator = CarrierDataUpdateCoordinator.__new__(CarrierDataUpdateCoordinator)
-    coordinator.data_flush = True
-    coordinator.update_interval = None
-
-    async def fake_full_refresh() -> None:
-        """Raise a raw timeout from the refresh path."""
-        raise TimeoutError("temporary")
-
-    with (
-        patch.object(coordinator, "_async_full_refresh", fake_full_refresh),
-        pytest.raises(UpdateFailed, match="Unexpected error during Carrier full data refresh"),
-    ):
-        await coordinator._async_update_data()
-
-    assert coordinator.data_flush is True
-    assert coordinator.update_interval is not None
-
-
-@pytest.mark.asyncio
 async def test_full_refresh_merges_new_changed_and_stale_systems(
     carrier_api: FakeCarrierApiConnection,
 ) -> None:

--- a/tests/test_carrier_data_update_coordinator.py
+++ b/tests/test_carrier_data_update_coordinator.py
@@ -250,6 +250,27 @@ async def test_update_data_keeps_plain_unauthorized_server_error_retryable() -> 
 
 
 @pytest.mark.asyncio
+async def test_update_data_maps_raw_timeout_refresh_to_update_failed() -> None:
+    """Keep raw refresh timeouts on the Home Assistant retry cadence."""
+    coordinator = CarrierDataUpdateCoordinator.__new__(CarrierDataUpdateCoordinator)
+    coordinator.data_flush = True
+    coordinator.update_interval = None
+
+    async def fake_full_refresh() -> None:
+        """Raise a raw timeout from the refresh path."""
+        raise TimeoutError("temporary")
+
+    with (
+        patch.object(coordinator, "_async_full_refresh", fake_full_refresh),
+        pytest.raises(UpdateFailed, match="Unexpected error during Carrier full data refresh"),
+    ):
+        await coordinator._async_update_data()
+
+    assert coordinator.data_flush is True
+    assert coordinator.update_interval is not None
+
+
+@pytest.mark.asyncio
 async def test_full_refresh_merges_new_changed_and_stale_systems(
     carrier_api: FakeCarrierApiConnection,
 ) -> None:

--- a/tests/test_carrier_data_update_coordinator.py
+++ b/tests/test_carrier_data_update_coordinator.py
@@ -6,7 +6,7 @@ from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import patch
 
-from carrier_api import CarrierApiAuthError, CarrierApiGraphqlError
+from carrier_api import CarrierApiAuthError, CarrierApiConnectionError, CarrierApiGraphqlError
 from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
 from homeassistant.helpers.update_coordinator import UpdateFailed
 import pytest
@@ -146,8 +146,8 @@ async def test_recoverable_write_communication_error_reconciles_and_raises_ha_er
     reconciled = False
 
     async def request() -> None:
-        """Raise a retryable write timeout."""
-        raise TimeoutError("timeout")
+        """Raise a retryable write communication failure."""
+        raise CarrierApiConnectionError("timeout")
 
     async def fake_reconcile(
         self: CarrierDataUpdateCoordinator,
@@ -157,7 +157,7 @@ async def test_recoverable_write_communication_error_reconciles_and_raises_ha_er
         """Record reconciliation after the failed write."""
         nonlocal reconciled
         assert operation_name == "set mode"
-        assert isinstance(error, TimeoutError)
+        assert isinstance(error, CarrierApiConnectionError)
         reconciled = True
 
     with (
@@ -166,7 +166,7 @@ async def test_recoverable_write_communication_error_reconciles_and_raises_ha_er
             "_async_reconcile_failed_write",
             fake_reconcile,
         ),
-        pytest.raises(HomeAssistantError, match="timed out"),
+        pytest.raises(HomeAssistantError, match="Failed to communicate"),
     ):
         await coordinator.async_perform_api_call("set mode", request)
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -28,6 +28,48 @@ from custom_components.ha_carrier.const import (
 from .conftest import IDENTITY_ID, PASSWORD, USERNAME, FakeCarrierApiConnection
 
 
+async def _async_validate_without_identity(
+    username: str,
+    password: str,
+) -> tuple[dict[str, str], str | None]:
+    """Return successful validation without a Carrier identity ID.
+
+    Args:
+        username: Submitted Carrier account username.
+        password: Submitted Carrier account password.
+
+    Returns:
+        tuple[dict[str, str], str | None]: No flow errors and no identity ID.
+    """
+    return {}, None
+
+
+def _mock_entry(
+    *,
+    entry_id: str = "entry-1",
+    unique_id: str = IDENTITY_ID,
+    username: str = USERNAME,
+    password: str = PASSWORD,
+) -> SimpleNamespace:
+    """Build a minimal config entry stand-in for direct flow tests.
+
+    Args:
+        entry_id: Config entry ID.
+        unique_id: Config entry unique ID.
+        username: Stored Carrier username.
+        password: Stored Carrier password.
+
+    Returns:
+        SimpleNamespace: Entry-like object exposing the flow attributes under test.
+    """
+    return SimpleNamespace(
+        entry_id=entry_id,
+        unique_id=unique_id,
+        data={CONF_USERNAME: username, CONF_PASSWORD: password},
+        title=username,
+    )
+
+
 @pytest.mark.asyncio
 async def test_user_flow_creates_entry_after_successful_validation(
     hass: HomeAssistant,
@@ -187,17 +229,11 @@ def test_user_flow_returns_unknown_when_validated_identity_is_missing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Keep the user flow on the form when validation returns no identity."""
-
-    async def async_validate_credentials(
-        username: str,
-        password: str,
-    ) -> tuple[dict[str, str], str | None]:
-        """Return a validation response without a Carrier identity."""
-        return {}, None
-
     flow = config_flow.CarrierConfigFlow()
     flow.context = {"source": config_entries.SOURCE_USER}
-    monkeypatch.setattr(config_flow, "_async_validate_credentials", async_validate_credentials)
+    monkeypatch.setattr(
+        config_flow, "_async_validate_credentials", _async_validate_without_identity
+    )
 
     result = _run_async(flow.async_step_user({CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD}))
 
@@ -209,12 +245,7 @@ def test_reconfigure_updates_username_and_reuses_blank_password(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Reconfigure can update username while keeping the saved password."""
-    reconfigure_entry = SimpleNamespace(
-        entry_id="entry-1",
-        unique_id=IDENTITY_ID,
-        data={CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD},
-        title=USERNAME,
-    )
+    reconfigure_entry = _mock_entry()
     updates: list[dict[str, Any]] = []
 
     async def async_validate_credentials(
@@ -283,23 +314,12 @@ def test_reconfigure_returns_unknown_when_validated_identity_is_missing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Keep reconfigure on the form when validation returns no identity."""
-    reconfigure_entry = SimpleNamespace(
-        entry_id="entry-1",
-        unique_id=IDENTITY_ID,
-        data={CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD},
-        title=USERNAME,
-    )
-
-    async def async_validate_credentials(
-        username: str,
-        password: str,
-    ) -> tuple[dict[str, str], str | None]:
-        """Return a validation response without a Carrier identity."""
-        return {}, None
-
+    reconfigure_entry = _mock_entry()
     flow = config_flow.CarrierConfigFlow()
     flow.context = {"source": "reconfigure", "entry_id": "entry-1"}
-    monkeypatch.setattr(config_flow, "_async_validate_credentials", async_validate_credentials)
+    monkeypatch.setattr(
+        config_flow, "_async_validate_credentials", _async_validate_without_identity
+    )
     monkeypatch.setattr(flow, "_get_reconfigure_entry", lambda: reconfigure_entry)
 
     result = _run_async(flow.async_step_reconfigure({CONF_USERNAME: USERNAME}))
@@ -333,24 +353,13 @@ def test_reauth_confirm_returns_unknown_when_validated_identity_is_missing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Keep reauth on the form when validation returns no identity."""
-    reauth_entry = SimpleNamespace(
-        entry_id="entry-1",
-        unique_id=IDENTITY_ID,
-        data={CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD},
-        title=USERNAME,
-    )
-
-    async def async_validate_credentials(
-        username: str,
-        password: str,
-    ) -> tuple[dict[str, str], str | None]:
-        """Return a validation response without a Carrier identity."""
-        return {}, None
-
+    reauth_entry = _mock_entry()
     flow = config_flow.CarrierConfigFlow()
     flow.context = {"source": "reauth", "entry_id": "entry-1"}
     flow._reauth_entry_data = dict(reauth_entry.data)
-    monkeypatch.setattr(config_flow, "_async_validate_credentials", async_validate_credentials)
+    monkeypatch.setattr(
+        config_flow, "_async_validate_credentials", _async_validate_without_identity
+    )
     monkeypatch.setattr(flow, "_get_reauth_entry", lambda: reauth_entry)
 
     result = _run_async(flow.async_step_reauth_confirm({CONF_USERNAME: USERNAME}))

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -72,6 +72,8 @@ async def test_user_flow_aborts_duplicate_account(
     [
         (CarrierApiAuthError("unauthorized"), ERROR_AUTH),
         (CarrierApiConnectionError("temporary"), ERROR_CANNOT_CONNECT),
+        (TimeoutError("temporary"), ERROR_CANNOT_CONNECT),
+        (OSError("temporary"), ERROR_CANNOT_CONNECT),
         (CarrierApiGraphqlError("unexpected"), ERROR_UNKNOWN),
     ],
 )

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -7,8 +7,7 @@ from collections.abc import Coroutine
 from types import SimpleNamespace
 from typing import Any
 
-from aiohttp import ClientError
-from carrier_api import AuthError, BaseError
+from carrier_api import CarrierApiAuthError, CarrierApiConnectionError, CarrierApiGraphqlError
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
@@ -71,9 +70,9 @@ async def test_user_flow_aborts_duplicate_account(
 @pytest.mark.parametrize(
     ("error", "expected_error"),
     [
-        (AuthError("unauthorized"), ERROR_AUTH),
-        (ClientError("temporary"), ERROR_CANNOT_CONNECT),
-        (BaseError("unexpected"), ERROR_UNKNOWN),
+        (CarrierApiAuthError("unauthorized"), ERROR_AUTH),
+        (CarrierApiConnectionError("temporary"), ERROR_CANNOT_CONNECT),
+        (CarrierApiGraphqlError("unexpected"), ERROR_UNKNOWN),
     ],
 )
 async def test_user_flow_maps_validation_errors(
@@ -93,6 +92,30 @@ async def test_user_flow_maps_validation_errors(
 
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": expected_error}
+
+
+@pytest.mark.asyncio
+async def test_user_flow_still_creates_entry_when_cleanup_reports_carrier_error(
+    hass: HomeAssistant,
+    patch_carrier_api: FakeCarrierApiConnection,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Do not fail a validated user flow only because API cleanup failed."""
+
+    async def cleanup() -> None:
+        """Raise the Carrier API cleanup failure."""
+        raise CarrierApiConnectionError("cleanup failed")
+
+    monkeypatch.setattr(patch_carrier_api, "cleanup", cleanup)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_USER},
+        data={CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD},
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["result"].unique_id == IDENTITY_ID
 
 
 @pytest.mark.asyncio
@@ -158,6 +181,28 @@ async def test_reauth_flow_updates_username_and_reuses_blank_password(
     assert patch_carrier_api.username == new_username
     assert patch_carrier_api.password == PASSWORD
     await _async_unload_loaded_entry(hass, config_entry)
+
+
+def test_user_flow_returns_unknown_when_validated_identity_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Keep the user flow on the form when validation returns no identity."""
+
+    async def async_validate_credentials(
+        username: str,
+        password: str,
+    ) -> tuple[dict[str, str], str | None]:
+        """Return a validation response without a Carrier identity."""
+        return {}, None
+
+    flow = config_flow.CarrierConfigFlow()
+    flow.context = {"source": config_entries.SOURCE_USER}
+    monkeypatch.setattr(config_flow, "_async_validate_credentials", async_validate_credentials)
+
+    result = _run_async(flow.async_step_user({CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD}))
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": ERROR_UNKNOWN}
 
 
 def test_reconfigure_updates_username_and_reuses_blank_password(
@@ -234,6 +279,35 @@ def test_reconfigure_updates_username_and_reuses_blank_password(
     ]
 
 
+def test_reconfigure_returns_unknown_when_validated_identity_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Keep reconfigure on the form when validation returns no identity."""
+    reconfigure_entry = SimpleNamespace(
+        entry_id="entry-1",
+        unique_id=IDENTITY_ID,
+        data={CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD},
+        title=USERNAME,
+    )
+
+    async def async_validate_credentials(
+        username: str,
+        password: str,
+    ) -> tuple[dict[str, str], str | None]:
+        """Return a validation response without a Carrier identity."""
+        return {}, None
+
+    flow = config_flow.CarrierConfigFlow()
+    flow.context = {"source": "reconfigure", "entry_id": "entry-1"}
+    monkeypatch.setattr(config_flow, "_async_validate_credentials", async_validate_credentials)
+    monkeypatch.setattr(flow, "_get_reconfigure_entry", lambda: reconfigure_entry)
+
+    result = _run_async(flow.async_step_reconfigure({CONF_USERNAME: USERNAME}))
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": ERROR_UNKNOWN}
+
+
 @pytest.mark.asyncio
 async def test_options_flow_updates_infinite_hold_option(hass: HomeAssistant) -> None:
     """Create options data from the Carrier options flow."""
@@ -253,6 +327,36 @@ async def test_options_flow_updates_infinite_hold_option(hass: HomeAssistant) ->
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["data"] == {CONF_INFINITE_HOLDS: False}
+
+
+def test_reauth_confirm_returns_unknown_when_validated_identity_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Keep reauth on the form when validation returns no identity."""
+    reauth_entry = SimpleNamespace(
+        entry_id="entry-1",
+        unique_id=IDENTITY_ID,
+        data={CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD},
+        title=USERNAME,
+    )
+
+    async def async_validate_credentials(
+        username: str,
+        password: str,
+    ) -> tuple[dict[str, str], str | None]:
+        """Return a validation response without a Carrier identity."""
+        return {}, None
+
+    flow = config_flow.CarrierConfigFlow()
+    flow.context = {"source": "reauth", "entry_id": "entry-1"}
+    flow._reauth_entry_data = dict(reauth_entry.data)
+    monkeypatch.setattr(config_flow, "_async_validate_credentials", async_validate_credentials)
+    monkeypatch.setattr(flow, "_get_reauth_entry", lambda: reauth_entry)
+
+    result = _run_async(flow.async_step_reauth_confirm({CONF_USERNAME: USERNAME}))
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": ERROR_UNKNOWN}
 
 
 def test_reauth_rejects_credentials_for_different_unconfigured_identity(

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -72,8 +72,6 @@ async def test_user_flow_aborts_duplicate_account(
     [
         (CarrierApiAuthError("unauthorized"), ERROR_AUTH),
         (CarrierApiConnectionError("temporary"), ERROR_CANNOT_CONNECT),
-        (TimeoutError("temporary"), ERROR_CANNOT_CONNECT),
-        (OSError("temporary"), ERROR_CANNOT_CONNECT),
         (CarrierApiGraphqlError("unexpected"), ERROR_UNKNOWN),
     ],
 )

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -6,11 +6,28 @@ import asyncio
 from collections.abc import Callable
 from typing import Any
 
+from carrier_api import CarrierApiAuthError, CarrierApiConnectionError
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from .conftest import FakeCarrierApiConnection
+from custom_components.ha_carrier import _async_await_websocket_task, async_setup_entry
+from custom_components.ha_carrier.carrier_data_update_coordinator import (
+    CarrierDataUpdateCoordinator,
+)
+from custom_components.ha_carrier.const import DOMAIN
+from custom_components.ha_carrier.exceptions import CarrierUnauthorizedError
+
+from .conftest import PASSWORD, USERNAME, FakeCarrierApiConnection
+
+
+def _config_entry_not_ready_from(error: BaseException) -> ConfigEntryNotReady:
+    """Build a setup retry exception that preserves the wrapped cause."""
+    config_entry_error = ConfigEntryNotReady("not ready")
+    config_entry_error.__cause__ = error
+    return config_entry_error
 
 
 @pytest.mark.asyncio
@@ -61,6 +78,31 @@ async def test_websocket_task_recovers_from_bad_update_data(
 
 
 @pytest.mark.asyncio
+async def test_websocket_task_recovers_from_carrier_connection_error(
+    hass: HomeAssistant,
+    carrier_api: FakeCarrierApiConnection,
+    monkeypatch: pytest.MonkeyPatch,
+    setup_integration: Callable[..., Any],
+) -> None:
+    """Keep websocket listening after the Carrier API reports a connection failure."""
+    monkeypatch.setattr("custom_components.ha_carrier.compute_backoff_delay", lambda *_: 0)
+    carrier_api.api_websocket.listener_errors.append(CarrierApiConnectionError("offline"))
+
+    config_entry = await setup_integration()
+    websocket_task = config_entry.runtime_data.websocket_task
+
+    for _ in range(10):
+        await hass.async_block_till_done()
+        if carrier_api.api_websocket.listener_calls >= 2:
+            break
+        await asyncio.sleep(0)
+
+    assert carrier_api.api_websocket.listener_calls == 2
+    assert websocket_task is not None
+    assert not websocket_task.done()
+
+
+@pytest.mark.asyncio
 async def test_unload_ignores_websocket_task_data_update_failure(
     hass: HomeAssistant,
     setup_integration: Callable[..., Any],
@@ -86,3 +128,88 @@ async def test_unload_ignores_websocket_task_data_update_failure(
 
     assert config_entry.state is ConfigEntryState.NOT_LOADED
     assert coordinator.websocket_task is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "task_error",
+    [
+        CarrierApiConnectionError("offline"),
+        RuntimeError("websocket missing"),
+    ],
+)
+async def test_await_websocket_task_suppresses_expected_failures(
+    hass: HomeAssistant,
+    task_error: Exception,
+) -> None:
+    """Drain failed websocket tasks for expected recoverable failure families."""
+
+    async def fail_websocket_task() -> None:
+        """Raise the configured websocket task failure."""
+        raise task_error
+
+    failed_task: asyncio.Task[None] = hass.async_create_task(
+        fail_websocket_task(),
+        name="failed_carrier_websocket",
+    )
+    await hass.async_block_till_done()
+
+    await _async_await_websocket_task(failed_task)
+
+
+@pytest.mark.asyncio
+async def test_setup_entry_maps_carrier_connection_error_to_not_ready(
+    hass: HomeAssistant,
+    patch_carrier_api: FakeCarrierApiConnection,
+) -> None:
+    """Convert Carrier API connection setup failures to Home Assistant retry."""
+    patch_carrier_api.load_data_error = CarrierApiConnectionError("offline")
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"username": USERNAME, "password": PASSWORD},
+    )
+    config_entry.add_to_hass(hass)
+
+    assert not await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("refresh_error", "expected_error"),
+    [
+        (ConfigEntryAuthFailed("reauth"), ConfigEntryAuthFailed),
+        (CarrierUnauthorizedError("unauthorized"), ConfigEntryAuthFailed),
+        (CarrierApiConnectionError("offline"), ConfigEntryNotReady),
+        (_config_entry_not_ready_from(CarrierApiAuthError("unauthorized")), ConfigEntryAuthFailed),
+        (ConfigEntryNotReady("offline"), ConfigEntryNotReady),
+    ],
+)
+async def test_setup_entry_maps_first_refresh_errors(
+    hass: HomeAssistant,
+    patch_carrier_api: FakeCarrierApiConnection,
+    monkeypatch: pytest.MonkeyPatch,
+    refresh_error: Exception,
+    expected_error: type[Exception],
+) -> None:
+    """Map first-refresh exceptions to the Home Assistant setup lifecycle."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"username": USERNAME, "password": PASSWORD},
+    )
+    config_entry.add_to_hass(hass)
+
+    async def async_first_refresh(self: CarrierDataUpdateCoordinator) -> None:
+        """Raise the configured first-refresh failure."""
+        raise refresh_error
+
+    monkeypatch.setattr(
+        CarrierDataUpdateCoordinator,
+        "async_config_entry_first_refresh",
+        async_first_refresh,
+    )
+
+    with pytest.raises(expected_error):
+        await async_setup_entry(hass, config_entry)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -78,15 +78,23 @@ async def test_websocket_task_recovers_from_bad_update_data(
 
 
 @pytest.mark.asyncio
-async def test_websocket_task_recovers_from_carrier_connection_error(
+@pytest.mark.parametrize(
+    "websocket_error",
+    [
+        CarrierApiAuthError("unauthorized"),
+        CarrierApiConnectionError("offline"),
+    ],
+)
+async def test_websocket_task_recovers_from_carrier_api_error(
     hass: HomeAssistant,
     carrier_api: FakeCarrierApiConnection,
     monkeypatch: pytest.MonkeyPatch,
     setup_integration: Callable[..., Any],
+    websocket_error: Exception,
 ) -> None:
-    """Keep websocket listening after the Carrier API reports a connection failure."""
+    """Keep websocket listening after the Carrier API reports a recoverable failure."""
     monkeypatch.setattr("custom_components.ha_carrier.compute_backoff_delay", lambda *_: 0)
-    carrier_api.api_websocket.listener_errors.append(CarrierApiConnectionError("offline"))
+    carrier_api.api_websocket.listener_errors.append(websocket_error)
 
     config_entry = await setup_integration()
     websocket_task = config_entry.runtime_data.websocket_task
@@ -135,6 +143,7 @@ async def test_unload_ignores_websocket_task_data_update_failure(
     "task_error",
     [
         CarrierApiConnectionError("offline"),
+        CarrierApiAuthError("unauthorized"),
         RuntimeError("websocket missing"),
     ],
 )

--- a/tests/test_integration_workflows.py
+++ b/tests/test_integration_workflows.py
@@ -6,7 +6,7 @@ from collections.abc import Awaitable, Callable
 from datetime import timedelta
 from inspect import isawaitable
 
-from aiohttp import ClientError
+from carrier_api import CarrierApiConnectionError
 from homeassistant import config_entries
 from homeassistant.components.climate import (
     ATTR_HVAC_MODE,
@@ -151,7 +151,7 @@ async def test_refresh_failure_and_recovery_update_poll_interval_in_ha_workflow(
     config_entry = await setup_integration()
     coordinator = config_entry.runtime_data
     coordinator.data_flush = True
-    carrier_api.load_data_error = ClientError("temporary")
+    carrier_api.load_data_error = CarrierApiConnectionError("temporary")
 
     await coordinator.async_refresh()
 

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from aiohttp import ClientError
+from carrier_api import CarrierApiConnectionError
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -55,7 +55,7 @@ async def test_migration_defers_version_update_when_live_data_cannot_load(
     patch_carrier_api: FakeCarrierApiConnection,
 ) -> None:
     """Keep migration non-destructive when Carrier data cannot be loaded."""
-    patch_carrier_api.load_data_error = ClientError("offline")
+    patch_carrier_api.load_data_error = CarrierApiConnectionError("offline")
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         version=1,
@@ -103,7 +103,7 @@ async def test_migration_defers_identity_update_when_user_info_cannot_load(
     patch_carrier_api: FakeCarrierApiConnection,
 ) -> None:
     """Keep v2 entries unchanged when Carrier identity lookup fails."""
-    patch_carrier_api.load_data_error = ClientError("offline")
+    patch_carrier_api.load_data_error = CarrierApiConnectionError("offline")
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         version=2,

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -50,12 +50,21 @@ async def test_migration_updates_system_and_zone_unique_ids(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "load_error",
+    [
+        CarrierApiConnectionError("offline"),
+        TimeoutError("offline"),
+        OSError("offline"),
+    ],
+)
 async def test_migration_defers_version_update_when_live_data_cannot_load(
     hass: HomeAssistant,
     patch_carrier_api: FakeCarrierApiConnection,
+    load_error: BaseException,
 ) -> None:
     """Keep migration non-destructive when Carrier data cannot be loaded."""
-    patch_carrier_api.load_data_error = CarrierApiConnectionError("offline")
+    patch_carrier_api.load_data_error = load_error
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         version=1,
@@ -98,12 +107,21 @@ async def test_migration_updates_config_entry_unique_id_to_identity_id(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "load_error",
+    [
+        CarrierApiConnectionError("offline"),
+        TimeoutError("offline"),
+        OSError("offline"),
+    ],
+)
 async def test_migration_defers_identity_update_when_user_info_cannot_load(
     hass: HomeAssistant,
     patch_carrier_api: FakeCarrierApiConnection,
+    load_error: BaseException,
 ) -> None:
     """Keep v2 entries unchanged when Carrier identity lookup fails."""
-    patch_carrier_api.load_data_error = CarrierApiConnectionError("offline")
+    patch_carrier_api.load_data_error = load_error
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         version=2,

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -47,6 +47,7 @@ async def test_migration_updates_system_and_zone_unique_ids(
     assert config_entry.version == 2
     assert ent_reg.async_get_entity_id("sensor", DOMAIN, "abc123_outdoor_temperature")
     assert ent_reg.async_get_entity_id("climate", DOMAIN, "abc123_zone_1_thermostat")
+    assert patch_carrier_api.cleanup_calls == 1
 
 
 @pytest.mark.asyncio
@@ -81,6 +82,7 @@ async def test_migration_defers_version_update_when_live_data_cannot_load(
 
     assert config_entry.version == 1
     assert ent_reg.async_get(entry.entity_id) is not None
+    assert patch_carrier_api.cleanup_calls == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -54,8 +54,6 @@ async def test_migration_updates_system_and_zone_unique_ids(
     "load_error",
     [
         CarrierApiConnectionError("offline"),
-        TimeoutError("offline"),
-        OSError("offline"),
     ],
 )
 async def test_migration_defers_version_update_when_live_data_cannot_load(
@@ -111,8 +109,6 @@ async def test_migration_updates_config_entry_unique_id_to_identity_id(
     "load_error",
     [
         CarrierApiConnectionError("offline"),
-        TimeoutError("offline"),
-        OSError("offline"),
     ],
 )
 async def test_migration_defers_identity_update_when_user_info_cannot_load(

--- a/tests/test_resiliency.py
+++ b/tests/test_resiliency.py
@@ -4,8 +4,7 @@ from __future__ import annotations
 
 import logging
 
-from aiohttp import ClientError
-from gql.transport.exceptions import TransportServerError
+from carrier_api import CarrierApiAuthError, CarrierApiConnectionError
 import pytest
 
 from custom_components.ha_carrier.exceptions import CarrierUnauthorizedError
@@ -43,7 +42,7 @@ async def test_retry_helper_retries_transient_failure_then_resets_state(
         nonlocal attempts
         attempts += 1
         if attempts == 1:
-            raise ClientError("temporary")
+            raise CarrierApiConnectionError("temporary")
         return "ok"
 
     result = await async_call_with_retry(
@@ -68,7 +67,7 @@ async def test_retry_helper_escalates_repeated_unauthorized_failures(
 
     async def operation() -> None:
         """Always raise an unauthorized Carrier transport error."""
-        raise TransportServerError("unauthorized", code=401)
+        raise CarrierApiAuthError("unauthorized")
 
     with pytest.raises(CarrierUnauthorizedError):
         await async_call_with_retry(

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -49,6 +49,8 @@ def test_integration_imports_supported_carrier_api_exception_names(module_path: 
         (is_transient_transport_error, CarrierApiConnectionError("temporary")),
         (is_transient_transport_error, CarrierApiTokenRefreshError("temporary")),
         (is_transient_transport_error, CarrierApiWebsocketError("temporary")),
+        (is_transient_transport_error, TimeoutError("temporary")),
+        (is_transient_transport_error, OSError("temporary")),
     ],
 )
 def test_exception_classifiers_inspect_context_when_cause_exists(

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -2,10 +2,17 @@
 
 from __future__ import annotations
 
+import ast
 from collections.abc import Callable
+from pathlib import Path
 
-from aiohttp import ClientError
-from gql.transport.exceptions import TransportServerError
+from carrier_api import (
+    CarrierApiAuthError,
+    CarrierApiConnectionError,
+    CarrierApiGraphqlError,
+    CarrierApiTokenRefreshError,
+    CarrierApiWebsocketError,
+)
 import pytest
 
 from custom_components.ha_carrier.util import (
@@ -14,12 +21,34 @@ from custom_components.ha_carrier.util import (
     is_unauthorized_error,
 )
 
+INTEGRATION_ROOT = Path(__file__).parents[1] / "custom_components" / "ha_carrier"
+DEPRECATED_CARRIER_API_EXCEPTIONS = {"AuthError", "BaseError"}
+
+
+@pytest.mark.parametrize("module_path", sorted(INTEGRATION_ROOT.glob("*.py")))
+def test_integration_imports_supported_carrier_api_exception_names(module_path: Path) -> None:
+    """Require integration modules to use the supported CarrierApi exception names."""
+    tree = ast.parse(module_path.read_text(encoding="utf-8"))
+    deprecated_imports: list[str] = []
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module == "carrier_api":
+            deprecated_imports.extend(
+                alias.name
+                for alias in node.names
+                if alias.name in DEPRECATED_CARRIER_API_EXCEPTIONS
+            )
+
+    assert deprecated_imports == []
+
 
 @pytest.mark.parametrize(
     ("classifier", "nested_error"),
     [
-        (is_unauthorized_error, TransportServerError("unauthorized", code=401)),
-        (is_transient_transport_error, ClientError("temporary")),
+        (is_unauthorized_error, CarrierApiAuthError("unauthorized")),
+        (is_transient_transport_error, CarrierApiConnectionError("temporary")),
+        (is_transient_transport_error, CarrierApiTokenRefreshError("temporary")),
+        (is_transient_transport_error, CarrierApiWebsocketError("temporary")),
     ],
 )
 def test_exception_classifiers_inspect_context_when_cause_exists(
@@ -32,6 +61,11 @@ def test_exception_classifiers_inspect_context_when_cause_exists(
     error.__context__ = nested_error
 
     assert classifier(error) is True
+
+
+def test_graphql_errors_are_not_classified_as_transient_transport() -> None:
+    """Keep Carrier GraphQL rejections out of transport retry classification."""
+    assert is_transient_transport_error(CarrierApiGraphqlError("rejected")) is False
 
 
 def test_async_redact_data_recursively_redacts_mappings_and_lists() -> None:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -49,8 +49,6 @@ def test_integration_imports_supported_carrier_api_exception_names(module_path: 
         (is_transient_transport_error, CarrierApiConnectionError("temporary")),
         (is_transient_transport_error, CarrierApiTokenRefreshError("temporary")),
         (is_transient_transport_error, CarrierApiWebsocketError("temporary")),
-        (is_transient_transport_error, TimeoutError("temporary")),
-        (is_transient_transport_error, OSError("temporary")),
     ],
 )
 def test_exception_classifiers_inspect_context_when_cause_exists(


### PR DESCRIPTION
## Summary

Updates the integration to use the normalized `carrier_api` exception taxonomy instead of importing lower-level `aiohttp` and `gql` transport exceptions directly. This keeps Home Assistant error handling at the Carrier API boundary and preserves retry, reauth, migration, and cleanup behavior with the new client exceptions.

## What Changed

- Replaced direct `AuthError`, `BaseError`, `aiohttp`, and `gql` exception handling with `CarrierApi*` exceptions exported by `carrier_api`
- Updated setup, config flow, coordinator refresh/write handling, websocket recovery, and migration paths to classify Carrier API auth, connection, token refresh, websocket, and GraphQL errors
- Kept raw retry-helper `TimeoutError` behavior only where it is still produced locally by `ha_carrier`
- Ensured v1 migration closes its `ApiConnectionGraphql` session after both successful and failed `load_data()` calls
- Added regression coverage for credential validation, setup retry/auth mapping, websocket recovery, migration cleanup, write failures, and exception classifier behavior
- Added a guard test that rejects deprecated `carrier_api` exception imports in integration modules

## Why

`carrier_api` is gaining a public error taxonomy so downstream integrations no longer need to know about its internal GraphQL or HTTP transport details. Handling those public exception classes in `ha_carrier` keeps the integration compatible with the new client contract while preserving Home Assistant-specific lifecycle behavior.

## Validation

- `./scripts/lint` passed locally
- `./scripts/test` passed locally with `115 passed` and coverage above the required threshold 

## Related

- ~~Depends on `carrier_api` [exception normalization changes](https://github.com/dahlb/carrier_api/pull/108)~~
- Updated to use carrier_api v3.1.0