### PR TITLE
Use Carrier API zone capability helpers

### DIFF
--- a/custom_components/ha_carrier/climate.py
+++ b/custom_components/ha_carrier/climate.py
@@ -56,18 +56,19 @@ async def async_setup_entry(
     coordinator = config_entry.runtime_data
     entities: list[Thermostat] = []
     for carrier_system in coordinator.systems:
+        supported_hvac_capabilities = carrier_system.supported_hvac_capabilities()
         support_flags = BASE_SUPPORT_FLAGS
         hvac_modes: list[HVACMode] = [
             HVACMode.OFF,
         ]
-        if carrier_system.supports_fan():
+        if supported_hvac_capabilities["fan"]:
             support_flags |= ClimateEntityFeature.FAN_MODE
             hvac_modes.append(HVACMode.FAN_ONLY)
-        if carrier_system.supports_cool():
+        if supported_hvac_capabilities["cool"]:
             hvac_modes.append(HVACMode.COOL)
-        if carrier_system.supports_heat():
+        if supported_hvac_capabilities["heat"]:
             hvac_modes.append(HVACMode.HEAT)
-        if carrier_system.supports_cool() and carrier_system.supports_heat():
+        if supported_hvac_capabilities["cool"] and supported_hvac_capabilities["heat"]:
             support_flags |= ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
             hvac_modes.append(HVACMode.HEAT_COOL)
         entities.extend(
@@ -136,43 +137,12 @@ class CarrierClimate(CarrierZoneEntity, ClimateEntity):
         return self.zone_api_id
 
     def _preset_mode(self) -> str | None:
-        """Return the preset that best matches current zone setpoints.
+        """Return the Carrier-reported current activity preset.
 
         Returns:
-            str | None: Matching activity type or API-reported fallback.
+            str | None: Status-derived activity type, or API-reported fallback.
         """
-        actual_heat = self._status_zone.heat_set_point
-        actual_cool = self._status_zone.cool_set_point
-
-        matching_activities = [
-            activity
-            for activity in self._config_zone.activities
-            if activity.heat_set_point == actual_heat and activity.cool_set_point == actual_cool
-        ]
-        if len(matching_activities) == 1:
-            return matching_activities[0].type.value
-        if len(matching_activities) > 1:
-            current_activity = self._current_activity()
-            if current_activity is None:
-                _LOGGER.debug(
-                    "Zone %s: Current activity %s was not found in the zone config",
-                    self._config_zone.name,
-                    self._status_zone.current_status_activity_type,
-                )
-                return self._status_zone.current_status_activity_type.value
-            return current_activity.type.value
-
-        _LOGGER.debug(
-            (
-                "Zone %s: No activity matched setpoints (heat=%s, cool=%s). "
-                "Falling back to API activity: %s"
-            ),
-            self._config_zone.name,
-            actual_heat,
-            actual_cool,
-            self._status_zone.current_status_activity_type,
-        )
-        current_activity = self._current_activity()
+        current_activity = self._config_zone.current_status_activity(self._status_zone)
         if current_activity is None:
             _LOGGER.debug(
                 "Zone %s: Current activity %s was not found in the zone config",

--- a/custom_components/ha_carrier/climate.py
+++ b/custom_components/ha_carrier/climate.py
@@ -28,7 +28,6 @@ from . import ConfigEntryCarrier
 from .carrier_data_update_coordinator import CarrierDataUpdateCoordinator
 from .carrier_entity import CarrierZoneEntity
 from .const import CONF_INFINITE_HOLDS, DEFAULT_INFINITE_HOLDS, FAN_AUTO
-from .util import has_cool, has_fan, has_heat
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -61,14 +60,14 @@ async def async_setup_entry(
         hvac_modes: list[HVACMode] = [
             HVACMode.OFF,
         ]
-        if has_fan(carrier_system):
+        if carrier_system.supports_fan():
             support_flags |= ClimateEntityFeature.FAN_MODE
             hvac_modes.append(HVACMode.FAN_ONLY)
-        if has_cool(carrier_system):
+        if carrier_system.supports_cool():
             hvac_modes.append(HVACMode.COOL)
-        if has_heat(carrier_system):
+        if carrier_system.supports_heat():
             hvac_modes.append(HVACMode.HEAT)
-        if has_cool(carrier_system) and has_heat(carrier_system):
+        if carrier_system.supports_cool() and carrier_system.supports_heat():
             support_flags |= ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
             hvac_modes.append(HVACMode.HEAT_COOL)
         entities.extend(
@@ -120,8 +119,7 @@ class CarrierClimate(CarrierZoneEntity, ClimateEntity):
         Returns:
             ConfigZoneActivity | None: Activity associated with current zone state.
         """
-        activity_type = self._config_zone.hold_activity or self._status_zone.current_activity
-        return self._config_zone.find_activity(activity_type)
+        return self._config_zone.current_status_activity(self._status_zone)
 
     @property
     def _required_zone_api_id(self) -> str:
@@ -159,9 +157,9 @@ class CarrierClimate(CarrierZoneEntity, ClimateEntity):
                 _LOGGER.debug(
                     "Zone %s: Current activity %s was not found in the zone config",
                     self._config_zone.name,
-                    self._status_zone.current_activity,
+                    self._status_zone.current_status_activity_type,
                 )
-                return self._status_zone.current_activity.value
+                return self._status_zone.current_status_activity_type.value
             return current_activity.type.value
 
         _LOGGER.debug(
@@ -172,16 +170,16 @@ class CarrierClimate(CarrierZoneEntity, ClimateEntity):
             self._config_zone.name,
             actual_heat,
             actual_cool,
-            self._status_zone.current_activity,
+            self._status_zone.current_status_activity_type,
         )
         current_activity = self._current_activity()
         if current_activity is None:
             _LOGGER.debug(
                 "Zone %s: Current activity %s was not found in the zone config",
                 self._config_zone.name,
-                self._status_zone.current_activity,
+                self._status_zone.current_status_activity_type,
             )
-            return self._status_zone.current_activity.value
+            return self._status_zone.current_status_activity_type.value
         return current_activity.type.value
 
     def _update_entity_attrs(self) -> None:
@@ -254,7 +252,7 @@ class CarrierClimate(CarrierZoneEntity, ClimateEntity):
             _LOGGER.debug(
                 "Zone %s: Current activity %s unavailable while reading fan mode",
                 self._config_zone.name,
-                self._status_zone.current_activity,
+                self._status_zone.current_status_activity_type,
             )
             self._attr_fan_mode = None
         elif current_activity.fan == FanModes.OFF:
@@ -435,6 +433,7 @@ class Thermostat(CarrierClimate):
         self._config_zone.hold = True
         self._config_zone.hold_activity = activity_type
         self._config_zone.hold_until = hold_until_sent or ""
+        self._status_zone.current_status_activity_type = activity_type
         if selected_activity is not None:
             self._status_zone.heat_set_point = selected_activity.heat_set_point
             self._status_zone.cool_set_point = selected_activity.cool_set_point
@@ -532,6 +531,7 @@ class Thermostat(CarrierClimate):
         self._config_zone.hold = True
         self._config_zone.hold_activity = ActivityTypes.MANUAL
         self._config_zone.hold_until = hold_until_sent or ""
+        self._status_zone.current_status_activity_type = ActivityTypes.MANUAL
         manual_activity.cool_set_point = cool_set_point
         manual_activity.heat_set_point = heat_set_point
         self._status_zone.cool_set_point = cool_set_point

--- a/custom_components/ha_carrier/manifest.json
+++ b/custom_components/ha_carrier/manifest.json
@@ -14,7 +14,7 @@
     "carrier_api"
   ],
   "requirements": [
-    "carrier-api==3.1.0"
+    "carrier-api==3.2.0"
   ],
   "version": "2.23.4"
 }

--- a/custom_components/ha_carrier/migrate.py
+++ b/custom_components/ha_carrier/migrate.py
@@ -13,7 +13,7 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_registry import EntityRegistry, RegistryEntry
 from homeassistant.util import slugify
 
-from .util import ENERGY_METRIC_MAP, TIMESTAMP_TYPES, async_get_carrier_identity_id, has_heat
+from .util import ENERGY_METRIC_MAP, TIMESTAMP_TYPES, async_get_carrier_identity_id
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -413,7 +413,7 @@ def _async_build_created_unique_ids(systems: Iterable[System]) -> set[str]:
             created_unique_ids.add(_async_new_unique_id(system_serial, "UV Lamp Remaining"))
         if carrier_system.profile.outdoor_unit_type in ["varcaphp", "varcapac"]:
             created_unique_ids.add(_async_new_unique_id(system_serial, "ODU Var"))
-        if has_heat(carrier_system):
+        if carrier_system.supports_heat():
             created_unique_ids.add(_async_new_unique_id(system_serial, "Heat Source"))
 
         for metric in ENERGY_METRIC_MAP:

--- a/custom_components/ha_carrier/select.py
+++ b/custom_components/ha_carrier/select.py
@@ -15,7 +15,6 @@ from . import ConfigEntryCarrier
 from .carrier_data_update_coordinator import CarrierDataUpdateCoordinator
 from .carrier_entity import CarrierEntity
 from .const import HEAT_SOURCE_IDU_ONLY_LABEL, HEAT_SOURCE_ODU_ONLY_LABEL, HEAT_SOURCE_SYSTEM_LABEL
-from .util import has_heat
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -36,7 +35,7 @@ async def async_setup_entry(
     entities: list[SelectEntity] = [
         HeatSourceSelect(coordinator=coordinator, system_serial=system.profile.serial)
         for system in coordinator.systems
-        if has_heat(system)
+        if system.supports_heat()
     ]
     async_add_entities(entities)
 

--- a/custom_components/ha_carrier/sensor.py
+++ b/custom_components/ha_carrier/sensor.py
@@ -869,7 +869,7 @@ class OutdoorUnitVarSensor(CarrierSensor):
         if value is None or not isinstance(value, str):
             self._attr_available = False
             return
-        if isinstance(value, str) and value == "off":
+        if isinstance(value, str) and value in {"off", "dehumidify"}:
             self._attr_native_value = 0.0
             self._attr_available = True
             return

--- a/custom_components/ha_carrier/util.py
+++ b/custom_components/ha_carrier/util.py
@@ -13,7 +13,6 @@ from carrier_api import (
     CarrierApiError,
     CarrierApiTokenRefreshError,
     CarrierApiWebsocketError,
-    System,
 )
 from homeassistant.core import callback
 
@@ -21,24 +20,6 @@ from .exceptions import CarrierUnauthorizedError
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 REDACTED = "**REDACTED**"
-
-HEAT_TYPES: list[str] = [
-    "electric_heat",
-    "gas",
-    "hp_heat",
-    "loop_pump",
-    "reheat",
-]
-
-COOL_TYPES: list[str] = [
-    "cooling",
-    "loop_pump",
-]
-
-FAN_TYPES: list[str] = [
-    "fan",
-    "fan_gas",
-]
 
 ENERGY_METRIC_MAP: dict[str, str] = {
     "cooling": "coolingKwh",
@@ -121,21 +102,6 @@ async def async_get_carrier_identity_id(api_connection: ApiConnectionGraphql) ->
         return None
 
     return identity_id
-
-
-def has_heat(carrier_system: System) -> bool:
-    """Return True if the Carrier system supports heat source selection."""
-    return any(getattr(carrier_system.energy, heat_type, False) is True for heat_type in HEAT_TYPES)
-
-
-def has_cool(carrier_system: System) -> bool:
-    """Return True if the Carrier system supports cool source selection."""
-    return any(getattr(carrier_system.energy, cool_type, False) is True for cool_type in COOL_TYPES)
-
-
-def has_fan(carrier_system: System) -> bool:
-    """Return True if the Carrier system supports fan mode selection."""
-    return any(getattr(carrier_system.energy, fan_type, False) is True for fan_type in FAN_TYPES)
 
 
 @overload

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ version = { attr = "custom_components.ha_carrier.const.VERSION" }
 
 [dependency-groups]
 ha = [
-    "carrier-api==3.1.0",
+    "carrier-api==3.2.0",
     "homeassistant",
 ]
 lint = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -270,6 +270,7 @@ def build_carrier_system(
     zone_name: str = "Living Room",
     zone_id: str = "1",
     has_heat_pump: bool = True,
+    fan_enabled: bool | None = None,
     disconnected: bool = False,
 ) -> System:
     """Build a realistic Carrier system from ``carrier_api`` model classes.
@@ -281,6 +282,8 @@ def build_carrier_system(
         zone_id: Identifier assigned to the zone. Defaults to ``"1"``.
         has_heat_pump: When ``True``, configure the outdoor unit as a variable-capacity
             heat pump; otherwise configure it as an air conditioner. Defaults to ``True``.
+        fan_enabled: Optional Carrier ``cfgfan`` value. Defaults to ``None`` to omit the
+            field and exercise energy-based fan capability fallback.
         disconnected: When ``True``, mark the status payload as disconnected so tests can
             exercise offline behavior. Defaults to ``False``.
 
@@ -304,23 +307,24 @@ def build_carrier_system(
             "odutype": "varcaphp" if has_heat_pump else "ac",
         }
     )
-    config = Config(
-        {
-            "cfgem": "F",
-            "mode": "auto",
-            "heatsource": "system",
-            "etag": "etag",
-            "fueltype": "gas",
-            "gasunit": "therm",
-            "cfguv": "on",
-            "cfghumid": "on",
-            "humidityHome": {"rhtg": 7},
-            "vacmaxt": 82,
-            "vacmint": 60,
-            "vacfan": "off",
-            "zones": [_zone_raw(zone_id=zone_id, name=zone_name)],
-        }
-    )
+    config_raw = {
+        "cfgem": "F",
+        "mode": "auto",
+        "heatsource": "system",
+        "etag": "etag",
+        "fueltype": "gas",
+        "gasunit": "therm",
+        "cfguv": "on",
+        "cfghumid": "on",
+        "humidityHome": {"rhtg": 7},
+        "vacmaxt": 82,
+        "vacmint": 60,
+        "vacfan": "off",
+        "zones": [_zone_raw(zone_id=zone_id, name=zone_name)],
+    }
+    if fan_enabled is not None:
+        config_raw["cfgfan"] = "on" if fan_enabled else "off"
+    config = Config(config_raw)
     status = Status(
         {
             "oat": 40,

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -70,6 +70,27 @@ async def test_climate_platform_uses_config_fan_capability(
 
 
 @pytest.mark.asyncio
+async def test_climate_preset_mode_uses_status_activity(
+    hass: HomeAssistant,
+    carrier_api: FakeCarrierApiConnection,
+    setup_integration: Callable[..., Any],
+) -> None:
+    """Prefer Carrier's status activity over matching configured setpoints."""
+    carrier_api.systems = [build_carrier_system()]
+    system = carrier_api.systems[0]
+    system.status.zones[0].current_status_activity_type = ActivityTypes.AWAY
+    system.status.zones[0].heat_set_point = 68
+    system.status.zones[0].cool_set_point = 74
+
+    await setup_integration()
+    entity_id = entity_id_for_unique_id(hass, CLIMATE_DOMAIN, "abc123_zone_1_thermostat")
+    state = hass.states.get(entity_id)
+
+    assert state is not None
+    assert state.attributes["preset_mode"] == "away"
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("service", "data", "expected_calls"),
     [

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any
 
-from carrier_api import FanModes
+from carrier_api import ActivityTypes, FanModes
 from homeassistant.components.climate import (
     ATTR_HVAC_MODE,
     ATTR_PRESET_MODE,
@@ -48,6 +48,25 @@ async def test_climate_platform_registers_zone_thermostat(
     assert state.state == HVACMode.HEAT_COOL
     assert state.attributes["current_temperature"] == 21.1
     assert FAN_AUTO in state.attributes["fan_modes"]
+
+
+@pytest.mark.asyncio
+async def test_climate_platform_uses_config_fan_capability(
+    hass: HomeAssistant,
+    carrier_api: FakeCarrierApiConnection,
+    setup_integration: Callable[..., Any],
+) -> None:
+    """Omit fan controls when Carrier config reports fan support is disabled."""
+    carrier_api.systems = [build_carrier_system(fan_enabled=False)]
+
+    await setup_integration()
+    entity_id = entity_id_for_unique_id(hass, CLIMATE_DOMAIN, "abc123_zone_1_thermostat")
+    state = hass.states.get(entity_id)
+
+    assert state is not None
+    assert "fan_mode" not in state.attributes
+    assert "fan_modes" not in state.attributes
+    assert HVACMode.FAN_ONLY not in state.attributes["hvac_modes"]
 
 
 @pytest.mark.asyncio
@@ -182,6 +201,40 @@ async def test_climate_fan_mode_service_updates_current_activity(
     state = hass.states.get(entity_id)
     assert state is not None
     assert state.attributes["fan_mode"] == "high"
+
+
+@pytest.mark.asyncio
+async def test_climate_fan_mode_service_uses_status_activity(
+    hass: HomeAssistant,
+    carrier_api: FakeCarrierApiConnection,
+    setup_integration: Callable[..., Any],
+) -> None:
+    """Write fan settings against Carrier's live status activity."""
+    carrier_api.systems = [build_carrier_system()]
+    system = carrier_api.systems[0]
+    system.config.zones[0].hold = True
+    system.config.zones[0].hold_activity = ActivityTypes.AWAY
+    system.status.zones[0].current_status_activity_type = ActivityTypes.HOME
+    await setup_integration()
+    entity_id = entity_id_for_unique_id(hass, CLIMATE_DOMAIN, "abc123_zone_1_thermostat")
+
+    await hass.services.async_call(
+        CLIMATE_DOMAIN,
+        SERVICE_SET_FAN_MODE,
+        {ATTR_ENTITY_ID: entity_id, ATTR_FAN_MODE: "high"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert carrier_api.calls[-1] == (
+        "update_fan",
+        {
+            "system_serial": "ABC123",
+            "zone_id": "1",
+            "activity_type": ActivityTypes.HOME,
+            "fan_mode": FanModes.HIGH,
+        },
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -76,7 +76,7 @@ async def test_climate_preset_mode_uses_status_activity(
     setup_integration: Callable[..., Any],
 ) -> None:
     """Prefer Carrier's status activity over matching configured setpoints."""
-    carrier_api.systems = [build_carrier_system()]
+    carrier_api.systems = [build_carrier_system(fan_enabled=True)]
     system = carrier_api.systems[0]
     system.status.zones[0].current_status_activity_type = ActivityTypes.AWAY
     system.status.zones[0].heat_set_point = 68
@@ -231,7 +231,7 @@ async def test_climate_fan_mode_service_uses_status_activity(
     setup_integration: Callable[..., Any],
 ) -> None:
     """Write fan settings against Carrier's live status activity."""
-    carrier_api.systems = [build_carrier_system()]
+    carrier_api.systems = [build_carrier_system(fan_enabled=True)]
     system = carrier_api.systems[0]
     system.config.zones[0].hold = True
     system.config.zones[0].hold_activity = ActivityTypes.AWAY

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -25,4 +25,15 @@ async def test_diagnostics_redacts_config_entry_and_includes_device_entities(
     assert diagnostics["entry"]["data"][CONF_USERNAME] == "**REDACTED**"
     assert diagnostics["entry"]["data"][CONF_PASSWORD] == "**REDACTED**"
     assert diagnostics["ABC123"]["mapped_data"]["serial"] == "**REDACTED**"
+    assert diagnostics["ABC123"]["mapped_data"]["supported_hvac_capabilities"] == {
+        "cool": True,
+        "fan": True,
+        "heat": True,
+    }
+    assert (
+        diagnostics["ABC123"]["mapped_data"]["config"]["zones"][0]["current_activity"][
+            "from_status"
+        ]["type"]
+        == "home"
+    )
     assert diagnostics["ABC123"]["device"]["entities"]

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -17,7 +17,7 @@ async def test_diagnostics_redacts_config_entry_and_includes_device_entities(
     hass: HomeAssistant,
     setup_integration: Callable[..., Any],
 ) -> None:
-    """Build diagnostics from a loaded entry with redacted sensitive data."""
+    """Build diagnostics with redaction, HVAC capabilities, and activity data."""
     config_entry = await setup_integration()
 
     diagnostics = await async_get_config_entry_diagnostics(hass, config_entry)


### PR DESCRIPTION
## Summary
Updates the Carrier climate and select paths to use the zone status activity and HVAC capability helpers now provided by `carrier_api` 3.2.0.

## What Changed
- Replaced local heat/cool/fan capability inference with `carrier_api` system capability helpers.
- Changed climate preset and fan-mode resolution to use Carrier's live status activity instead of deriving the active profile from matching setpoints or stale hold config.
- Removed the old local capability helper constants/functions from `ha_carrier.util`.
- Bumped the integration dependency to `carrier-api==3.2.0`.
- Added regression coverage for status-derived preset resolution, status-derived fan writes, config-reported fan capability, and diagnostics mapped data from `System.as_dict()`.
- Updated review-follow-up tests so fan-dependent climate assertions opt into fan capability explicitly.

## Why
`carrier_api` now owns raw-data interpretation for zone profile selection and HVAC capability reporting. Keeping that logic in one package avoids duplicated inference in `ha_carrier` and fixes cases where matching setpoints or stale hold state could point at the wrong activity.

## Validation
- `./scripts/lint`
- `./.venv/bin/pytest`
- Upstream PR checks: lint, hassfest, HACS validation, and pytest/coverage all passing.

## Related
- Uses the helpers released in `carrier-api==3.2.0`.
