### PR TITLE
Use Carrier API energy helper models

### DIFF
--- a/custom_components/ha_carrier/climate.py
+++ b/custom_components/ha_carrier/climate.py
@@ -58,6 +58,7 @@ async def async_setup_entry(
     for carrier_system in coordinator.systems:
         supported_hvac_capabilities = carrier_system.supported_hvac_capabilities()
         support_flags = BASE_SUPPORT_FLAGS
+        supported_hvac_capabilities = carrier_system.supported_hvac_capabilities()
         hvac_modes: list[HVACMode] = [
             HVACMode.OFF,
         ]

--- a/custom_components/ha_carrier/climate.py
+++ b/custom_components/ha_carrier/climate.py
@@ -56,7 +56,6 @@ async def async_setup_entry(
     coordinator = config_entry.runtime_data
     entities: list[Thermostat] = []
     for carrier_system in coordinator.systems:
-        supported_hvac_capabilities = carrier_system.supported_hvac_capabilities()
         support_flags = BASE_SUPPORT_FLAGS
         supported_hvac_capabilities = carrier_system.supported_hvac_capabilities()
         hvac_modes: list[HVACMode] = [

--- a/custom_components/ha_carrier/manifest.json
+++ b/custom_components/ha_carrier/manifest.json
@@ -14,7 +14,7 @@
     "carrier_api"
   ],
   "requirements": [
-    "carrier-api==3.2.0"
+    "carrier-api==3.3.0"
   ],
   "version": "2.23.5"
 }

--- a/custom_components/ha_carrier/migrate.py
+++ b/custom_components/ha_carrier/migrate.py
@@ -5,7 +5,13 @@ from __future__ import annotations
 from collections.abc import Iterable, Mapping
 import logging
 
-from carrier_api import ENERGY_USAGE_METRICS, ApiConnectionGraphql, CarrierApiError, System
+from carrier_api import (
+    ENERGY_USAGE_METRICS,
+    ApiConnectionGraphql,
+    CarrierApiError,
+    EnergyUsageMetric,
+    System,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
@@ -430,7 +436,10 @@ def _async_build_created_unique_ids(systems: Iterable[System]) -> set[str]:
             )
 
         fuel_type = carrier_system.config.fuel_type
-        if carrier_system.energy.is_usage_metric_enabled("gas") and fuel_type is not None:
+        if (
+            carrier_system.energy.is_usage_metric_enabled(EnergyUsageMetric.GAS)
+            and fuel_type is not None
+        ):
             created_unique_ids.add(
                 _async_new_unique_id(
                     system_serial,

--- a/custom_components/ha_carrier/migrate.py
+++ b/custom_components/ha_carrier/migrate.py
@@ -13,7 +13,7 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_registry import EntityRegistry, RegistryEntry
 from homeassistant.util import slugify
 
-from .util import TIMESTAMP_TYPES, async_get_carrier_identity_id, energy_metric_value
+from .util import TIMESTAMP_TYPES, async_get_carrier_identity_id
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -318,8 +318,6 @@ def _async_build_unique_id_migration_map(
     Returns:
         dict[str, str]: Mapping from version 1 unique IDs to version 2 unique IDs.
     """
-    from .sensor import _energy_metric_label  # noqa: PLC0415
-
     migration_map: dict[str, str] = {}
 
     for carrier_system in systems:
@@ -362,7 +360,7 @@ def _async_build_unique_id_migration_map(
             metric_labels = {
                 metric_name,
                 metric_name.replace("_", " ").title(),
-                _energy_metric_label(metric),
+                metric.label,
             }
             for metric_label in metric_labels:
                 _async_add_unique_id_migration(
@@ -425,8 +423,7 @@ def _async_build_created_unique_ids(systems: Iterable[System]) -> set[str]:
             created_unique_ids.add(_async_new_unique_id(system_serial, "Heat Source"))
 
         for metric in carrier_system.energy.enabled_usage_metrics():
-            metric_value = energy_metric_value(metric)
-            metric_title = metric_value.replace("_", " ").title()
+            metric_title = metric.value.replace("_", " ").title()
             created_unique_ids.add(
                 _async_new_unique_id(system_serial, f"{metric_title} Energy Year to Date")
             )

--- a/custom_components/ha_carrier/migrate.py
+++ b/custom_components/ha_carrier/migrate.py
@@ -5,13 +5,7 @@ from __future__ import annotations
 from collections.abc import Iterable, Mapping
 import logging
 
-from carrier_api import (
-    ENERGY_USAGE_METRICS,
-    ApiConnectionGraphql,
-    CarrierApiError,
-    EnergyUsageMetric,
-    System,
-)
+from carrier_api import ApiConnectionGraphql, CarrierApiError, EnergyUsageMetric, System
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
@@ -363,7 +357,7 @@ def _async_build_unique_id_migration_map(
             "Propane Consumption Year to Date",
         )
 
-        for metric in ENERGY_USAGE_METRICS:
+        for metric in EnergyUsageMetric:
             metric_name = metric.value
             metric_labels = {
                 metric_name,

--- a/custom_components/ha_carrier/migrate.py
+++ b/custom_components/ha_carrier/migrate.py
@@ -423,8 +423,6 @@ def _async_build_created_unique_ids(systems: Iterable[System]) -> set[str]:
             created_unique_ids.add(_async_new_unique_id(system_serial, "Heat Source"))
 
         for metric in carrier_system.energy.enabled_usage_metrics():
-            if metric == EnergyUsageMetric.GAS:
-                continue
             created_unique_ids.add(
                 _async_new_unique_id(system_serial, f"{metric.value} Energy Year to Date")
             )

--- a/custom_components/ha_carrier/migrate.py
+++ b/custom_components/ha_carrier/migrate.py
@@ -423,15 +423,14 @@ def _async_build_created_unique_ids(systems: Iterable[System]) -> set[str]:
             created_unique_ids.add(_async_new_unique_id(system_serial, "Heat Source"))
 
         for metric in carrier_system.energy.enabled_usage_metrics():
-            metric_title = metric.value.replace("_", " ").title()
             created_unique_ids.add(
-                _async_new_unique_id(system_serial, f"{metric_title} Energy Year to Date")
+                _async_new_unique_id(system_serial, f"{metric.value} Energy Year to Date")
             )
             created_unique_ids.add(
-                _async_new_unique_id(system_serial, f"{metric_title} Energy Yesterday")
+                _async_new_unique_id(system_serial, f"{metric.value} Energy Yesterday")
             )
             created_unique_ids.add(
-                _async_new_unique_id(system_serial, f"{metric_title} Energy Last Month")
+                _async_new_unique_id(system_serial, f"{metric.value} Energy Last Month")
             )
 
         fuel_type = carrier_system.config.fuel_type

--- a/custom_components/ha_carrier/migrate.py
+++ b/custom_components/ha_carrier/migrate.py
@@ -19,7 +19,7 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_registry import EntityRegistry, RegistryEntry
 from homeassistant.util import slugify
 
-from .util import TIMESTAMP_TYPES, async_get_carrier_identity_id
+from .util import TIMESTAMP_TYPES, async_get_carrier_identity_id, energy_metric_value
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -49,18 +49,6 @@ SYSTEM_ENTITY_SUFFIXES: set[str] = {
     *ALWAYS_CREATED_SYSTEM_ENTITY_SUFFIXES,
     *CONDITIONALLY_CREATED_SYSTEM_ENTITY_SUFFIXES,
 }
-
-
-def _energy_metric_value(metric: EnergyUsageMetric | str) -> str:
-    """Return the normalized value for a Carrier energy usage metric.
-
-    Args:
-        metric: Carrier API energy metric enum or string value.
-
-    Returns:
-        str: Normalized metric value used in unique IDs.
-    """
-    return metric.value if isinstance(metric, EnergyUsageMetric) else metric
 
 
 def _async_new_unique_id(system_serial: str, new_suffix: str) -> str:
@@ -436,7 +424,7 @@ def _async_build_created_unique_ids(systems: Iterable[System]) -> set[str]:
             created_unique_ids.add(_async_new_unique_id(system_serial, "Heat Source"))
 
         for metric in carrier_system.energy.enabled_usage_metrics():
-            metric_value = _energy_metric_value(metric)
+            metric_value = energy_metric_value(metric)
             metric_title = metric_value.replace("_", " ").title()
             created_unique_ids.add(
                 _async_new_unique_id(system_serial, f"{metric_title} Energy Year to Date")

--- a/custom_components/ha_carrier/migrate.py
+++ b/custom_components/ha_carrier/migrate.py
@@ -423,6 +423,8 @@ def _async_build_created_unique_ids(systems: Iterable[System]) -> set[str]:
             created_unique_ids.add(_async_new_unique_id(system_serial, "Heat Source"))
 
         for metric in carrier_system.energy.enabled_usage_metrics():
+            if metric == EnergyUsageMetric.GAS:
+                continue
             created_unique_ids.add(
                 _async_new_unique_id(system_serial, f"{metric.value} Energy Year to Date")
             )

--- a/custom_components/ha_carrier/migrate.py
+++ b/custom_components/ha_carrier/migrate.py
@@ -324,6 +324,8 @@ def _async_build_unique_id_migration_map(
     Returns:
         dict[str, str]: Mapping from version 1 unique IDs to version 2 unique IDs.
     """
+    from .sensor import _energy_metric_label  # noqa: PLC0415
+
     migration_map: dict[str, str] = {}
 
     for carrier_system in systems:
@@ -363,25 +365,30 @@ def _async_build_unique_id_migration_map(
 
         for metric in ENERGY_USAGE_METRICS:
             metric_name = metric.value
-            metric_title = metric_name.replace("_", " ").title()
-            _async_add_unique_id_migration(
-                migration_map,
-                system_serial,
-                f"{metric_name} Energy Yearly",
-                f"{metric_title} Energy Year to Date",
-            )
-            _async_add_unique_id_migration(
-                migration_map,
-                system_serial,
-                f"{metric_name} Energy Yesterday",
-                f"{metric_title} Energy Yesterday",
-            )
-            _async_add_unique_id_migration(
-                migration_map,
-                system_serial,
-                f"{metric_name} Energy Last Month",
-                f"{metric_title} Energy Last Month",
-            )
+            metric_labels = {
+                metric_name,
+                metric_name.replace("_", " ").title(),
+                _energy_metric_label(metric),
+            }
+            for metric_label in metric_labels:
+                _async_add_unique_id_migration(
+                    migration_map,
+                    system_serial,
+                    f"{metric_label} Energy Yearly",
+                    f"{metric_name} Energy Year to Date",
+                )
+                _async_add_unique_id_migration(
+                    migration_map,
+                    system_serial,
+                    f"{metric_label} Energy Yesterday",
+                    f"{metric_name} Energy Yesterday",
+                )
+                _async_add_unique_id_migration(
+                    migration_map,
+                    system_serial,
+                    f"{metric_label} Energy Last Month",
+                    f"{metric_name} Energy Last Month",
+                )
 
     # Zone entities need registry context because their v1 unique IDs were based
     # on names and v2 unique IDs are based on stable Carrier zone API IDs.

--- a/custom_components/ha_carrier/migrate.py
+++ b/custom_components/ha_carrier/migrate.py
@@ -51,6 +51,18 @@ SYSTEM_ENTITY_SUFFIXES: set[str] = {
 }
 
 
+def _energy_metric_value(metric: EnergyUsageMetric | str) -> str:
+    """Return the normalized value for a Carrier energy usage metric.
+
+    Args:
+        metric: Carrier API energy metric enum or string value.
+
+    Returns:
+        str: Normalized metric value used in unique IDs.
+    """
+    return metric.value if isinstance(metric, EnergyUsageMetric) else metric
+
+
 def _async_new_unique_id(system_serial: str, new_suffix: str) -> str:
     """Return the version 2 unique ID for a Carrier entity.
 
@@ -424,7 +436,8 @@ def _async_build_created_unique_ids(systems: Iterable[System]) -> set[str]:
             created_unique_ids.add(_async_new_unique_id(system_serial, "Heat Source"))
 
         for metric in carrier_system.energy.enabled_usage_metrics():
-            metric_title = metric.value.replace("_", " ").title()
+            metric_value = _energy_metric_value(metric)
+            metric_title = metric_value.replace("_", " ").title()
             created_unique_ids.add(
                 _async_new_unique_id(system_serial, f"{metric_title} Energy Year to Date")
             )

--- a/custom_components/ha_carrier/migrate.py
+++ b/custom_components/ha_carrier/migrate.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Iterable, Mapping
 import logging
 
-from carrier_api import ApiConnectionGraphql, CarrierApiError, System
+from carrier_api import ENERGY_USAGE_METRICS, ApiConnectionGraphql, CarrierApiError, System
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
@@ -13,7 +13,7 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_registry import EntityRegistry, RegistryEntry
 from homeassistant.util import slugify
 
-from .util import ENERGY_METRIC_MAP, TIMESTAMP_TYPES, async_get_carrier_identity_id
+from .util import TIMESTAMP_TYPES, async_get_carrier_identity_id
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -355,24 +355,25 @@ def _async_build_unique_id_migration_map(
             "Propane Consumption Year to Date",
         )
 
-        for metric in ENERGY_METRIC_MAP:
-            metric_title = metric.replace("_", " ").title()
+        for metric in ENERGY_USAGE_METRICS:
+            metric_name = metric.value
+            metric_title = metric_name.replace("_", " ").title()
             _async_add_unique_id_migration(
                 migration_map,
                 system_serial,
-                f"{metric} Energy Yearly",
+                f"{metric_name} Energy Yearly",
                 f"{metric_title} Energy Year to Date",
             )
             _async_add_unique_id_migration(
                 migration_map,
                 system_serial,
-                f"{metric} Energy Yesterday",
+                f"{metric_name} Energy Yesterday",
                 f"{metric_title} Energy Yesterday",
             )
             _async_add_unique_id_migration(
                 migration_map,
                 system_serial,
-                f"{metric} Energy Last Month",
+                f"{metric_name} Energy Last Month",
                 f"{metric_title} Energy Last Month",
             )
 
@@ -416,21 +417,20 @@ def _async_build_created_unique_ids(systems: Iterable[System]) -> set[str]:
         if carrier_system.supports_heat():
             created_unique_ids.add(_async_new_unique_id(system_serial, "Heat Source"))
 
-        for metric in ENERGY_METRIC_MAP:
-            if getattr(carrier_system.energy, metric, False) is True:
-                metric_title = metric.replace("_", " ").title()
-                created_unique_ids.add(
-                    _async_new_unique_id(system_serial, f"{metric_title} Energy Year to Date")
-                )
-                created_unique_ids.add(
-                    _async_new_unique_id(system_serial, f"{metric_title} Energy Yesterday")
-                )
-                created_unique_ids.add(
-                    _async_new_unique_id(system_serial, f"{metric_title} Energy Last Month")
-                )
+        for metric in carrier_system.energy.enabled_usage_metrics():
+            metric_title = metric.value.replace("_", " ").title()
+            created_unique_ids.add(
+                _async_new_unique_id(system_serial, f"{metric_title} Energy Year to Date")
+            )
+            created_unique_ids.add(
+                _async_new_unique_id(system_serial, f"{metric_title} Energy Yesterday")
+            )
+            created_unique_ids.add(
+                _async_new_unique_id(system_serial, f"{metric_title} Energy Last Month")
+            )
 
         fuel_type = carrier_system.config.fuel_type
-        if getattr(carrier_system.energy, "gas", False) is True and fuel_type is not None:
+        if carrier_system.energy.is_usage_metric_enabled("gas") and fuel_type is not None:
             created_unique_ids.add(
                 _async_new_unique_id(
                     system_serial,

--- a/custom_components/ha_carrier/sensor.py
+++ b/custom_components/ha_carrier/sensor.py
@@ -22,21 +22,9 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from . import ConfigEntryCarrier
 from .carrier_data_update_coordinator import CarrierDataUpdateCoordinator
 from .carrier_entity import CarrierEntity, CarrierZoneEntity
-from .util import TIMESTAMP_TYPES
+from .util import TIMESTAMP_TYPES, energy_metric_value
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
-
-
-def _energy_metric_value(metric: EnergyUsageMetric | str) -> str:
-    """Return the normalized value for a Carrier energy metric.
-
-    Args:
-        metric: Carrier API energy metric enum or string value.
-
-    Returns:
-        Normalized metric value used in unique IDs and helper lookups.
-    """
-    return metric.value if isinstance(metric, EnergyUsageMetric) else metric
 
 
 def _energy_metric_label(metric: EnergyUsageMetric | str) -> str:
@@ -56,14 +44,14 @@ def _energy_metric_label(metric: EnergyUsageMetric | str) -> str:
         return metric.replace("_", " ").title()
 
 
-def _energy_native_value(value: float | None) -> float | None:
+def _energy_native_value(value: float | None) -> int | float | None:
     """Return an energy value without changing whole-number state strings.
 
     Args:
         value: Energy value returned by carrier_api.
 
     Returns:
-        The original value, except integral floats are normalized to integers.
+        The original value as int when integral, otherwise unchanged.
     """
     if isinstance(value, float) and value.is_integer():
         return int(value)
@@ -461,7 +449,7 @@ class YearlyEnergyMeasurementSensor(CarrierSensor):
         """
         self.metric = metric
         metric_label = _energy_metric_label(metric)
-        metric_value = _energy_metric_value(metric)
+        metric_value = energy_metric_value(metric)
         super().__init__(
             entity_name=f"{metric_label} Energy Year to Date",
             coordinator=coordinator,
@@ -499,7 +487,7 @@ class DailyEnergyMeasurementSensor(CarrierSensor):
         """
         self.metric = metric
         metric_label = _energy_metric_label(metric)
-        metric_value = _energy_metric_value(metric)
+        metric_value = energy_metric_value(metric)
         super().__init__(
             entity_name=f"{metric_label} Energy Yesterday",
             coordinator=coordinator,
@@ -537,7 +525,7 @@ class MonthlyEnergyMeasurementSensor(CarrierSensor):
         """
         self.metric = metric
         metric_label = _energy_metric_label(metric)
-        metric_value = _energy_metric_value(metric)
+        metric_value = energy_metric_value(metric)
         super().__init__(
             entity_name=f"{metric_label} Energy Last Month",
             coordinator=coordinator,

--- a/custom_components/ha_carrier/sensor.py
+++ b/custom_components/ha_carrier/sensor.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
 import logging
 
 from carrier_api import EnergyPeriod, EnergyUsageMetric, StatusUnit, TemperatureUnits
@@ -27,21 +26,16 @@ from .util import TIMESTAMP_TYPES, energy_metric_value
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
 
-def _energy_metric_label(metric: EnergyUsageMetric | str) -> str:
+def _energy_metric_label(metric: EnergyUsageMetric) -> str:
     """Return the display label for a Carrier energy metric.
 
     Args:
-        metric: Carrier API energy metric enum or string value.
+        metric: Carrier API energy metric enum.
 
     Returns:
-        Carrier API metric label, or a title-cased fallback for unknown strings.
+        Carrier API metric label.
     """
-    if isinstance(metric, EnergyUsageMetric):
-        return metric.label
-    try:
-        return EnergyUsageMetric(metric).label
-    except ValueError:
-        return metric.replace("_", " ").title()
+    return metric.label
 
 
 def _energy_native_value(value: float | None) -> int | float | None:
@@ -58,37 +52,19 @@ def _energy_native_value(value: float | None) -> int | float | None:
     return value
 
 
-def _unit_status_attributes(
-    unit: StatusUnit | None,
-    raw_attributes: object = None,
-) -> dict[str, object]:
+def _unit_status_attributes(unit: StatusUnit | None) -> dict[str, object]:
     """Return Home Assistant attributes for mapped Carrier unit status details.
 
     Args:
         unit: Mapped Carrier API indoor or outdoor unit status.
-        raw_attributes: Raw Carrier unit status attributes to preserve.
 
     Returns:
         Dictionary of available unit attributes, or an empty dictionary when no
         mapped unit status exists.
     """
-    attributes: dict[str, object] = (
-        dict(raw_attributes) if isinstance(raw_attributes, Mapping) else {}
-    )
     if unit is None:
-        return attributes
-    attributes.update(unit.as_dict())
-    legacy_attributes = {
-        "type": unit.type,
-        "opstat": unit.operational_status,
-        "cfm": unit.airflow_cfm,
-        "statpress": unit.static_pressure,
-        "blwrpm": unit.blower_rpm,
-    }
-    for key, value in legacy_attributes.items():
-        if value is not None:
-            attributes.setdefault(key, value)
-    return attributes
+        return {}
+    return unit.as_dict()
 
 
 async def async_setup_entry(
@@ -438,14 +414,14 @@ class YearlyEnergyMeasurementSensor(CarrierSensor):
         self,
         coordinator: CarrierDataUpdateCoordinator,
         system_serial: str,
-        metric: EnergyUsageMetric | str,
+        metric: EnergyUsageMetric,
     ) -> None:
         """Initialize a yearly energy measurement sensor.
 
         Args:
             coordinator: Coordinator that provides energy payloads.
             system_serial: Carrier system serial for this entity.
-            metric: Name of the Carrier energy metric to expose.
+            metric: Carrier API energy metric to expose.
         """
         self.metric = metric
         metric_label = _energy_metric_label(metric)
@@ -476,14 +452,14 @@ class DailyEnergyMeasurementSensor(CarrierSensor):
         self,
         coordinator: CarrierDataUpdateCoordinator,
         system_serial: str,
-        metric: EnergyUsageMetric | str,
+        metric: EnergyUsageMetric,
     ) -> None:
         """Initialize a daily energy sensor for a specific metric.
 
         Args:
             coordinator: Coordinator that provides energy payloads.
             system_serial: Carrier system serial for this entity.
-            metric: Internal Carrier metric name to expose.
+            metric: Carrier API energy metric to expose.
         """
         self.metric = metric
         metric_label = _energy_metric_label(metric)
@@ -514,14 +490,14 @@ class MonthlyEnergyMeasurementSensor(CarrierSensor):
         self,
         coordinator: CarrierDataUpdateCoordinator,
         system_serial: str,
-        metric: EnergyUsageMetric | str,
+        metric: EnergyUsageMetric,
     ) -> None:
         """Initialize a monthly energy sensor for a specific metric.
 
         Args:
             coordinator: Coordinator that provides energy payloads.
             system_serial: Carrier system serial for this entity.
-            metric: Internal Carrier metric name to expose.
+            metric: Carrier API energy metric to expose.
         """
         self.metric = metric
         metric_label = _energy_metric_label(metric)
@@ -786,7 +762,7 @@ class StaticPressureSensor(CarrierSensor):
 
 
 class OutdoorUnitOperationalStatusSensor(CarrierSensor):
-    """Sensor for outdoor unit operational status and related raw details."""
+    """Sensor for outdoor unit operational status and mapped unit details."""
 
     _attr_icon = "mdi:hvac"
 
@@ -815,13 +791,11 @@ class OutdoorUnitOperationalStatusSensor(CarrierSensor):
         else:
             self._attr_native_value = value
             self._attr_available = True
-        status_raw = self.carrier_system.status.raw
-        raw_attributes = status_raw.get("odu") if status_raw is not None else None
-        self._attr_extra_state_attributes = _unit_status_attributes(outdoor_unit, raw_attributes)
+        self._attr_extra_state_attributes = _unit_status_attributes(outdoor_unit)
 
 
 class IndoorUnitOperationalStatusSensor(CarrierSensor):
-    """Sensor for indoor unit operational status and related raw details."""
+    """Sensor for indoor unit operational status and mapped unit details."""
 
     _attr_icon = "mdi:hvac"
 
@@ -843,9 +817,7 @@ class IndoorUnitOperationalStatusSensor(CarrierSensor):
         indoor_unit = self.carrier_system.status.indoor_unit
         self._attr_native_value = self.carrier_system.status.indoor_unit_operational_status
         self._attr_available = self._attr_native_value is not None
-        status_raw = self.carrier_system.status.raw
-        raw_attributes = status_raw.get("idu") if status_raw is not None else None
-        self._attr_extra_state_attributes = _unit_status_attributes(indoor_unit, raw_attributes)
+        self._attr_extra_state_attributes = _unit_status_attributes(indoor_unit)
 
 
 class OutdoorUnitVarSensor(CarrierSensor):

--- a/custom_components/ha_carrier/sensor.py
+++ b/custom_components/ha_carrier/sensor.py
@@ -2,10 +2,9 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
 import logging
 
-from carrier_api import TemperatureUnits
+from carrier_api import EnergyPeriod, EnergyUsageMetric, StatusUnit, TemperatureUnits
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity, SensorStateClass
 from homeassistant.const import (
     PERCENTAGE,
@@ -22,9 +21,36 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from . import ConfigEntryCarrier
 from .carrier_data_update_coordinator import CarrierDataUpdateCoordinator
 from .carrier_entity import CarrierEntity, CarrierZoneEntity
-from .util import ENERGY_METRIC_MAP, TIMESTAMP_TYPES
+from .util import TIMESTAMP_TYPES
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
+
+
+def _energy_metric_name(metric: EnergyUsageMetric | str) -> str:
+    """Return the normalized name for a Carrier energy metric.
+
+    Args:
+        metric: Carrier API energy metric enum or string value.
+
+    Returns:
+        Normalized metric name used in entity names and helper lookups.
+    """
+    return metric.value if isinstance(metric, EnergyUsageMetric) else metric
+
+
+def _unit_status_attributes(unit: StatusUnit | None) -> dict[str, object]:
+    """Return Home Assistant attributes for mapped Carrier unit status details.
+
+    Args:
+        unit: Mapped Carrier API indoor or outdoor unit status.
+
+    Returns:
+        Dictionary of available unit attributes, or an empty dictionary when no
+        mapped unit status exists.
+    """
+    if unit is None:
+        return {}
+    return unit.as_dict()
 
 
 async def async_setup_entry(
@@ -91,30 +117,31 @@ async def async_setup_entry(
                     coordinator=coordinator, system_serial=carrier_system.profile.serial
                 )
             )
-        for electric_metric in ENERGY_METRIC_MAP:
-            if getattr(carrier_system.energy, electric_metric, False) is True:
-                entities.extend(
-                    [
-                        YearlyEnergyMeasurementSensor(
-                            coordinator=coordinator,
-                            system_serial=carrier_system.profile.serial,
-                            metric=electric_metric,
-                        ),
-                        DailyEnergyMeasurementSensor(
-                            coordinator=coordinator,
-                            system_serial=carrier_system.profile.serial,
-                            metric=electric_metric,
-                        ),
-                        MonthlyEnergyMeasurementSensor(
-                            coordinator=coordinator,
-                            system_serial=carrier_system.profile.serial,
-                            metric=electric_metric,
-                        ),
-                    ]
-                )
-        gas_measurement = getattr(carrier_system.energy, "gas", False)
+        for electric_metric in carrier_system.energy.enabled_usage_metrics():
+            entities.extend(
+                [
+                    YearlyEnergyMeasurementSensor(
+                        coordinator=coordinator,
+                        system_serial=carrier_system.profile.serial,
+                        metric=electric_metric,
+                    ),
+                    DailyEnergyMeasurementSensor(
+                        coordinator=coordinator,
+                        system_serial=carrier_system.profile.serial,
+                        metric=electric_metric,
+                    ),
+                    MonthlyEnergyMeasurementSensor(
+                        coordinator=coordinator,
+                        system_serial=carrier_system.profile.serial,
+                        metric=electric_metric,
+                    ),
+                ]
+            )
         fuel_type = carrier_system.config.fuel_type
-        if gas_measurement is True and fuel_type is not None:
+        if (
+            carrier_system.energy.is_usage_metric_enabled(EnergyUsageMetric.GAS)
+            and fuel_type is not None
+        ):
             entities.append(
                 GasMeasurementSensor(
                     coordinator=coordinator,
@@ -291,26 +318,13 @@ class GasMeasurementSensor(CarrierSensor):
 
     def _update_entity_attrs(self) -> None:
         """Update gas usage attrs from coordinator data."""
-        if self.carrier_system.energy.raw is None:
-            self._attr_available = False
-            return
-
-        api_field = ENERGY_METRIC_MAP.get(self.metric)
-        if api_field is None:
-            _LOGGER.debug("Unknown gas usage metric requested: %s", self.metric)
-            self._attr_available = False
-            return
-
-        energy_periods = self.carrier_system.energy.raw.get("energyPeriods", [])
-        value: float | None = None
-        for period in energy_periods:
-            if period.get("energyPeriodType") == "year1":
-                value = period.get(api_field)
-                break
+        value: float | int | None = self.carrier_system.energy.value_for_period_metric(
+            EnergyPeriod.YEAR_1, self.metric
+        )
         if value is None:
             _LOGGER.debug(
-                "%s missing in year1 energyPeriod for system %s; marking unavailable",
-                api_field,
+                "%s missing in year1 energy period for system %s; marking unavailable",
+                self.metric,
                 self._system_serial,
             )
             self._attr_available = False
@@ -359,26 +373,11 @@ class PropaneMeasurementSensor(CarrierSensor):
 
     def _update_entity_attrs(self) -> None:
         """Update propane usage attrs from coordinator data."""
-        if self.carrier_system.energy.raw is None:
-            self._attr_available = False
-            return
-
-        api_field = ENERGY_METRIC_MAP.get(self.metric)
-        if api_field is None:
-            _LOGGER.debug("Unknown propane usage metric requested: %s", self.metric)
-            self._attr_available = False
-            return
-
-        energy_periods = self.carrier_system.energy.raw.get("energyPeriods", [])
-        value: float | None = None
-        for period in energy_periods:
-            if period.get("energyPeriodType") == "year1":
-                value = period.get(api_field)
-                break
+        value = self.carrier_system.energy.value_for_period_metric(EnergyPeriod.YEAR_1, self.metric)
         if value is None:
             _LOGGER.debug(
-                "%s missing in year1 energyPeriod for system %s; marking unavailable",
-                api_field,
+                "%s missing in year1 energy period for system %s; marking unavailable",
+                self.metric,
                 self._system_serial,
             )
             self._attr_available = False
@@ -398,7 +397,10 @@ class YearlyEnergyMeasurementSensor(CarrierSensor):
     _attr_suggested_display_precision = 0
 
     def __init__(
-        self, coordinator: CarrierDataUpdateCoordinator, system_serial: str, metric: str
+        self,
+        coordinator: CarrierDataUpdateCoordinator,
+        system_serial: str,
+        metric: EnergyUsageMetric | str,
     ) -> None:
         """Initialize a yearly energy measurement sensor.
 
@@ -408,33 +410,18 @@ class YearlyEnergyMeasurementSensor(CarrierSensor):
             metric: Name of the Carrier energy metric to expose.
         """
         self.metric = metric
+        metric_name = _energy_metric_name(metric)
         super().__init__(
-            entity_name=f"{metric.replace('_', ' ').title()} Energy Year to Date",
+            entity_name=f"{metric_name.replace('_', ' ').title()} Energy Year to Date",
             coordinator=coordinator,
             system_serial=system_serial,
         )
 
     def _update_entity_attrs(self) -> None:
         """Update yearly energy attrs from coordinator data."""
-        if self.carrier_system.energy.raw is None:
-            self._attr_available = False
-            return
-
-        api_field = ENERGY_METRIC_MAP.get(self.metric)
-        if api_field is None:
-            _LOGGER.debug("Unknown yearly energy metric requested: %s", self.metric)
-            self._attr_available = False
-            return
-
-        energy_periods = self.carrier_system.energy.raw.get("energyPeriods", [])
-        for period in energy_periods:
-            if period.get("energyPeriodType") == "year1":
-                value = period.get(api_field)
-                if value is not None:
-                    self._attr_native_value = value
-                    self._attr_available = True
-                    return
-        self._attr_available = False
+        value = self.carrier_system.energy.value_for_period_metric(EnergyPeriod.YEAR_1, self.metric)
+        self._attr_native_value = value
+        self._attr_available = value is not None
 
 
 class DailyEnergyMeasurementSensor(CarrierSensor):
@@ -446,7 +433,10 @@ class DailyEnergyMeasurementSensor(CarrierSensor):
     _attr_suggested_display_precision = 1
 
     def __init__(
-        self, coordinator: CarrierDataUpdateCoordinator, system_serial: str, metric: str
+        self,
+        coordinator: CarrierDataUpdateCoordinator,
+        system_serial: str,
+        metric: EnergyUsageMetric | str,
     ) -> None:
         """Initialize a daily energy sensor for a specific metric.
 
@@ -456,33 +446,18 @@ class DailyEnergyMeasurementSensor(CarrierSensor):
             metric: Internal Carrier metric name to expose.
         """
         self.metric = metric
+        metric_name = _energy_metric_name(metric)
         super().__init__(
-            entity_name=f"{metric.replace('_', ' ').title()} Energy Yesterday",
+            entity_name=f"{metric_name.replace('_', ' ').title()} Energy Yesterday",
             coordinator=coordinator,
             system_serial=system_serial,
         )
 
     def _update_entity_attrs(self) -> None:
         """Update daily energy attrs from coordinator data."""
-        if self.carrier_system.energy.raw is None:
-            self._attr_available = False
-            return
-
-        api_field = ENERGY_METRIC_MAP.get(self.metric)
-        if api_field is None:
-            _LOGGER.debug("Unknown daily energy metric requested: %s", self.metric)
-            self._attr_available = False
-            return
-
-        energy_periods = self.carrier_system.energy.raw.get("energyPeriods", [])
-        for period in energy_periods:
-            if period.get("energyPeriodType") == "day1":
-                value = period.get(api_field)
-                if value is not None:
-                    self._attr_native_value = value
-                    self._attr_available = True
-                    return
-        self._attr_available = False
+        value = self.carrier_system.energy.value_for_period_metric(EnergyPeriod.DAY_1, self.metric)
+        self._attr_native_value = value
+        self._attr_available = value is not None
 
 
 class MonthlyEnergyMeasurementSensor(CarrierSensor):
@@ -494,7 +469,10 @@ class MonthlyEnergyMeasurementSensor(CarrierSensor):
     _attr_suggested_display_precision = 0
 
     def __init__(
-        self, coordinator: CarrierDataUpdateCoordinator, system_serial: str, metric: str
+        self,
+        coordinator: CarrierDataUpdateCoordinator,
+        system_serial: str,
+        metric: EnergyUsageMetric | str,
     ) -> None:
         """Initialize a monthly energy sensor for a specific metric.
 
@@ -504,33 +482,20 @@ class MonthlyEnergyMeasurementSensor(CarrierSensor):
             metric: Internal Carrier metric name to expose.
         """
         self.metric = metric
+        metric_name = _energy_metric_name(metric)
         super().__init__(
-            entity_name=f"{metric.replace('_', ' ').title()} Energy Last Month",
+            entity_name=f"{metric_name.replace('_', ' ').title()} Energy Last Month",
             coordinator=coordinator,
             system_serial=system_serial,
         )
 
     def _update_entity_attrs(self) -> None:
         """Update monthly energy attrs from coordinator data."""
-        if self.carrier_system.energy.raw is None:
-            self._attr_available = False
-            return
-
-        api_field = ENERGY_METRIC_MAP.get(self.metric)
-        if api_field is None:
-            _LOGGER.debug("Unknown monthly energy metric requested: %s", self.metric)
-            self._attr_available = False
-            return
-
-        energy_periods = self.carrier_system.energy.raw.get("energyPeriods", [])
-        for period in energy_periods:
-            if period.get("energyPeriodType") == "month1":
-                value = period.get(api_field)
-                if value is not None:
-                    self._attr_native_value = value
-                    self._attr_available = True
-                    return
-        self._attr_available = False
+        value = self.carrier_system.energy.value_for_period_metric(
+            EnergyPeriod.MONTH_1, self.metric
+        )
+        self._attr_native_value = value
+        self._attr_available = value is not None
 
 
 class ZoneTemperatureSensor(CarrierZoneSensor):
@@ -734,10 +699,12 @@ class AirflowSensor(CarrierSensor):
 
     def _update_entity_attrs(self) -> None:
         """Update airflow attrs from coordinator data."""
-        if self.carrier_system.status.airflow_cfm is None:
+        indoor_unit = self.carrier_system.status.indoor_unit
+        value = indoor_unit.airflow_cfm if indoor_unit is not None else None
+        if value is None:
             self._attr_available = False
             return
-        self._attr_native_value = int(self.carrier_system.status.airflow_cfm)
+        self._attr_native_value = int(value)
         self._attr_available = True
 
 
@@ -764,7 +731,8 @@ class StaticPressureSensor(CarrierSensor):
 
     def _update_entity_attrs(self) -> None:
         """Update static pressure attrs from coordinator data."""
-        self._attr_native_value = self.carrier_system.status.static_pressure
+        indoor_unit = self.carrier_system.status.indoor_unit
+        self._attr_native_value = indoor_unit.static_pressure if indoor_unit is not None else None
         self._attr_available = self._attr_native_value is not None
 
 
@@ -788,6 +756,7 @@ class OutdoorUnitOperationalStatusSensor(CarrierSensor):
 
     def _update_entity_attrs(self) -> None:
         """Update outdoor operational status attrs from coordinator data."""
+        outdoor_unit = self.carrier_system.status.outdoor_unit
         value = self.carrier_system.status.outdoor_unit_operational_status
         if value is None:
             self._attr_available = False
@@ -797,12 +766,7 @@ class OutdoorUnitOperationalStatusSensor(CarrierSensor):
         else:
             self._attr_native_value = value
             self._attr_available = True
-        status_raw = self.carrier_system.status.raw
-        if status_raw is None:
-            return
-        outdoor_unit_attributes = status_raw.get("odu")
-        if isinstance(outdoor_unit_attributes, Mapping):
-            self._attr_extra_state_attributes = dict(outdoor_unit_attributes)
+        self._attr_extra_state_attributes = _unit_status_attributes(outdoor_unit)
 
 
 class IndoorUnitOperationalStatusSensor(CarrierSensor):
@@ -825,17 +789,10 @@ class IndoorUnitOperationalStatusSensor(CarrierSensor):
 
     def _update_entity_attrs(self) -> None:
         """Update indoor operational status attrs from coordinator data."""
+        indoor_unit = self.carrier_system.status.indoor_unit
         self._attr_native_value = self.carrier_system.status.indoor_unit_operational_status
         self._attr_available = self._attr_native_value is not None
-        status_raw = self.carrier_system.status.raw
-        if status_raw is None:
-            self._attr_extra_state_attributes = {}
-            return
-        indoor_unit_attributes = status_raw.get("idu")
-        if isinstance(indoor_unit_attributes, Mapping):
-            self._attr_extra_state_attributes = dict(indoor_unit_attributes)
-        else:
-            self._attr_extra_state_attributes = {}
+        self._attr_extra_state_attributes = _unit_status_attributes(indoor_unit)
 
 
 class OutdoorUnitVarSensor(CarrierSensor):

--- a/custom_components/ha_carrier/sensor.py
+++ b/custom_components/ha_carrier/sensor.py
@@ -67,7 +67,18 @@ def _unit_status_attributes(unit: StatusUnit | None) -> dict[str, object]:
     """
     if unit is None:
         return {}
-    return unit.as_dict()
+    attributes = unit.as_dict()
+    legacy_attributes = {
+        "type": unit.type,
+        "opstat": unit.operational_status,
+        "cfm": unit.airflow_cfm,
+        "statpress": unit.static_pressure,
+        "blwrpm": unit.blower_rpm,
+    }
+    for key, value in legacy_attributes.items():
+        if value is not None:
+            attributes.setdefault(key, value)
+    return attributes
 
 
 async def async_setup_entry(

--- a/custom_components/ha_carrier/sensor.py
+++ b/custom_components/ha_carrier/sensor.py
@@ -56,6 +56,20 @@ def _energy_metric_label(metric: EnergyUsageMetric | str) -> str:
         return metric.replace("_", " ").title()
 
 
+def _energy_native_value(value: float | None) -> float | None:
+    """Return an energy value without changing whole-number state strings.
+
+    Args:
+        value: Energy value returned by carrier_api.
+
+    Returns:
+        The original value, except integral floats are normalized to integers.
+    """
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
+    return value
+
+
 def _unit_status_attributes(
     unit: StatusUnit | None,
     raw_attributes: object = None,
@@ -458,7 +472,7 @@ class YearlyEnergyMeasurementSensor(CarrierSensor):
     def _update_entity_attrs(self) -> None:
         """Update yearly energy attrs from coordinator data."""
         value = self.carrier_system.energy.value_for_period_metric(EnergyPeriod.YEAR_1, self.metric)
-        self._attr_native_value = value
+        self._attr_native_value = _energy_native_value(value)
         self._attr_available = value is not None
 
 
@@ -496,7 +510,7 @@ class DailyEnergyMeasurementSensor(CarrierSensor):
     def _update_entity_attrs(self) -> None:
         """Update daily energy attrs from coordinator data."""
         value = self.carrier_system.energy.value_for_period_metric(EnergyPeriod.DAY_1, self.metric)
-        self._attr_native_value = value
+        self._attr_native_value = _energy_native_value(value)
         self._attr_available = value is not None
 
 
@@ -536,7 +550,7 @@ class MonthlyEnergyMeasurementSensor(CarrierSensor):
         value = self.carrier_system.energy.value_for_period_metric(
             EnergyPeriod.MONTH_1, self.metric
         )
-        self._attr_native_value = value
+        self._attr_native_value = _energy_native_value(value)
         self._attr_available = value is not None
 
 

--- a/custom_components/ha_carrier/sensor.py
+++ b/custom_components/ha_carrier/sensor.py
@@ -26,16 +26,33 @@ from .util import TIMESTAMP_TYPES
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
 
-def _energy_metric_name(metric: EnergyUsageMetric | str) -> str:
-    """Return the normalized name for a Carrier energy metric.
+def _energy_metric_value(metric: EnergyUsageMetric | str) -> str:
+    """Return the normalized value for a Carrier energy metric.
 
     Args:
         metric: Carrier API energy metric enum or string value.
 
     Returns:
-        Normalized metric name used in entity names and helper lookups.
+        Normalized metric value used in unique IDs and helper lookups.
     """
     return metric.value if isinstance(metric, EnergyUsageMetric) else metric
+
+
+def _energy_metric_label(metric: EnergyUsageMetric | str) -> str:
+    """Return the display label for a Carrier energy metric.
+
+    Args:
+        metric: Carrier API energy metric enum or string value.
+
+    Returns:
+        Carrier API metric label, or a title-cased fallback for unknown strings.
+    """
+    if isinstance(metric, EnergyUsageMetric):
+        return metric.label
+    try:
+        return EnergyUsageMetric(metric).label
+    except ValueError:
+        return metric.replace("_", " ").title()
 
 
 def _unit_status_attributes(unit: StatusUnit | None) -> dict[str, object]:
@@ -410,11 +427,13 @@ class YearlyEnergyMeasurementSensor(CarrierSensor):
             metric: Name of the Carrier energy metric to expose.
         """
         self.metric = metric
-        metric_name = _energy_metric_name(metric)
+        metric_label = _energy_metric_label(metric)
+        metric_value = _energy_metric_value(metric)
         super().__init__(
-            entity_name=f"{metric_name.replace('_', ' ').title()} Energy Year to Date",
+            entity_name=f"{metric_label} Energy Year to Date",
             coordinator=coordinator,
             system_serial=system_serial,
+            unique_id_suffix=f"{metric_value} Energy Year to Date",
         )
 
     def _update_entity_attrs(self) -> None:
@@ -446,11 +465,13 @@ class DailyEnergyMeasurementSensor(CarrierSensor):
             metric: Internal Carrier metric name to expose.
         """
         self.metric = metric
-        metric_name = _energy_metric_name(metric)
+        metric_label = _energy_metric_label(metric)
+        metric_value = _energy_metric_value(metric)
         super().__init__(
-            entity_name=f"{metric_name.replace('_', ' ').title()} Energy Yesterday",
+            entity_name=f"{metric_label} Energy Yesterday",
             coordinator=coordinator,
             system_serial=system_serial,
+            unique_id_suffix=f"{metric_value} Energy Yesterday",
         )
 
     def _update_entity_attrs(self) -> None:
@@ -482,11 +503,13 @@ class MonthlyEnergyMeasurementSensor(CarrierSensor):
             metric: Internal Carrier metric name to expose.
         """
         self.metric = metric
-        metric_name = _energy_metric_name(metric)
+        metric_label = _energy_metric_label(metric)
+        metric_value = _energy_metric_value(metric)
         super().__init__(
-            entity_name=f"{metric_name.replace('_', ' ').title()} Energy Last Month",
+            entity_name=f"{metric_label} Energy Last Month",
             coordinator=coordinator,
             system_serial=system_serial,
+            unique_id_suffix=f"{metric_value} Energy Last Month",
         )
 
     def _update_entity_attrs(self) -> None:

--- a/custom_components/ha_carrier/sensor.py
+++ b/custom_components/ha_carrier/sensor.py
@@ -725,6 +725,8 @@ class StaticPressureSensor(CarrierSensor):
         value = indoor_unit.static_pressure if indoor_unit is not None else None
         if value is None:
             value = self.carrier_system.status.static_pressure
+        # Carrier reports this as a native inH2O value; Home Assistant handles
+        # display conversion for users based on UnitOfPressure.INH2O.
         self._attr_native_value = value
         self._attr_available = self._attr_native_value is not None
 

--- a/custom_components/ha_carrier/sensor.py
+++ b/custom_components/ha_carrier/sensor.py
@@ -106,8 +106,6 @@ async def async_setup_entry(
                 )
             )
         for electric_metric in carrier_system.energy.enabled_usage_metrics():
-            if electric_metric == EnergyUsageMetric.GAS:
-                continue
             entities.extend(
                 [
                     YearlyEnergyMeasurementSensor(

--- a/custom_components/ha_carrier/sensor.py
+++ b/custom_components/ha_carrier/sensor.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 import logging
 
 from carrier_api import EnergyPeriod, EnergyUsageMetric, StatusUnit, TemperatureUnits
@@ -55,19 +56,26 @@ def _energy_metric_label(metric: EnergyUsageMetric | str) -> str:
         return metric.replace("_", " ").title()
 
 
-def _unit_status_attributes(unit: StatusUnit | None) -> dict[str, object]:
+def _unit_status_attributes(
+    unit: StatusUnit | None,
+    raw_attributes: object = None,
+) -> dict[str, object]:
     """Return Home Assistant attributes for mapped Carrier unit status details.
 
     Args:
         unit: Mapped Carrier API indoor or outdoor unit status.
+        raw_attributes: Raw Carrier unit status attributes to preserve.
 
     Returns:
         Dictionary of available unit attributes, or an empty dictionary when no
         mapped unit status exists.
     """
+    attributes: dict[str, object] = (
+        dict(raw_attributes) if isinstance(raw_attributes, Mapping) else {}
+    )
     if unit is None:
-        return {}
-    attributes = unit.as_dict()
+        return attributes
+    attributes.update(unit.as_dict())
     legacy_attributes = {
         "type": unit.type,
         "opstat": unit.operational_status,
@@ -736,6 +744,8 @@ class AirflowSensor(CarrierSensor):
         indoor_unit = self.carrier_system.status.indoor_unit
         value = indoor_unit.airflow_cfm if indoor_unit is not None else None
         if value is None:
+            value = self.carrier_system.status.airflow_cfm
+        if value is None:
             self._attr_available = False
             return
         self._attr_native_value = int(value)
@@ -766,7 +776,10 @@ class StaticPressureSensor(CarrierSensor):
     def _update_entity_attrs(self) -> None:
         """Update static pressure attrs from coordinator data."""
         indoor_unit = self.carrier_system.status.indoor_unit
-        self._attr_native_value = indoor_unit.static_pressure if indoor_unit is not None else None
+        value = indoor_unit.static_pressure if indoor_unit is not None else None
+        if value is None:
+            value = self.carrier_system.status.static_pressure
+        self._attr_native_value = value
         self._attr_available = self._attr_native_value is not None
 
 
@@ -800,7 +813,9 @@ class OutdoorUnitOperationalStatusSensor(CarrierSensor):
         else:
             self._attr_native_value = value
             self._attr_available = True
-        self._attr_extra_state_attributes = _unit_status_attributes(outdoor_unit)
+        status_raw = self.carrier_system.status.raw
+        raw_attributes = status_raw.get("odu") if status_raw is not None else None
+        self._attr_extra_state_attributes = _unit_status_attributes(outdoor_unit, raw_attributes)
 
 
 class IndoorUnitOperationalStatusSensor(CarrierSensor):
@@ -826,7 +841,9 @@ class IndoorUnitOperationalStatusSensor(CarrierSensor):
         indoor_unit = self.carrier_system.status.indoor_unit
         self._attr_native_value = self.carrier_system.status.indoor_unit_operational_status
         self._attr_available = self._attr_native_value is not None
-        self._attr_extra_state_attributes = _unit_status_attributes(indoor_unit)
+        status_raw = self.carrier_system.status.raw
+        raw_attributes = status_raw.get("idu") if status_raw is not None else None
+        self._attr_extra_state_attributes = _unit_status_attributes(indoor_unit, raw_attributes)
 
 
 class OutdoorUnitVarSensor(CarrierSensor):

--- a/custom_components/ha_carrier/sensor.py
+++ b/custom_components/ha_carrier/sensor.py
@@ -21,35 +21,9 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from . import ConfigEntryCarrier
 from .carrier_data_update_coordinator import CarrierDataUpdateCoordinator
 from .carrier_entity import CarrierEntity, CarrierZoneEntity
-from .util import TIMESTAMP_TYPES, energy_metric_value
+from .util import TIMESTAMP_TYPES
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
-
-
-def _energy_metric_label(metric: EnergyUsageMetric) -> str:
-    """Return the display label for a Carrier energy metric.
-
-    Args:
-        metric: Carrier API energy metric enum.
-
-    Returns:
-        Carrier API metric label.
-    """
-    return metric.label
-
-
-def _energy_native_value(value: float | None) -> int | float | None:
-    """Return an energy value without changing whole-number state strings.
-
-    Args:
-        value: Energy value returned by carrier_api.
-
-    Returns:
-        The original value as int when integral, otherwise unchanged.
-    """
-    if isinstance(value, float) and value.is_integer():
-        return int(value)
-    return value
 
 
 def _unit_status_attributes(unit: StatusUnit | None) -> dict[str, object]:
@@ -424,19 +398,17 @@ class YearlyEnergyMeasurementSensor(CarrierSensor):
             metric: Carrier API energy metric to expose.
         """
         self.metric = metric
-        metric_label = _energy_metric_label(metric)
-        metric_value = energy_metric_value(metric)
         super().__init__(
-            entity_name=f"{metric_label} Energy Year to Date",
+            entity_name=f"{metric.label} Energy Year to Date",
             coordinator=coordinator,
             system_serial=system_serial,
-            unique_id_suffix=f"{metric_value} Energy Year to Date",
+            unique_id_suffix=f"{metric.value} Energy Year to Date",
         )
 
     def _update_entity_attrs(self) -> None:
         """Update yearly energy attrs from coordinator data."""
         value = self.carrier_system.energy.value_for_period_metric(EnergyPeriod.YEAR_1, self.metric)
-        self._attr_native_value = _energy_native_value(value)
+        self._attr_native_value = value
         self._attr_available = value is not None
 
 
@@ -462,19 +434,17 @@ class DailyEnergyMeasurementSensor(CarrierSensor):
             metric: Carrier API energy metric to expose.
         """
         self.metric = metric
-        metric_label = _energy_metric_label(metric)
-        metric_value = energy_metric_value(metric)
         super().__init__(
-            entity_name=f"{metric_label} Energy Yesterday",
+            entity_name=f"{metric.label} Energy Yesterday",
             coordinator=coordinator,
             system_serial=system_serial,
-            unique_id_suffix=f"{metric_value} Energy Yesterday",
+            unique_id_suffix=f"{metric.value} Energy Yesterday",
         )
 
     def _update_entity_attrs(self) -> None:
         """Update daily energy attrs from coordinator data."""
         value = self.carrier_system.energy.value_for_period_metric(EnergyPeriod.DAY_1, self.metric)
-        self._attr_native_value = _energy_native_value(value)
+        self._attr_native_value = value
         self._attr_available = value is not None
 
 
@@ -500,13 +470,11 @@ class MonthlyEnergyMeasurementSensor(CarrierSensor):
             metric: Carrier API energy metric to expose.
         """
         self.metric = metric
-        metric_label = _energy_metric_label(metric)
-        metric_value = energy_metric_value(metric)
         super().__init__(
-            entity_name=f"{metric_label} Energy Last Month",
+            entity_name=f"{metric.label} Energy Last Month",
             coordinator=coordinator,
             system_serial=system_serial,
-            unique_id_suffix=f"{metric_value} Energy Last Month",
+            unique_id_suffix=f"{metric.value} Energy Last Month",
         )
 
     def _update_entity_attrs(self) -> None:
@@ -514,7 +482,7 @@ class MonthlyEnergyMeasurementSensor(CarrierSensor):
         value = self.carrier_system.energy.value_for_period_metric(
             EnergyPeriod.MONTH_1, self.metric
         )
-        self._attr_native_value = _energy_native_value(value)
+        self._attr_native_value = value
         self._attr_available = value is not None
 
 

--- a/custom_components/ha_carrier/sensor.py
+++ b/custom_components/ha_carrier/sensor.py
@@ -106,6 +106,8 @@ async def async_setup_entry(
                 )
             )
         for electric_metric in carrier_system.energy.enabled_usage_metrics():
+            if electric_metric == EnergyUsageMetric.GAS:
+                continue
             entities.extend(
                 [
                     YearlyEnergyMeasurementSensor(

--- a/custom_components/ha_carrier/sensor.py
+++ b/custom_components/ha_carrier/sensor.py
@@ -333,7 +333,7 @@ class GasMeasurementSensor(CarrierSensor):
         Raises:
             ValueError: Raised when the system serial cannot be resolved.
         """
-        self.metric = "gas"
+        self.metric = EnergyUsageMetric.GAS
         self.fuel_type = fuel_type
         super().__init__(
             entity_name=f"{self.fuel_type.capitalize()} Usage Year to Date",
@@ -400,7 +400,7 @@ class PropaneMeasurementSensor(CarrierSensor):
             coordinator: Coordinator that provides energy payloads.
             system_serial: Carrier system serial for this entity.
         """
-        self.metric = "gas"
+        self.metric = EnergyUsageMetric.GAS
         super().__init__(
             entity_name="Propane Consumption Year to Date",
             coordinator=coordinator,

--- a/custom_components/ha_carrier/sensor.py
+++ b/custom_components/ha_carrier/sensor.py
@@ -725,8 +725,9 @@ class StaticPressureSensor(CarrierSensor):
         value = indoor_unit.static_pressure if indoor_unit is not None else None
         if value is None:
             value = self.carrier_system.status.static_pressure
-        # Carrier reports this as a native inH2O value; Home Assistant handles
-        # display conversion for users based on UnitOfPressure.INH2O.
+        # Both sources are native inH2O readings from Carrier. The indoor unit
+        # value is the mapped unit-status field; the top-level status value is
+        # the system-status fallback used when that mapped field is absent.
         self._attr_native_value = value
         self._attr_available = self._attr_native_value is not None
 

--- a/custom_components/ha_carrier/util.py
+++ b/custom_components/ha_carrier/util.py
@@ -21,17 +21,6 @@ from .exceptions import CarrierUnauthorizedError
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 REDACTED = "**REDACTED**"
 
-ENERGY_METRIC_MAP: dict[str, str] = {
-    "cooling": "coolingKwh",
-    "electric_heat": "eHeatKwh",
-    "fan_gas": "fanGasKwh",
-    "fan": "fanKwh",
-    "gas": "gasKwh",
-    "hp_heat": "hPHeatKwh",
-    "loop_pump": "loopPumpKwh",
-    "reheat": "reheatKwh",
-}
-
 TIMESTAMP_TYPES: tuple[str, ...] = ("all_data", "websocket", "energy")
 
 # Transport-layer exceptions that should retry with backoff.

--- a/custom_components/ha_carrier/util.py
+++ b/custom_components/ha_carrier/util.py
@@ -13,6 +13,7 @@ from carrier_api import (
     CarrierApiError,
     CarrierApiTokenRefreshError,
     CarrierApiWebsocketError,
+    EnergyUsageMetric,
 )
 from homeassistant.core import callback
 
@@ -55,6 +56,18 @@ WEBSOCKET_DATA_UPDATE_EXCEPTIONS: tuple[type[BaseException], ...] = (
     TypeError,
     ValueError,
 )
+
+
+def energy_metric_value(metric: EnergyUsageMetric | str) -> str:
+    """Return the normalized value for a Carrier energy metric.
+
+    Args:
+        metric: Carrier API energy metric enum or string value.
+
+    Returns:
+        str: Normalized metric value used in unique IDs and helper lookups.
+    """
+    return metric.value if isinstance(metric, EnergyUsageMetric) else metric
 
 
 async def async_get_carrier_identity_id(api_connection: ApiConnectionGraphql) -> str | None:

--- a/custom_components/ha_carrier/util.py
+++ b/custom_components/ha_carrier/util.py
@@ -13,7 +13,6 @@ from carrier_api import (
     CarrierApiError,
     CarrierApiTokenRefreshError,
     CarrierApiWebsocketError,
-    EnergyUsageMetric,
 )
 from homeassistant.core import callback
 
@@ -56,18 +55,6 @@ WEBSOCKET_DATA_UPDATE_EXCEPTIONS: tuple[type[BaseException], ...] = (
     TypeError,
     ValueError,
 )
-
-
-def energy_metric_value(metric: EnergyUsageMetric) -> str:
-    """Return the normalized value for a Carrier energy metric.
-
-    Args:
-        metric: Carrier API energy metric enum.
-
-    Returns:
-        str: Normalized metric value used in unique IDs and helper lookups.
-    """
-    return metric.value
 
 
 async def async_get_carrier_identity_id(api_connection: ApiConnectionGraphql) -> str | None:

--- a/custom_components/ha_carrier/util.py
+++ b/custom_components/ha_carrier/util.py
@@ -58,16 +58,16 @@ WEBSOCKET_DATA_UPDATE_EXCEPTIONS: tuple[type[BaseException], ...] = (
 )
 
 
-def energy_metric_value(metric: EnergyUsageMetric | str) -> str:
+def energy_metric_value(metric: EnergyUsageMetric) -> str:
     """Return the normalized value for a Carrier energy metric.
 
     Args:
-        metric: Carrier API energy metric enum or string value.
+        metric: Carrier API energy metric enum.
 
     Returns:
         str: Normalized metric value used in unique IDs and helper lookups.
     """
-    return metric.value if isinstance(metric, EnergyUsageMetric) else metric
+    return metric.value
 
 
 async def async_get_carrier_identity_id(api_connection: ApiConnectionGraphql) -> str | None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ version = { attr = "custom_components.ha_carrier.const.VERSION" }
 
 [dependency-groups]
 ha = [
-    "carrier-api==3.2.0",
+    "carrier-api==3.3.0",
     "homeassistant",
 ]
 lint = [

--- a/tests/test_carrier_data_update_coordinator.py
+++ b/tests/test_carrier_data_update_coordinator.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
-from typing import Any, cast
+from typing import Any
 from unittest.mock import patch
 
 from carrier_api import CarrierApiAuthError, CarrierApiConnectionError, CarrierApiGraphqlError
@@ -24,6 +24,14 @@ from custom_components.ha_carrier.resiliency import ResiliencyState
 from .conftest import FakeCarrierApiConnection, build_carrier_system
 
 
+def _set_coordinator_api_connection(
+    coordinator: CarrierDataUpdateCoordinator,
+    api_connection: FakeCarrierApiConnection,
+) -> None:
+    """Attach a fake API connection to a partially constructed coordinator."""
+    object.__setattr__(coordinator, "api_connection", api_connection)
+
+
 @pytest.mark.asyncio
 async def test_initial_full_refresh_preserves_systems_list_identity(
     carrier_api: FakeCarrierApiConnection,
@@ -34,7 +42,7 @@ async def test_initial_full_refresh_preserves_systems_list_identity(
     fresh_systems = [build_carrier_system()]
     carrier_api.systems = fresh_systems
     coordinator.systems = systems
-    coordinator.api_connection = cast("Any", carrier_api)
+    _set_coordinator_api_connection(coordinator, carrier_api)
     coordinator.resiliency = ResiliencyState(
         unauthorized_threshold=UNAUTHORIZED_RETRY_THRESHOLD,
         transient_threshold=TRANSIENT_FAILURE_THRESHOLD,
@@ -54,9 +62,10 @@ async def test_energy_refresh_uses_cycle_scoped_success_reset(
     """Preserve resiliency state across per-system energy successes."""
     coordinator = CarrierDataUpdateCoordinator.__new__(CarrierDataUpdateCoordinator)
     coordinator.systems = [build_carrier_system()]
-    coordinator.api_connection = cast("Any", carrier_api)
-    coordinator.resiliency = cast(
-        "Any",
+    _set_coordinator_api_connection(coordinator, carrier_api)
+    object.__setattr__(
+        coordinator,
+        "resiliency",
         SimpleNamespace(
             reset_unauthorized=lambda: None,
             reset_transient=lambda: None,
@@ -261,7 +270,7 @@ async def test_full_refresh_merges_new_changed_and_stale_systems(
     fresh_new = build_carrier_system(serial="NEW123", name="New")
     carrier_api.systems = [fresh_existing, fresh_new]
     coordinator.systems = [existing, stale]
-    coordinator.api_connection = cast("Any", carrier_api)
+    _set_coordinator_api_connection(coordinator, carrier_api)
     coordinator.resiliency = ResiliencyState(
         unauthorized_threshold=UNAUTHORIZED_RETRY_THRESHOLD,
         transient_threshold=TRANSIENT_FAILURE_THRESHOLD,
@@ -287,8 +296,9 @@ async def test_energy_refresh_records_one_unauthorized_per_cycle(
         build_carrier_system(serial="ABC123"),
         build_carrier_system(serial="DEF456"),
     ]
+    existing_energy = systems[0].energy
     coordinator.systems = systems
-    coordinator.api_connection = cast("Any", carrier_api)
+    _set_coordinator_api_connection(coordinator, carrier_api)
     coordinator.resiliency = ResiliencyState(unauthorized_threshold=2, transient_threshold=3)
     coordinator.update_interval = None
 
@@ -304,7 +314,7 @@ async def test_energy_refresh_records_one_unauthorized_per_cycle(
 
     assert coordinator.resiliency.consecutive_unauthorized == 1
     assert coordinator.update_interval is not None
-    assert systems[0].energy.raw is not None
+    assert systems[0].energy is existing_energy
 
 
 @pytest.mark.asyncio
@@ -314,7 +324,7 @@ async def test_energy_refresh_escalates_after_threshold(
     """Raise CarrierUnauthorizedError once the energy-cycle auth threshold is crossed."""
     coordinator = CarrierDataUpdateCoordinator.__new__(CarrierDataUpdateCoordinator)
     coordinator.systems = [build_carrier_system()]
-    coordinator.api_connection = cast("Any", carrier_api)
+    _set_coordinator_api_connection(coordinator, carrier_api)
     coordinator.resiliency = ResiliencyState(unauthorized_threshold=1, transient_threshold=3)
     coordinator.update_interval = None
 

--- a/tests/test_carrier_entity.py
+++ b/tests/test_carrier_entity.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-from types import SimpleNamespace
-from typing import Any, cast
-
 import pytest
 
+from custom_components.ha_carrier.carrier_data_update_coordinator import (
+    CarrierDataUpdateCoordinator,
+)
 from custom_components.ha_carrier.carrier_entity import CarrierZoneEntity
 
 from .conftest import build_carrier_system
@@ -15,10 +15,8 @@ from .conftest import build_carrier_system
 def test_zone_entity_resolves_zone_name_from_coordinator_systems() -> None:
     """Resolve a zone display name from coordinator system data."""
     system = build_carrier_system(zone_name="Bedroom", zone_id="2")
-    coordinator = cast(
-        "Any",
-        SimpleNamespace(system=lambda system_serial: system if system_serial == "ABC123" else None),
-    )
+    coordinator = CarrierDataUpdateCoordinator.__new__(CarrierDataUpdateCoordinator)
+    coordinator.systems = [system]
 
     assert CarrierZoneEntity.resolve_zone_name(coordinator, "ABC123", "2") == "Bedroom"
 
@@ -26,7 +24,8 @@ def test_zone_entity_resolves_zone_name_from_coordinator_systems() -> None:
 def test_zone_entity_raises_when_zone_cannot_be_resolved() -> None:
     """Raise a clear error when a zone ID is missing from coordinator data."""
     system = build_carrier_system(zone_name="Bedroom", zone_id="2")
-    coordinator = cast("Any", SimpleNamespace(system=lambda system_serial: system))
+    coordinator = CarrierDataUpdateCoordinator.__new__(CarrierDataUpdateCoordinator)
+    coordinator.systems = [system]
 
     with pytest.raises(ValueError, match="Config Zone not found: missing"):
         CarrierZoneEntity.resolve_zone_name(coordinator, "ABC123", "missing")

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -51,6 +51,50 @@ async def test_migration_updates_system_and_zone_unique_ids(
 
 
 @pytest.mark.asyncio
+async def test_migration_preserves_energy_and_propane_unique_ids(
+    hass: HomeAssistant,
+    patch_carrier_api: FakeCarrierApiConnection,
+) -> None:
+    """Migrate enabled energy and propane sensor unique IDs to current suffixes."""
+    system = patch_carrier_api.systems[0]
+    system.config.fuel_type = "propane"
+    system.config.gas_unit = "gallon"
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=1,
+        data={CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD},
+    )
+    config_entry.add_to_hass(hass)
+    ent_reg = er.async_get(hass)
+    for old_unique_id in (
+        "ABC123_hp_heat Energy Yearly",
+        "ABC123_hp_heat Energy Yesterday",
+        "ABC123_hp_heat Energy Last Month",
+        "ABC123_Propane Yearly",
+        "ABC123_Propane Yearly Gallons",
+    ):
+        ent_reg.async_get_or_create(
+            "sensor",
+            DOMAIN,
+            old_unique_id,
+            config_entry=config_entry,
+        )
+
+    assert await migrate_1_to_2(hass, config_entry)
+
+    assert config_entry.version == 2
+    for new_unique_id in (
+        "abc123_hp_heat_energy_year_to_date",
+        "abc123_hp_heat_energy_yesterday",
+        "abc123_hp_heat_energy_last_month",
+        "abc123_propane_usage_year_to_date",
+        "abc123_propane_consumption_year_to_date",
+    ):
+        assert ent_reg.async_get_entity_id("sensor", DOMAIN, new_unique_id)
+    assert patch_carrier_api.cleanup_calls == 1
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "load_error",
     [

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -89,13 +89,12 @@ async def test_migration_preserves_energy_and_propane_unique_ids(
         "abc123_hp_heat_energy_year_to_date",
         "abc123_hp_heat_energy_yesterday",
         "abc123_hp_heat_energy_last_month",
+        "abc123_gas_energy_year_to_date",
         "abc123_propane_usage_year_to_date",
         "abc123_propane_consumption_year_to_date",
         "abc123_heat_source",
     ):
         assert ent_reg.async_get_entity_id("sensor", DOMAIN, new_unique_id)
-    assert ent_reg.async_get_entity_id("sensor", DOMAIN, "ABC123_gas Energy Yearly") is None
-    assert ent_reg.async_get_entity_id("sensor", DOMAIN, "abc123_gas_energy_year_to_date") is None
     assert patch_carrier_api.cleanup_calls == 1
 
 

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -70,6 +70,7 @@ async def test_migration_preserves_energy_and_propane_unique_ids(
         "ABC123_Heat Pump Heat Energy Yearly",
         "ABC123_hp_heat Energy Yesterday",
         "ABC123_hp_heat Energy Last Month",
+        "ABC123_gas Energy Yearly",
         "ABC123_Propane Yearly",
         "ABC123_Propane Yearly Gallons",
         "ABC123_Heat Source",
@@ -93,6 +94,8 @@ async def test_migration_preserves_energy_and_propane_unique_ids(
         "abc123_heat_source",
     ):
         assert ent_reg.async_get_entity_id("sensor", DOMAIN, new_unique_id)
+    assert ent_reg.async_get_entity_id("sensor", DOMAIN, "ABC123_gas Energy Yearly") is None
+    assert ent_reg.async_get_entity_id("sensor", DOMAIN, "abc123_gas_energy_year_to_date") is None
     assert patch_carrier_api.cleanup_calls == 1
 
 

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -75,6 +75,7 @@ async def test_migration_preserves_energy_and_propane_unique_ids(
         "ABC123_hp_heat Energy Last Month",
         "ABC123_Propane Yearly",
         "ABC123_Propane Yearly Gallons",
+        "ABC123_Heat Source",
     ):
         ent_reg.async_get_or_create(
             "sensor",
@@ -92,6 +93,7 @@ async def test_migration_preserves_energy_and_propane_unique_ids(
         "abc123_hp_heat_energy_last_month",
         "abc123_propane_usage_year_to_date",
         "abc123_propane_consumption_year_to_date",
+        "abc123_heat_source",
     ):
         assert ent_reg.async_get_entity_id("sensor", DOMAIN, new_unique_id)
     assert patch_carrier_api.cleanup_calls == 1

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any, cast
-
 from carrier_api import CarrierApiConnectionError
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
@@ -61,7 +59,6 @@ async def test_migration_preserves_energy_and_propane_unique_ids(
     system = patch_carrier_api.systems[0]
     system.config.fuel_type = "propane"
     system.config.gas_unit = "gallon"
-    cast("Any", system.energy).enabled_usage_metrics = lambda: ("hp_heat",)
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         version=1,
@@ -70,7 +67,7 @@ async def test_migration_preserves_energy_and_propane_unique_ids(
     config_entry.add_to_hass(hass)
     ent_reg = er.async_get(hass)
     for old_unique_id in (
-        "ABC123_hp_heat Energy Yearly",
+        "ABC123_Heat Pump Heat Energy Yearly",
         "ABC123_hp_heat Energy Yesterday",
         "ABC123_hp_heat Energy Last Month",
         "ABC123_Propane Yearly",

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any, cast
+
 from carrier_api import CarrierApiConnectionError
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
@@ -59,6 +61,7 @@ async def test_migration_preserves_energy_and_propane_unique_ids(
     system = patch_carrier_api.systems[0]
     system.config.fuel_type = "propane"
     system.config.gas_unit = "gallon"
+    cast("Any", system.energy).enabled_usage_metrics = lambda: ("hp_heat",)
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         version=1,

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -21,9 +21,9 @@ from .conftest import FakeCarrierApiConnection, build_carrier_system, entity_id_
         ("abc123_static_pressure", "0.049817781666667"),
         ("abc123_zone_1_temperature", "21.1111111111111"),
         ("abc123_zone_1_humidity", "45"),
-        ("abc123_cooling_energy_year_to_date", "100"),
-        ("abc123_cooling_energy_yesterday", "1"),
-        ("abc123_cooling_energy_last_month", "10"),
+        ("abc123_cooling_energy_year_to_date", "100.0"),
+        ("abc123_cooling_energy_yesterday", "1.0"),
+        ("abc123_cooling_energy_last_month", "10.0"),
     ],
 )
 async def test_sensor_platform_registers_representative_state_sensors(
@@ -55,9 +55,9 @@ async def test_energy_sensors_use_carrier_api_energy_helpers(
     await setup_integration()
 
     expected_states = {
-        "abc123_cooling_energy_year_to_date": "100",
-        "abc123_cooling_energy_yesterday": "1",
-        "abc123_cooling_energy_last_month": "10",
+        "abc123_cooling_energy_year_to_date": "100.0",
+        "abc123_cooling_energy_yesterday": "1.0",
+        "abc123_cooling_energy_last_month": "10.0",
     }
     for unique_id, expected_state in expected_states.items():
         entity_id = entity_id_for_unique_id(hass, "sensor", unique_id)

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 from typing import Any
 
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 import pytest
 
 from .conftest import FakeCarrierApiConnection, build_carrier_system, entity_id_for_unique_id
@@ -64,6 +65,12 @@ async def test_energy_sensors_use_carrier_api_energy_helpers(
 
         assert state is not None
         assert state.state == expected_state
+    assert (
+        er.async_get(hass).async_get_entity_id(
+            "sensor", "ha_carrier", "abc123_gas_energy_year_to_date"
+        )
+        is None
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -50,6 +50,7 @@ async def test_energy_sensors_use_carrier_api_energy_helpers(
 ) -> None:
     """Register energy sensors from mapped Carrier API energy helpers."""
     carrier_api.systems = [build_carrier_system()]
+    # Force helper-backed values by removing the raw energy payload.
     cast("Any", carrier_api.systems[0].energy).raw = None
 
     await setup_integration()
@@ -127,6 +128,7 @@ async def test_unit_status_sensors_use_carrier_api_status_unit_helpers(
 ) -> None:
     """Populate unit status attributes from mapped Carrier API status unit data."""
     carrier_api.systems = [build_carrier_system()]
+    # Force helper-backed values by removing the raw status payload.
     cast("Any", carrier_api.systems[0].status).raw = None
 
     await setup_integration()

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -207,6 +207,33 @@ async def test_unit_status_sensors_keep_raw_fallbacks_when_mapped_units_are_miss
 
 
 @pytest.mark.asyncio
+async def test_airflow_and_static_pressure_fall_back_when_mapped_fields_are_missing(
+    hass: HomeAssistant,
+    carrier_api: FakeCarrierApiConnection,
+    setup_integration: Callable[..., Any],
+) -> None:
+    """Use top-level status values when mapped indoor unit fields are partial."""
+    carrier_api.systems = [build_carrier_system()]
+    indoor_unit = carrier_api.systems[0].status.indoor_unit
+    assert indoor_unit is not None
+    cast("Any", indoor_unit).airflow_cfm = None
+    cast("Any", indoor_unit).static_pressure = None
+
+    await setup_integration()
+
+    expected_states = {
+        "abc123_airflow": "1200",
+        "abc123_static_pressure": "0.049817781666667",
+    }
+    for unique_id, expected_state in expected_states.items():
+        entity_id = entity_id_for_unique_id(hass, "sensor", unique_id)
+        state = hass.states.get(entity_id)
+
+        assert state is not None
+        assert state.state == expected_state
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("outdoor_status", "expected_state"),
     [

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -134,16 +134,12 @@ async def test_unit_status_sensors_use_carrier_api_status_unit_helpers(
     await setup_integration()
 
     expected_attributes: dict[str, dict[str, object]] = {
-        "abc123_odu_status": {"operational_status": "idle", "opstat": "idle"},
+        "abc123_odu_status": {"operational_status": "idle"},
         "abc123_idu_status": {
             "airflow_cfm": 1200,
-            "cfm": 1200,
             "blower_rpm": 500,
-            "blwrpm": 500,
             "operational_status": "idle",
-            "opstat": "idle",
             "static_pressure": 0.2,
-            "statpress": 0.2,
         },
     }
     for unique_id, attributes in expected_attributes.items():
@@ -167,12 +163,12 @@ async def test_unit_status_sensors_use_carrier_api_status_unit_helpers(
 
 
 @pytest.mark.asyncio
-async def test_unit_status_sensors_keep_raw_fallbacks_when_mapped_units_are_missing(
+async def test_unit_status_sensors_do_not_expose_raw_attributes_when_mapped_units_are_missing(
     hass: HomeAssistant,
     carrier_api: FakeCarrierApiConnection,
     setup_integration: Callable[..., Any],
 ) -> None:
-    """Preserve legacy unit status fallbacks when mapped unit helpers are missing."""
+    """Avoid exposing raw status attributes when mapped unit helpers are missing."""
     carrier_api.systems = [build_carrier_system()]
     status = carrier_api.systems[0].status
     cast("Any", status).outdoor_unit = None
@@ -191,21 +187,25 @@ async def test_unit_status_sensors_keep_raw_fallbacks_when_mapped_units_are_miss
         assert state is not None
         assert state.state == expected_state
 
-    expected_attributes: dict[str, dict[str, object]] = {
-        "abc123_odu_status": {"opstat": "idle"},
-        "abc123_idu_status": {
-            "cfm": 1200,
-            "blwrpm": 500,
-            "opstat": "idle",
-            "statpress": 0.2,
-        },
-    }
-    for unique_id, attributes in expected_attributes.items():
+    for unique_id in ("abc123_odu_status", "abc123_idu_status"):
         entity_id = entity_id_for_unique_id(hass, "sensor", unique_id)
         state = hass.states.get(entity_id)
 
         assert state is not None
-        assert {key: state.attributes[key] for key in attributes} == attributes
+        assert not (
+            {
+                "airflow_cfm",
+                "blwrpm",
+                "blower_rpm",
+                "cfm",
+                "operational_status",
+                "opstat",
+                "static_pressure",
+                "statpress",
+                "type",
+            }
+            & set(state.attributes)
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -99,6 +99,7 @@ async def test_sensor_platform_registers_propane_and_lifecycle_sensors(
     system = carrier_api.systems[0]
     system.config.fuel_type = "propane"
     system.config.gas_unit = "gallon"
+    cast("Any", system.energy).raw = None
 
     await setup_integration()
 
@@ -146,6 +147,17 @@ async def test_unit_status_sensors_use_carrier_api_status_unit_helpers(
         assert state is not None
         assert state.state == "idle"
         assert {key: state.attributes[key] for key in attributes} == attributes
+
+    expected_states = {
+        "abc123_airflow": "1200",
+        "abc123_static_pressure": "0.049817781666667",
+    }
+    for unique_id, expected_state in expected_states.items():
+        entity_id = entity_id_for_unique_id(hass, "sensor", unique_id)
+        state = hass.states.get(entity_id)
+
+        assert state is not None
+        assert state.state == expected_state
 
 
 @pytest.mark.asyncio

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -68,6 +68,27 @@ async def test_energy_sensors_use_carrier_api_energy_helpers(
 
 
 @pytest.mark.asyncio
+async def test_energy_sensor_names_use_carrier_api_metric_labels_with_stable_unique_ids(
+    hass: HomeAssistant,
+    setup_integration: Callable[..., Any],
+) -> None:
+    """Use Carrier API metric labels without changing entity unique IDs."""
+    await setup_integration()
+
+    expected_names = {
+        "abc123_hp_heat_energy_year_to_date": "Home Heat Pump Heat Energy Year to Date",
+        "abc123_hp_heat_energy_yesterday": "Home Heat Pump Heat Energy Yesterday",
+        "abc123_hp_heat_energy_last_month": "Home Heat Pump Heat Energy Last Month",
+    }
+    for unique_id, expected_name in expected_names.items():
+        entity_id = entity_id_for_unique_id(hass, "sensor", unique_id)
+        state = hass.states.get(entity_id)
+
+        assert state is not None
+        assert state.attributes["friendly_name"] == expected_name
+
+
+@pytest.mark.asyncio
 async def test_sensor_platform_registers_propane_and_lifecycle_sensors(
     hass: HomeAssistant,
     carrier_api: FakeCarrierApiConnection,

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -132,12 +132,16 @@ async def test_unit_status_sensors_use_carrier_api_status_unit_helpers(
     await setup_integration()
 
     expected_attributes: dict[str, dict[str, object]] = {
-        "abc123_odu_status": {"operational_status": "idle"},
+        "abc123_odu_status": {"operational_status": "idle", "opstat": "idle"},
         "abc123_idu_status": {
             "airflow_cfm": 1200,
+            "cfm": 1200,
             "blower_rpm": 500,
+            "blwrpm": 500,
             "operational_status": "idle",
+            "opstat": "idle",
             "static_pressure": 0.2,
+            "statpress": 0.2,
         },
     }
     for unique_id, attributes in expected_attributes.items():

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Any, cast
+from typing import Any
 
 from homeassistant.core import HomeAssistant
 import pytest
@@ -50,8 +50,6 @@ async def test_energy_sensors_use_carrier_api_energy_helpers(
 ) -> None:
     """Register energy sensors from mapped Carrier API energy helpers."""
     carrier_api.systems = [build_carrier_system()]
-    # Force helper-backed values by removing the raw energy payload.
-    cast("Any", carrier_api.systems[0].energy).raw = None
 
     await setup_integration()
 
@@ -100,7 +98,6 @@ async def test_sensor_platform_registers_propane_and_lifecycle_sensors(
     system = carrier_api.systems[0]
     system.config.fuel_type = "propane"
     system.config.gas_unit = "gallon"
-    cast("Any", system.energy).raw = None
 
     await setup_integration()
 
@@ -128,8 +125,6 @@ async def test_unit_status_sensors_use_carrier_api_status_unit_helpers(
 ) -> None:
     """Populate unit status attributes from mapped Carrier API status unit data."""
     carrier_api.systems = [build_carrier_system()]
-    # Force helper-backed values by removing the raw status payload.
-    cast("Any", carrier_api.systems[0].status).raw = None
 
     await setup_integration()
 
@@ -171,8 +166,8 @@ async def test_unit_status_sensors_do_not_expose_raw_attributes_when_mapped_unit
     """Avoid exposing raw status attributes when mapped unit helpers are missing."""
     carrier_api.systems = [build_carrier_system()]
     status = carrier_api.systems[0].status
-    cast("Any", status).outdoor_unit = None
-    cast("Any", status).indoor_unit = None
+    status.outdoor_unit = None
+    status.indoor_unit = None
 
     await setup_integration()
 
@@ -216,10 +211,10 @@ async def test_airflow_and_static_pressure_fall_back_when_mapped_fields_are_miss
 ) -> None:
     """Use top-level status values when mapped indoor unit fields are partial."""
     carrier_api.systems = [build_carrier_system()]
-    indoor_unit = carrier_api.systems[0].status.indoor_unit
+    status = carrier_api.systems[0].status
+    indoor_unit = status.indoor_unit
     assert indoor_unit is not None
-    cast("Any", indoor_unit).airflow_cfm = None
-    cast("Any", indoor_unit).static_pressure = None
+    status.indoor_unit = type(indoor_unit)({"opstat": "idle", "blwrpm": 500})
 
     await setup_integration()
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -21,9 +21,9 @@ from .conftest import FakeCarrierApiConnection, build_carrier_system, entity_id_
         ("abc123_static_pressure", "0.049817781666667"),
         ("abc123_zone_1_temperature", "21.1111111111111"),
         ("abc123_zone_1_humidity", "45"),
-        ("abc123_cooling_energy_year_to_date", "100.0"),
-        ("abc123_cooling_energy_yesterday", "1.0"),
-        ("abc123_cooling_energy_last_month", "10.0"),
+        ("abc123_cooling_energy_year_to_date", "100"),
+        ("abc123_cooling_energy_yesterday", "1"),
+        ("abc123_cooling_energy_last_month", "10"),
     ],
 )
 async def test_sensor_platform_registers_representative_state_sensors(
@@ -55,9 +55,9 @@ async def test_energy_sensors_use_carrier_api_energy_helpers(
     await setup_integration()
 
     expected_states = {
-        "abc123_cooling_energy_year_to_date": "100.0",
-        "abc123_cooling_energy_yesterday": "1.0",
-        "abc123_cooling_energy_last_month": "10.0",
+        "abc123_cooling_energy_year_to_date": "100",
+        "abc123_cooling_energy_yesterday": "1",
+        "abc123_cooling_energy_last_month": "10",
     }
     for unique_id, expected_state in expected_states.items():
         entity_id = entity_id_for_unique_id(hass, "sensor", unique_id)

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -67,9 +67,8 @@ async def test_energy_sensors_use_carrier_api_energy_helpers(
 
         assert state is not None
         assert state.state == expected_state
-    assert (
-        er.async_get(hass).async_get_entity_id("sensor", DOMAIN, "abc123_gas_energy_year_to_date")
-        is None
+    assert er.async_get(hass).async_get_entity_id(
+        "sensor", DOMAIN, "abc123_gas_energy_year_to_date"
     )
 
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Any
+from typing import Any, cast
 
 from homeassistant.core import HomeAssistant
 import pytest
@@ -43,6 +43,31 @@ async def test_sensor_platform_registers_representative_state_sensors(
 
 
 @pytest.mark.asyncio
+async def test_energy_sensors_use_carrier_api_energy_helpers(
+    hass: HomeAssistant,
+    carrier_api: FakeCarrierApiConnection,
+    setup_integration: Callable[..., Any],
+) -> None:
+    """Register energy sensors from mapped Carrier API energy helpers."""
+    carrier_api.systems = [build_carrier_system()]
+    cast("Any", carrier_api.systems[0].energy).raw = None
+
+    await setup_integration()
+
+    expected_states = {
+        "abc123_cooling_energy_year_to_date": "100",
+        "abc123_cooling_energy_yesterday": "1",
+        "abc123_cooling_energy_last_month": "10",
+    }
+    for unique_id, expected_state in expected_states.items():
+        entity_id = entity_id_for_unique_id(hass, "sensor", unique_id)
+        state = hass.states.get(entity_id)
+
+        assert state is not None
+        assert state.state == expected_state
+
+
+@pytest.mark.asyncio
 async def test_sensor_platform_registers_propane_and_lifecycle_sensors(
     hass: HomeAssistant,
     carrier_api: FakeCarrierApiConnection,
@@ -70,6 +95,36 @@ async def test_sensor_platform_registers_propane_and_lifecycle_sensors(
 
         assert state is not None
         assert state.state == expected_state
+
+
+@pytest.mark.asyncio
+async def test_unit_status_sensors_use_carrier_api_status_unit_helpers(
+    hass: HomeAssistant,
+    carrier_api: FakeCarrierApiConnection,
+    setup_integration: Callable[..., Any],
+) -> None:
+    """Populate unit status attributes from mapped Carrier API status unit data."""
+    carrier_api.systems = [build_carrier_system()]
+    cast("Any", carrier_api.systems[0].status).raw = None
+
+    await setup_integration()
+
+    expected_attributes: dict[str, dict[str, object]] = {
+        "abc123_odu_status": {"operational_status": "idle"},
+        "abc123_idu_status": {
+            "airflow_cfm": 1200,
+            "blower_rpm": 500,
+            "operational_status": "idle",
+            "static_pressure": 0.2,
+        },
+    }
+    for unique_id, attributes in expected_attributes.items():
+        entity_id = entity_id_for_unique_id(hass, "sensor", unique_id)
+        state = hass.states.get(entity_id)
+
+        assert state is not None
+        assert state.state == "idle"
+        assert {key: state.attributes[key] for key in attributes} == attributes
 
 
 @pytest.mark.asyncio

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -165,6 +165,48 @@ async def test_unit_status_sensors_use_carrier_api_status_unit_helpers(
 
 
 @pytest.mark.asyncio
+async def test_unit_status_sensors_keep_raw_fallbacks_when_mapped_units_are_missing(
+    hass: HomeAssistant,
+    carrier_api: FakeCarrierApiConnection,
+    setup_integration: Callable[..., Any],
+) -> None:
+    """Preserve legacy unit status fallbacks when mapped unit helpers are missing."""
+    carrier_api.systems = [build_carrier_system()]
+    status = carrier_api.systems[0].status
+    cast("Any", status).outdoor_unit = None
+    cast("Any", status).indoor_unit = None
+
+    await setup_integration()
+
+    expected_states = {
+        "abc123_airflow": "1200",
+        "abc123_static_pressure": "0.049817781666667",
+    }
+    for unique_id, expected_state in expected_states.items():
+        entity_id = entity_id_for_unique_id(hass, "sensor", unique_id)
+        state = hass.states.get(entity_id)
+
+        assert state is not None
+        assert state.state == expected_state
+
+    expected_attributes: dict[str, dict[str, object]] = {
+        "abc123_odu_status": {"opstat": "idle"},
+        "abc123_idu_status": {
+            "cfm": 1200,
+            "blwrpm": 500,
+            "opstat": "idle",
+            "statpress": 0.2,
+        },
+    }
+    for unique_id, attributes in expected_attributes.items():
+        entity_id = entity_id_for_unique_id(hass, "sensor", unique_id)
+        state = hass.states.get(entity_id)
+
+        assert state is not None
+        assert {key: state.attributes[key] for key in attributes} == attributes
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("outdoor_status", "expected_state"),
     [

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -9,6 +9,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 import pytest
 
+from custom_components.ha_carrier.const import DOMAIN
+
 from .conftest import FakeCarrierApiConnection, build_carrier_system, entity_id_for_unique_id
 
 
@@ -66,9 +68,7 @@ async def test_energy_sensors_use_carrier_api_energy_helpers(
         assert state is not None
         assert state.state == expected_state
     assert (
-        er.async_get(hass).async_get_entity_id(
-            "sensor", "ha_carrier", "abc123_gas_energy_year_to_date"
-        )
+        er.async_get(hass).async_get_entity_id("sensor", DOMAIN, "abc123_gas_energy_year_to_date")
         is None
     )
 


### PR DESCRIPTION
## Summary
Updates ha_carrier to consume the new Carrier API helper surface for HVAC capabilities, energy metrics, energy measurements, and mapped unit status details.

## What Changed
- Replaced local HVAC capability inference with `System.supported_hvac_capabilities()` and `System.supports_heat()`.
- Replaced raw energy payload parsing with `Energy.enabled_usage_metrics()`, `is_usage_metric_enabled()`, and `value_for_period_metric()`.
- Uses `EnergyUsageMetric` labels and values for sensor names, unique IDs, and migration mappings.
- Uses mapped `StatusUnit` data for indoor/outdoor unit sensor attributes while preserving tested top-level airflow/static-pressure fallbacks.
- Removed local energy metric maps and heat/cool/fan helper lists that now belong in `carrier_api`.
- Added regression coverage for helper-backed sensors, migration IDs, metric labels, unit attributes, and coordinator energy refresh behavior.

## Why
This keeps the integration aligned with the newer `carrier_api` model helpers and avoids duplicating Carrier-specific raw payload mapping inside Home Assistant entity code.

## Validation
- `./.venv/bin/pytest`
- `./scripts/lint`

## Related
- Depends on carrier_api 3.3.0
