### PR TITLE
Fix carrier-api update workflow

### DIFF
--- a/.github/scripts/__init__.py
+++ b/.github/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""GitHub workflow helper scripts."""

--- a/.github/scripts/build_carrier_api_release_notes.py
+++ b/.github/scripts/build_carrier_api_release_notes.py
@@ -1,0 +1,300 @@
+"""Build the carrier-api dependency update pull request body."""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Mapping, Sequence
+import json
+import logging
+import os
+from pathlib import Path
+import re
+import sys
+from urllib.error import URLError
+from urllib.request import Request, urlopen
+
+GITHUB_API_URL = "https://api.github.com"
+LOGGER = logging.getLogger(__name__)
+MENTION_RE = re.compile(r"@(?=[A-Za-z0-9-]+(?:/[A-Za-z0-9-]+)?)")
+MENTION_LINK_RE = re.compile(r"\[@([A-Za-z0-9-]+)\]\(https?://github\.com/[A-Za-z0-9-]+\)")
+CLOSING_KEYWORD_RE = re.compile(
+    r"\b(close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+"
+    r"((?:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#\d+)",
+    re.IGNORECASE,
+)
+PRERELEASE_RE = re.compile(r"(?i)(?:[.\-_]?(?:a|alpha|b|beta|c|pre|preview|rc|dev)\d*)")
+
+
+def _version_key(version: str) -> tuple[tuple[int, int | str], ...]:
+    """Return a tolerant comparison key for release versions.
+
+    Args:
+        version: Version string to normalize.
+
+    Returns:
+        Tuple suitable for comparing common dotted release versions.
+    """
+    parts = re.findall(r"\d+|[A-Za-z]+", version.lstrip("vV"))
+    return tuple((0, int(part)) if part.isdigit() else (1, part.lower()) for part in parts)
+
+
+def _is_prerelease(version: str) -> bool:
+    """Return whether a version string appears to be a prerelease.
+
+    Args:
+        version: Version string to evaluate.
+
+    Returns:
+        True when the version has a common prerelease marker.
+    """
+    return PRERELEASE_RE.search(version) is not None
+
+
+def _stable_version(version: str) -> str:
+    """Return the stable base of a version string.
+
+    Args:
+        version: Version string to normalize.
+
+    Returns:
+        Stable release portion of the version.
+    """
+    match = PRERELEASE_RE.search(version)
+    return version[: match.start()].rstrip(".-_") if match else version
+
+
+def _sanitize_release_body(body: str) -> str:
+    """Return release text that is safe to embed in a generated PR body.
+
+    Args:
+        body: Release text from GitHub.
+
+    Returns:
+        Sanitized release text.
+    """
+    body = MENTION_LINK_RE.sub(r"\1", body)
+    body = MENTION_RE.sub("@<!-- -->", body)
+    return CLOSING_KEYWORD_RE.sub(
+        lambda match: f"{match.group(1)} {match.group(2).replace('#', r'\#')}",
+        body,
+    )
+
+
+def build_release_notes(
+    *,
+    releases: Sequence[Mapping[str, object]],
+    current_version: str,
+    latest_version: str,
+) -> str:
+    """Build sanitized release notes for the updated version range.
+
+    Args:
+        releases: GitHub releases from the carrier_api repository.
+        current_version: Currently pinned carrier-api version.
+        latest_version: Target carrier-api version.
+
+    Returns:
+        Markdown release notes for matching stable releases.
+    """
+    current = current_version.removeprefix("v").removeprefix("V")
+    latest = latest_version.removeprefix("v").removeprefix("V")
+    current_is_prerelease = _is_prerelease(current)
+    current_stable = _stable_version(current)
+
+    selected: list[Mapping[str, object]] = []
+    for release in releases:
+        tag_name = release.get("tag_name")
+        if not isinstance(tag_name, str):
+            continue
+
+        tag_version = tag_name.removeprefix("v").removeprefix("V")
+        lower_bound = _version_key(tag_version) > _version_key(current_stable)
+        prerelease_repair = current_is_prerelease and _version_key(tag_version) == _version_key(
+            current_stable,
+        )
+        if (
+            not _is_prerelease(tag_version)
+            and (lower_bound or prerelease_repair)
+            and _version_key(tag_version) <= _version_key(latest)
+        ):
+            selected.append(release)
+
+    if not selected:
+        return "No matching GitHub release notes were found for this version range."
+
+    selected.sort(key=lambda release: _version_key(str(release["tag_name"])))
+    notes: list[str] = []
+    for release in selected:
+        tag_name = str(release["tag_name"])
+        title = _sanitize_release_body(str(release.get("name") or tag_name))
+        tag = _sanitize_release_body(tag_name)
+        html_url = str(release.get("html_url") or "")
+        raw_body = str(release.get("body") or "No release body provided.").strip()
+        body = _sanitize_release_body(raw_body)
+        notes.append("\n".join([f"### {title} ({tag})", html_url, "", body]))
+
+    return "\n\n---\n\n".join(notes)
+
+
+def write_pr_body(
+    *,
+    body_path: Path,
+    releases: Sequence[Mapping[str, object]],
+    current_version: str,
+    pyproject_current_version: str,
+    latest_version: str,
+) -> None:
+    """Write the generated carrier-api update PR body.
+
+    Args:
+        body_path: Path to write the markdown body to.
+        releases: GitHub releases from the carrier_api repository.
+        current_version: Currently pinned manifest version.
+        pyproject_current_version: Currently pinned pyproject version.
+        latest_version: Target carrier-api version.
+    """
+    release_notes = build_release_notes(
+        releases=releases,
+        current_version=current_version,
+        latest_version=latest_version,
+    )
+    body_path.write_text(
+        "\n".join(
+            [
+                "Automated update of carrier-api dependency pins.",
+                "",
+                f"- Previous manifest pinned version: `carrier-api=={current_version}`",
+                f"- Previous pyproject pinned version: `carrier-api=={pyproject_current_version}`",
+                f"- Updated pinned version: `carrier-api=={latest_version}`",
+                "",
+                "## carrier-api release notes in range",
+                release_notes,
+                "",
+            ],
+        ),
+    )
+
+
+def fetch_releases(*, owner: str, repo: str, token: str | None = None) -> list[dict[str, object]]:
+    """Fetch releases from the GitHub REST API.
+
+    Args:
+        owner: Repository owner.
+        repo: Repository name.
+        token: Optional GitHub token.
+
+    Returns:
+        List of GitHub release objects.
+    """
+    releases: list[dict[str, object]] = []
+    url: str | None = f"{GITHUB_API_URL}/repos/{owner}/{repo}/releases?per_page=100"
+    while url is not None:
+        request = Request(url, headers=_github_headers(token))  # noqa: S310
+        with urlopen(request, timeout=30) as response:  # noqa: S310
+            payload = json.load(response)
+            if not isinstance(payload, list):
+                raise TypeError(f"Expected a list of releases from {url}")
+            releases.extend(release for release in payload if isinstance(release, dict))
+            url = _next_link(response.headers.get("Link"))
+    return releases
+
+
+def _github_headers(token: str | None) -> dict[str, str]:
+    """Build GitHub API request headers.
+
+    Args:
+        token: Optional GitHub token.
+
+    Returns:
+        Request headers.
+    """
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "ha-carrier-update-carrier-api",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def _next_link(link_header: str | None) -> str | None:
+    """Return the next pagination URL from a GitHub Link header.
+
+    Args:
+        link_header: Raw Link header value.
+
+    Returns:
+        Next URL when present.
+    """
+    if not link_header:
+        return None
+    for link in link_header.split(","):
+        url_part, *params = link.split(";")
+        if any(param.strip() == 'rel="next"' for param in params):
+            return url_part.strip()[1:-1]
+    return None
+
+
+def _parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    """Parse command-line arguments.
+
+    Args:
+        argv: Command-line arguments excluding the executable name.
+
+    Returns:
+        Parsed arguments.
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--current-version", required=True)
+    parser.add_argument("--pyproject-current-version", required=True)
+    parser.add_argument("--latest-version", required=True)
+    parser.add_argument("--release-owner", required=True)
+    parser.add_argument("--release-repo", required=True)
+    parser.add_argument("--body-path", type=Path, required=True)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Build the update PR body file.
+
+    Args:
+        argv: Optional command-line arguments excluding the executable name.
+
+    Returns:
+        Process exit code.
+    """
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    token = os.environ.get("GITHUB_TOKEN")
+    try:
+        releases = fetch_releases(owner=args.release_owner, repo=args.release_repo, token=token)
+    except URLError as err:
+        LOGGER.error(
+            "Failed to fetch releases for %s/%s: %s",
+            args.release_owner,
+            args.release_repo,
+            err,
+        )
+        return 1
+    if not releases:
+        LOGGER.error(
+            "No releases found for %s/%s. Check workflow inputs or repository variables "
+            "(CARRIER_API_RELEASE_OWNER/CARRIER_API_RELEASE_REPO).",
+            args.release_owner,
+            args.release_repo,
+        )
+        return 1
+
+    write_pr_body(
+        body_path=args.body_path,
+        releases=releases,
+        current_version=args.current_version,
+        pyproject_current_version=args.pyproject_current_version,
+        latest_version=args.latest_version,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/cleanup_carrier_api_update_branches.py
+++ b/.github/scripts/cleanup_carrier_api_update_branches.py
@@ -1,0 +1,391 @@
+"""Clean up stale carrier-api update pull requests and branches."""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+import json
+import logging
+import os
+import sys
+from typing import Protocol
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+GITHUB_API_URL = "https://api.github.com"
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class CleanupResult:
+    """Result of cleaning workflow-owned pull requests and branches.
+
+    Attributes:
+        closed_prs: Pull request numbers closed as stale.
+        deleted_branches: Branch names deleted from the repository.
+    """
+
+    closed_prs: list[int] = field(default_factory=list)
+    deleted_branches: list[str] = field(default_factory=list)
+
+
+class GithubCleanupClient(Protocol):
+    """Protocol for GitHub operations needed by the cleanup routine."""
+
+    def list_pulls(self, *, state: str) -> list[dict[str, object]]:
+        """List pull requests by state."""
+
+    def close_pull(self, pull_number: int) -> None:
+        """Close a pull request by number."""
+
+    def delete_ref(self, ref: str) -> None:
+        """Delete a git ref by name."""
+
+
+class GithubClient:
+    """Small GitHub REST client for the workflow cleanup task."""
+
+    def __init__(self, *, repository: str, token: str) -> None:
+        """Initialize the client.
+
+        Args:
+            repository: Repository in ``owner/name`` format.
+            token: GitHub token for API calls.
+        """
+        self.repository = repository
+        self.token = token
+
+    def list_pulls(self, *, state: str) -> list[dict[str, object]]:
+        """List pull requests by state.
+
+        Args:
+            state: Pull request state to request.
+
+        Returns:
+            Pull request objects from GitHub.
+        """
+        pulls: list[dict[str, object]] = []
+        url: str | None = (
+            f"{GITHUB_API_URL}/repos/{self.repository}/pulls?state={state}&per_page=100"
+        )
+        while url is not None:
+            payload, link_header = self._request("GET", url)
+            if not isinstance(payload, list):
+                raise TypeError(f"Expected pull request list from {url}")
+            pulls.extend(pull for pull in payload if isinstance(pull, dict))
+            url = _next_link(link_header)
+        return pulls
+
+    def close_pull(self, pull_number: int) -> None:
+        """Close a pull request.
+
+        Args:
+            pull_number: Pull request number to close.
+        """
+        url = f"{GITHUB_API_URL}/repos/{self.repository}/pulls/{pull_number}"
+        self._request("PATCH", url, payload={"state": "closed"})
+
+    def delete_ref(self, ref: str) -> None:
+        """Delete a git ref if it exists.
+
+        Args:
+            ref: Ref path such as ``heads/branch-name``.
+        """
+        url = f"{GITHUB_API_URL}/repos/{self.repository}/git/refs/{ref}"
+        try:
+            self._request("DELETE", url)
+        except HTTPError as err:
+            if err.code == 404 or (err.code == 422 and _is_missing_ref_error(err)):
+                LOGGER.info("Ref %s was already deleted.", ref)
+                return
+            raise
+
+    def _request(
+        self,
+        method: str,
+        url: str,
+        *,
+        payload: Mapping[str, object] | None = None,
+    ) -> tuple[object, str | None]:
+        """Send a GitHub REST request.
+
+        Args:
+            method: HTTP method.
+            url: Request URL.
+            payload: Optional JSON payload.
+
+        Returns:
+            Decoded payload and Link header.
+        """
+        data = json.dumps(payload).encode() if payload is not None else None
+        request = Request(url, data=data, headers=_github_headers(self.token), method=method)  # noqa: S310
+        with urlopen(request, timeout=30) as response:  # noqa: S310
+            if response.status == 204:
+                return {}, response.headers.get("Link")
+            return json.load(response), response.headers.get("Link")
+
+
+def cleanup_update_branches(
+    *,
+    client: GithubCleanupClient,
+    repository: str,
+    branch: str,
+    branch_prefix: str,
+    label_name: str,
+    keep_pr_number: int | None,
+    close_stale_prs: bool,
+    delete_stale_branch: bool,
+    delete_merged_branches: bool,
+) -> CleanupResult:
+    """Clean workflow-owned stale pull requests and branches.
+
+    Args:
+        client: GitHub client with list, close, and delete methods.
+        repository: Repository in ``owner/name`` format.
+        branch: Current workflow update branch.
+        branch_prefix: Prefix for workflow-owned update branches.
+        label_name: Label identifying workflow-created PRs.
+        keep_pr_number: Optional PR number to preserve.
+        close_stale_prs: Whether to close open stale update PRs.
+        delete_stale_branch: Whether to delete the current stale branch.
+        delete_merged_branches: Whether to delete branches from merged update PRs.
+
+    Returns:
+        Summary of cleanup actions.
+    """
+    result = CleanupResult()
+    protected_branches: set[str] = set()
+    branches_to_delete: set[str] = set()
+
+    open_pulls = client.list_pulls(state="open")
+    for pull in open_pulls:
+        if not _is_workflow_pull(
+            pull,
+            repository=repository,
+            branch=branch,
+            branch_prefix=branch_prefix,
+            label_name=label_name,
+        ):
+            continue
+
+        pull_number = _pull_number(pull)
+        head_ref = _head_ref(pull)
+        if keep_pr_number is not None and pull_number == keep_pr_number:
+            protected_branches.add(head_ref)
+            continue
+
+        if close_stale_prs:
+            client.close_pull(pull_number)
+            result.closed_prs.append(pull_number)
+            branches_to_delete.add(head_ref)
+
+    if delete_stale_branch and branch not in protected_branches:
+        branches_to_delete.add(branch)
+
+    if delete_merged_branches:
+        closed_pulls = client.list_pulls(state="closed")
+        for pull in closed_pulls:
+            if pull.get("merged_at") is not None and _is_workflow_pull(
+                pull,
+                repository=repository,
+                branch=branch,
+                branch_prefix=branch_prefix,
+                label_name=label_name,
+            ):
+                branches_to_delete.add(_head_ref(pull))
+
+    branches_to_delete -= protected_branches
+    for branch_name in sorted(branches_to_delete):
+        client.delete_ref(f"heads/{branch_name}")
+        result.deleted_branches.append(branch_name)
+
+    return result
+
+
+def _is_workflow_pull(
+    pull: Mapping[str, object],
+    *,
+    repository: str,
+    branch: str,
+    branch_prefix: str,
+    label_name: str,
+) -> bool:
+    """Return whether a pull request belongs to this workflow.
+
+    Args:
+        pull: Pull request object.
+        repository: Repository in ``owner/name`` format.
+        branch: Current workflow update branch.
+        branch_prefix: Prefix for workflow-owned update branches.
+        label_name: Label identifying workflow-created PRs.
+
+    Returns:
+        True when the PR head branch is owned by this workflow.
+    """
+    labels = pull.get("labels", [])
+    if not isinstance(labels, list) or not any(
+        isinstance(label, dict) and label.get("name") == label_name for label in labels
+    ):
+        return False
+
+    head = pull.get("head", {})
+    if not isinstance(head, dict):
+        return False
+    head_ref = head.get("ref")
+    if not isinstance(head_ref, str):
+        return False
+    if head_ref != branch and not head_ref.startswith(branch_prefix):
+        return False
+
+    head_repo = head.get("repo", {})
+    if not isinstance(head_repo, dict):
+        return False
+    return head_repo.get("full_name") == repository
+
+
+def _head_ref(pull: Mapping[str, object]) -> str:
+    """Return a pull request head ref.
+
+    Args:
+        pull: Pull request object.
+
+    Returns:
+        Pull request head ref.
+    """
+    head = pull["head"]
+    if not isinstance(head, dict) or not isinstance(head.get("ref"), str):
+        raise TypeError("Pull request is missing a head ref")
+    return head["ref"]
+
+
+def _pull_number(pull: Mapping[str, object]) -> int:
+    """Return a pull request number.
+
+    Args:
+        pull: Pull request object.
+
+    Returns:
+        Pull request number.
+    """
+    number = pull["number"]
+    if isinstance(number, int):
+        return number
+    if isinstance(number, str):
+        return int(number)
+    raise TypeError("Pull request is missing a numeric number")
+
+
+def _github_headers(token: str) -> dict[str, str]:
+    """Build GitHub API request headers.
+
+    Args:
+        token: GitHub token.
+
+    Returns:
+        Request headers.
+    """
+    return {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"Bearer {token}",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "ha-carrier-update-carrier-api-cleanup",
+    }
+
+
+def _is_missing_ref_error(err: HTTPError) -> bool:
+    """Return whether a GitHub 422 error reports a missing ref.
+
+    Args:
+        err: HTTP error from the GitHub API.
+
+    Returns:
+        True when the error body says the reference does not exist.
+    """
+    body = err.read().decode(errors="replace")
+    if not body:
+        return False
+    try:
+        payload = json.loads(body)
+    except json.JSONDecodeError:
+        return "Reference does not exist" in body
+    if not isinstance(payload, dict):
+        return False
+    message = payload.get("message")
+    return isinstance(message, str) and "Reference does not exist" in message
+
+
+def _next_link(link_header: str | None) -> str | None:
+    """Return the next pagination URL from a GitHub Link header.
+
+    Args:
+        link_header: Raw Link header value.
+
+    Returns:
+        Next URL when present.
+    """
+    if not link_header:
+        return None
+    for link in link_header.split(","):
+        url_part, *params = link.split(";")
+        if any(param.strip() == 'rel="next"' for param in params):
+            return url_part.strip()[1:-1]
+    return None
+
+
+def _parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    """Parse command-line arguments.
+
+    Args:
+        argv: Command-line arguments excluding the executable name.
+
+    Returns:
+        Parsed arguments.
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--branch", required=True)
+    parser.add_argument("--branch-prefix", required=True)
+    parser.add_argument("--label-name", required=True)
+    parser.add_argument("--keep-pr-number", type=int)
+    parser.add_argument("--close-stale-prs", action="store_true")
+    parser.add_argument("--delete-stale-branch", action="store_true")
+    parser.add_argument("--delete-merged-branches", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run workflow branch cleanup.
+
+    Args:
+        argv: Optional command-line arguments excluding the executable name.
+
+    Returns:
+        Process exit code.
+    """
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    token = os.environ.get("GITHUB_TOKEN")
+    if not token:
+        LOGGER.error("GITHUB_TOKEN is required for cleanup.")
+        return 1
+
+    client = GithubClient(repository=args.repository, token=token)
+    result = cleanup_update_branches(
+        client=client,
+        repository=args.repository,
+        branch=args.branch,
+        branch_prefix=args.branch_prefix,
+        label_name=args.label_name,
+        keep_pr_number=args.keep_pr_number,
+        close_stale_prs=args.close_stale_prs,
+        delete_stale_branch=args.delete_stale_branch,
+        delete_merged_branches=args.delete_merged_branches,
+    )
+    LOGGER.info("Closed stale PRs: %s", result.closed_prs or "none")
+    LOGGER.info("Deleted branches: %s", result.deleted_branches or "none")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/update_carrier_api_pins.py
+++ b/.github/scripts/update_carrier_api_pins.py
@@ -6,13 +6,16 @@ import argparse
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 import json
+import logging
 from pathlib import Path
 import re
 import sys
 import tomllib
+from urllib.error import HTTPError, URLError
 from urllib.request import urlopen
 
 PYPI_URL = "https://pypi.org/pypi/carrier-api/json"
+LOGGER = logging.getLogger(__name__)
 PIN_PREFIX = "carrier-api=="
 PYPROJECT_PIN_RE = re.compile(r'(?m)^(\s*)"carrier-api==[^"]+"(,?)\s*$')
 PRERELEASE_RE = re.compile(r"(?i)(?:[.\-_]?(?:a|alpha|b|beta|c|pre|preview|rc|dev)\d*)")
@@ -100,10 +103,19 @@ def fetch_latest_version() -> str:
     Raises:
         ValueError: If PyPI does not return a usable version.
     """
-    with urlopen(PYPI_URL, timeout=30) as response:  # noqa: S310
-        payload = json.load(response)
-
-    return _select_latest_stable_version(payload)
+    try:
+        with urlopen(PYPI_URL, timeout=30) as response:  # noqa: S310
+            payload = json.load(response)
+        return _select_latest_stable_version(payload)
+    except (HTTPError, URLError) as err:
+        LOGGER.error("Failed to fetch carrier-api PyPI metadata: %s", err)
+        raise
+    except json.JSONDecodeError as err:
+        LOGGER.error("Failed to decode carrier-api PyPI metadata: %s", err)
+        raise
+    except (TypeError, ValueError) as err:
+        LOGGER.error("Failed to select latest carrier-api version from PyPI metadata: %s", err)
+        raise
 
 
 def _select_latest_stable_version(payload: Mapping[str, object]) -> str:
@@ -348,16 +360,29 @@ def main(argv: Sequence[str] | None = None) -> int:
     Returns:
         Process exit code.
     """
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
     args = _parse_args(sys.argv[1:] if argv is None else argv)
-    latest_version = args.latest_version or fetch_latest_version()
-    result = update_pins(
-        manifest_path=args.manifest_path,
-        pyproject_path=args.pyproject_path,
-        latest_version=latest_version,
-        write=args.write,
-    )
-    if args.github_output is not None:
-        _write_github_outputs(result, args.github_output)
+    try:
+        latest_version = args.latest_version or fetch_latest_version()
+        result = update_pins(
+            manifest_path=args.manifest_path,
+            pyproject_path=args.pyproject_path,
+            latest_version=latest_version,
+            write=args.write,
+        )
+        if args.github_output is not None:
+            _write_github_outputs(result, args.github_output)
+    except (
+        HTTPError,
+        URLError,
+        json.JSONDecodeError,
+        tomllib.TOMLDecodeError,
+        OSError,
+        TypeError,
+        ValueError,
+    ) as err:
+        LOGGER.error("Failed to update carrier-api dependency pins: %s", err)
+        return 1
     return 0
 
 

--- a/.github/scripts/update_carrier_api_pins.py
+++ b/.github/scripts/update_carrier_api_pins.py
@@ -1,0 +1,365 @@
+"""Update carrier-api dependency pins in manifest and pyproject files."""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+import json
+from pathlib import Path
+import re
+import sys
+import tomllib
+from urllib.request import urlopen
+
+PYPI_URL = "https://pypi.org/pypi/carrier-api/json"
+PIN_PREFIX = "carrier-api=="
+PYPROJECT_PIN_RE = re.compile(r'(?m)^(\s*)"carrier-api==[^"]+"(,?)\s*$')
+PRERELEASE_RE = re.compile(r"(?i)(?:[.\-_]?(?:a|alpha|b|beta|c|pre|preview|rc|dev)\d*)")
+
+
+@dataclass(frozen=True)
+class UpdateResult:
+    """Result of evaluating carrier-api dependency pins.
+
+    Attributes:
+        current: Current manifest carrier-api pin version.
+        pyproject_current: Current pyproject carrier-api pin version.
+        latest: carrier-api version selected as the update target.
+        update_needed: Whether at least one pin should be updated.
+    """
+
+    current: str
+    pyproject_current: str
+    latest: str
+    update_needed: bool
+
+
+def _version_key(version: str) -> tuple[tuple[int, int | str], ...]:
+    """Return a tolerant comparison key for carrier-api version strings.
+
+    Args:
+        version: Version string to normalize.
+
+    Returns:
+        Tuple suitable for comparing common dotted release versions.
+    """
+    parts = re.findall(r"\d+|[A-Za-z]+", version.lstrip("vV"))
+    return tuple((0, int(part)) if part.isdigit() else (1, part.lower()) for part in parts)
+
+
+def _latest_is_newer(current: str, latest: str) -> bool:
+    """Return whether the latest version is newer than the current version.
+
+    Args:
+        current: Current pinned version.
+        latest: Latest available version.
+
+    Returns:
+        True when latest sorts after current.
+    """
+    if _is_prerelease(latest):
+        return False
+    if _is_prerelease(current):
+        return _version_key(latest) >= _stable_version_key(current)
+    return _version_key(latest) > _version_key(current)
+
+
+def _stable_version_key(version: str) -> tuple[tuple[int, int | str], ...]:
+    """Return a comparison key for the stable part of a version string.
+
+    Args:
+        version: Version string to normalize.
+
+    Returns:
+        Tuple suitable for comparing the stable release version.
+    """
+    match = PRERELEASE_RE.search(version)
+    stable_version = version[: match.start()].rstrip(".-_") if match else version
+    return _version_key(stable_version)
+
+
+def _is_prerelease(version: str) -> bool:
+    """Return whether a version string appears to be a prerelease.
+
+    Args:
+        version: Version string to evaluate.
+
+    Returns:
+        True when the version has a common prerelease marker.
+    """
+    return PRERELEASE_RE.search(version) is not None
+
+
+def fetch_latest_version() -> str:
+    """Fetch the latest stable carrier-api version from PyPI.
+
+    Returns:
+        Latest stable version string.
+
+    Raises:
+        ValueError: If PyPI does not return a usable version.
+    """
+    with urlopen(PYPI_URL, timeout=30) as response:  # noqa: S310
+        payload = json.load(response)
+
+    return _select_latest_stable_version(payload)
+
+
+def _select_latest_stable_version(payload: Mapping[str, object]) -> str:
+    """Select the newest stable version from a PyPI JSON payload.
+
+    Args:
+        payload: PyPI JSON response payload.
+
+    Returns:
+        Newest non-prerelease version from the release list.
+
+    Raises:
+        ValueError: If PyPI does not return any stable versions.
+    """
+    releases = payload.get("releases", {})
+    if not isinstance(releases, dict):
+        raise TypeError("Expected releases mapping in PyPI response")
+
+    stable_versions = [
+        version
+        for version, files in releases.items()
+        if (
+            isinstance(version, str)
+            and not _is_prerelease(version)
+            and _release_has_usable_file(files)
+        )
+    ]
+    if not stable_versions:
+        raise ValueError("Unable to determine latest stable carrier-api version from PyPI response")
+    return max(stable_versions, key=_version_key)
+
+
+def _release_has_usable_file(files: object) -> bool:
+    """Return whether a PyPI release has at least one non-yanked file.
+
+    Args:
+        files: Release file list from a PyPI JSON response.
+
+    Returns:
+        True when at least one file can be installed.
+    """
+    if not isinstance(files, list):
+        return False
+    return any(isinstance(file, dict) and file.get("yanked") is not True for file in files)
+
+
+def _read_manifest_version(manifest_path: Path) -> str:
+    """Read the carrier-api pin version from a Home Assistant manifest.
+
+    Args:
+        manifest_path: Path to the integration manifest.
+
+    Returns:
+        Current carrier-api version.
+
+    Raises:
+        ValueError: If there is not exactly one pinned carrier-api requirement.
+    """
+    manifest = json.loads(manifest_path.read_text())
+    requirements = manifest.get("requirements", [])
+    if not isinstance(requirements, list):
+        raise TypeError(f"Expected requirements list in {manifest_path}")
+
+    pins = [requirement for requirement in requirements if _is_carrier_api_pin(requirement)]
+    if len(pins) != 1:
+        raise ValueError(
+            f"Expected exactly one carrier-api requirement in {manifest_path}; found {len(pins)}"
+        )
+    return pins[0].removeprefix(PIN_PREFIX)
+
+
+def _read_pyproject_version(pyproject_path: Path) -> str:
+    """Read the carrier-api pin version from dependency groups in pyproject.
+
+    Args:
+        pyproject_path: Path to pyproject.toml.
+
+    Returns:
+        Current carrier-api version.
+
+    Raises:
+        ValueError: If there is not exactly one pinned carrier-api dependency.
+    """
+    pyproject = tomllib.loads(pyproject_path.read_text())
+    dependency_groups = pyproject.get("dependency-groups", {})
+    if not isinstance(dependency_groups, dict):
+        raise TypeError(f"Expected dependency-groups table in {pyproject_path}")
+
+    pins: list[str] = []
+    for dependencies in dependency_groups.values():
+        if not isinstance(dependencies, list):
+            continue
+        pins.extend(dependency for dependency in dependencies if _is_carrier_api_pin(dependency))
+
+    if len(pins) != 1:
+        raise ValueError(
+            f"Expected exactly one pinned carrier-api dependency in {pyproject_path}; "
+            f"found {len(pins)}"
+        )
+    return pins[0].removeprefix(PIN_PREFIX)
+
+
+def _is_carrier_api_pin(requirement: object) -> bool:
+    """Return whether a dependency entry is a carrier-api exact pin.
+
+    Args:
+        requirement: Dependency entry read from JSON or TOML.
+
+    Returns:
+        True when the entry is an exact carrier-api pin.
+    """
+    return isinstance(requirement, str) and requirement.startswith(PIN_PREFIX)
+
+
+def _write_manifest_version(manifest_path: Path, latest_version: str) -> None:
+    """Write the carrier-api pin version into the manifest.
+
+    Args:
+        manifest_path: Path to the integration manifest.
+        latest_version: Version to pin.
+
+    Raises:
+        ValueError: If there is not exactly one pinned carrier-api requirement.
+    """
+    manifest = json.loads(manifest_path.read_text())
+    requirements = manifest.get("requirements", [])
+    if not isinstance(requirements, list):
+        raise TypeError(f"Expected requirements list in {manifest_path}")
+
+    updated_count = 0
+    updated_requirements: list[object] = []
+    for requirement in requirements:
+        if _is_carrier_api_pin(requirement):
+            updated_count += 1
+            updated_requirements.append(f"{PIN_PREFIX}{latest_version}")
+        else:
+            updated_requirements.append(requirement)
+
+    if updated_count != 1:
+        raise ValueError(
+            f"Expected to update exactly one carrier-api requirement in {manifest_path}; "
+            f"updated {updated_count}"
+        )
+
+    manifest["requirements"] = updated_requirements
+    manifest_path.write_text(f"{json.dumps(manifest, indent=2)}\n")
+
+
+def _write_pyproject_version(pyproject_path: Path, latest_version: str) -> None:
+    """Write the carrier-api pin version into pyproject while preserving layout.
+
+    Args:
+        pyproject_path: Path to pyproject.toml.
+        latest_version: Version to pin.
+
+    Raises:
+        ValueError: If there is not exactly one pinned carrier-api dependency line.
+    """
+    text = pyproject_path.read_text()
+    updated, count = PYPROJECT_PIN_RE.subn(rf'\1"{PIN_PREFIX}{latest_version}"\2', text)
+    if count != 1:
+        raise ValueError(
+            f"Expected to update exactly one carrier-api pin in {pyproject_path}; updated {count}"
+        )
+    pyproject_path.write_text(updated)
+
+
+def update_pins(
+    *,
+    manifest_path: Path,
+    pyproject_path: Path,
+    latest_version: str,
+    write: bool = True,
+) -> UpdateResult:
+    """Evaluate and optionally update carrier-api dependency pins.
+
+    Args:
+        manifest_path: Path to manifest.json.
+        pyproject_path: Path to pyproject.toml.
+        latest_version: Latest carrier-api version available for evaluation.
+        write: Whether to rewrite dependency files when an update is needed.
+
+    Returns:
+        Evaluation result for workflow outputs and tests.
+    """
+    current = _read_manifest_version(manifest_path)
+    pyproject_current = _read_pyproject_version(pyproject_path)
+    latest_is_newer = _latest_is_newer(current, latest_version)
+    target_version = latest_version if latest_is_newer else current
+    update_needed = latest_is_newer or pyproject_current != target_version
+
+    if write and update_needed:
+        _write_manifest_version(manifest_path, target_version)
+        _write_pyproject_version(pyproject_path, target_version)
+
+    return UpdateResult(
+        current=current,
+        pyproject_current=pyproject_current,
+        latest=target_version,
+        update_needed=update_needed,
+    )
+
+
+def _write_github_outputs(result: UpdateResult, output_path: Path) -> None:
+    """Append update result values to the GitHub Actions output file.
+
+    Args:
+        result: Update result to write.
+        output_path: Path from the GITHUB_OUTPUT environment variable.
+    """
+    with output_path.open("a") as output_file:
+        output_file.write(f"current={result.current}\n")
+        output_file.write(f"pyproject_current={result.pyproject_current}\n")
+        output_file.write(f"latest={result.latest}\n")
+        output_file.write(f"update_needed={str(result.update_needed).lower()}\n")
+
+
+def _parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    """Parse command-line arguments.
+
+    Args:
+        argv: Command-line arguments excluding the executable name.
+
+    Returns:
+        Parsed arguments.
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest-path", type=Path, required=True)
+    parser.add_argument("--pyproject-path", type=Path, required=True)
+    parser.add_argument("--latest-version")
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument("--github-output", type=Path)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the carrier-api dependency pin updater.
+
+    Args:
+        argv: Optional command-line arguments excluding the executable name.
+
+    Returns:
+        Process exit code.
+    """
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    latest_version = args.latest_version or fetch_latest_version()
+    result = update_pins(
+        manifest_path=args.manifest_path,
+        pyproject_path=args.pyproject_path,
+        latest_version=latest_version,
+        write=args.write,
+    )
+    if args.github_output is not None:
+        _write_github_outputs(result, args.github_output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/update_carrier_api.yml
+++ b/.github/workflows/update_carrier_api.yml
@@ -30,6 +30,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/update_carrier_api.yml
+++ b/.github/workflows/update_carrier_api.yml
@@ -1,4 +1,4 @@
-name: Update carrier-api
+name: Update carrier-api dependency
 
 on:
   schedule:
@@ -23,7 +23,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  update-carrier_api:
+  update-carrier-api:
     name: Update carrier-api
     runs-on: ubuntu-latest
 
@@ -31,175 +31,54 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v6
 
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.14'
+          cache: 'pip'
+
       - name: Determine current and latest carrier-api versions
         id: versions
         run: |
           set -euo pipefail
 
-          manifest_path="custom_components/ha_carrier/manifest.json"
-          pyproject_path="pyproject.toml"
-          package_name="carrier-api"
-          current_manifest_requirement_count="$(
-            jq -r --arg package_name "$package_name" '[.requirements[] | select(startswith($package_name + "=="))] | length' "$manifest_path"
-          )"
-          current_manifest_requirement="$(
-            jq -r --arg package_name "$package_name" '[.requirements[] | select(startswith($package_name + "=="))] | .[0] // empty' "$manifest_path"
-          )"
-          if [ "$current_manifest_requirement_count" -ne 1 ]; then
-            echo "Expected exactly one $package_name requirement in $manifest_path; found $current_manifest_requirement_count (current_manifest_requirement='$current_manifest_requirement')" >&2
-            exit 1
-          fi
+          python .github/scripts/update_carrier_api_pins.py \
+            --manifest-path custom_components/ha_carrier/manifest.json \
+            --pyproject-path pyproject.toml \
+            --github-output "$GITHUB_OUTPUT"
 
-          current_pyproject_requirement_count="$(grep -Eo '"carrier-api==[^"]+"' "$pyproject_path" | wc -l | tr -d ' ')"
-          current_pyproject_requirement="$(grep -Eo '"carrier-api==[^"]+"' "$pyproject_path" | head -n1 | tr -d '"')"
-          current_pyproject_versions="$(grep -Eo '"carrier-api==[^"]+"' "$pyproject_path" | tr -d '"' | sed -E 's/^[^0-9]*//' | sort -Vu)"
-          current_pyproject_version_count="$(printf '%s\n' "$current_pyproject_versions" | sed '/^$/d' | wc -l | tr -d ' ')"
-          if [ "$current_pyproject_requirement_count" -lt 1 ]; then
-            echo "Expected at least one $package_name requirement in $pyproject_path; found none" >&2
-            exit 1
-          fi
-
-          current_version="$(printf '%s' "$current_manifest_requirement" | sed -E 's/^[^0-9]*//')"
-          pyproject_version="$(printf '%s' "$current_pyproject_requirement" | sed -E 's/^[^0-9]*//')"
-          latest_version="$(curl -fsSL https://pypi.org/pypi/carrier-api/json | jq -r '.info.version // empty')"
-          if [ -z "$latest_version" ] || [ "$latest_version" = "null" ]; then
-            echo "Unable to determine latest carrier-api version from PyPI response" >&2
-            exit 1
-          fi
-
-          update_needed="false"
-          if [ "$current_pyproject_version_count" -ne 1 ]; then
-            update_needed="true"
-          elif [ "$current_version" != "$pyproject_version" ]; then
-            update_needed="true"
-          elif [ "$(printf '%s\n%s\n' "$current_version" "$latest_version" | sort -V | tail -n1)" = "$latest_version" ] && [ "$current_version" != "$latest_version" ]; then
-            update_needed="true"
-          fi
-
-          {
-            echo "current_manifest=$current_version"
-            echo "current_pyproject=$pyproject_version"
-            echo "latest=$latest_version"
-            echo "update_needed=$update_needed"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Update carrier-api requirements
+      - name: Update carrier-api dependency pins
         if: steps.versions.outputs.update_needed == 'true'
+        env:
+          LATEST_VERSION: ${{ steps.versions.outputs.latest }}
         run: |
           set -euo pipefail
 
-          manifest_path="custom_components/ha_carrier/manifest.json"
-          pyproject_path="pyproject.toml"
-          latest_version="${{ steps.versions.outputs.latest }}"
-          manifest_tmp_file="$(mktemp)"
-          pyproject_tmp_file="$(mktemp)"
-
-          jq --arg latest "$latest_version" '
-            .requirements |= map(
-              if startswith("carrier-api==")
-              then "carrier-api==" + $latest
-              else .
-              end
-            )
-          ' "$manifest_path" > "$manifest_tmp_file"
-
-          sed -E 's/"carrier-api==[^"]+"/"carrier-api=='"$latest_version"'"/g' "$pyproject_path" > "$pyproject_tmp_file"
-
-          mv "$manifest_tmp_file" "$manifest_path"
-          mv "$pyproject_tmp_file" "$pyproject_path"
-
-      - name: Install semver for release notes generation
-        if: steps.versions.outputs.update_needed == 'true'
-        run: npm install --prefix "$RUNNER_TEMP/ha-carrier-semver" semver
+          python .github/scripts/update_carrier_api_pins.py \
+            --manifest-path custom_components/ha_carrier/manifest.json \
+            --pyproject-path pyproject.toml \
+            --latest-version "$LATEST_VERSION" \
+            --write
 
       - name: Build carrier-api release notes
         if: steps.versions.outputs.update_needed == 'true'
-        id: release_notes
-        uses: actions/github-script@v9
         env:
-          CURRENT_VERSION: ${{ steps.versions.outputs.current_manifest }}
+          GITHUB_TOKEN: ${{ github.token }}
+          CURRENT_VERSION: ${{ steps.versions.outputs.current }}
+          PYPROJECT_CURRENT_VERSION: ${{ steps.versions.outputs.pyproject_current }}
           LATEST_VERSION: ${{ steps.versions.outputs.latest }}
-          NODE_PATH: ${{ runner.temp }}/ha-carrier-semver/node_modules
-          REPO_OWNER: ${{ github.event.inputs.carrier_api_release_owner || 'dahlb' }}
-          REPO_NAME: ${{ github.event.inputs.carrier_api_release_repo || 'carrier_api' }}
-        with:
-          script: |
-            const semver = require("semver");
-            const current = process.env.CURRENT_VERSION.replace(/^v/i, "");
-            const latest = process.env.LATEST_VERSION.replace(/^v/i, "");
-            const releaseOwner = process.env.REPO_OWNER;
-            const releaseRepo = process.env.REPO_NAME;
+          REPO_OWNER: ${{ github.event.inputs.carrier_api_release_owner || vars.CARRIER_API_RELEASE_OWNER || 'dahlb' }}
+          REPO_NAME: ${{ github.event.inputs.carrier_api_release_repo || vars.CARRIER_API_RELEASE_REPO || 'carrier_api' }}
+        run: |
+          set -euo pipefail
 
-            function normalizeTagVersion(version) {
-              return semver.clean(version, { loose: true });
-            }
-
-            function sanitizeReleaseBody(body) {
-              return body
-                .replace(/\[@([A-Za-z0-9-]+)\]\(https?:\/\/github\.com\/[A-Za-z0-9-]+\)/g, "$1")
-                .replace(/(?<![A-Za-z0-9_])@([A-Za-z0-9-]+)/g, "$1");
-            }
-
-            const normalizedCurrent = normalizeTagVersion(current);
-            const normalizedLatest = normalizeTagVersion(latest);
-            if (!normalizedCurrent || !normalizedLatest) {
-              core.setFailed(
-                `Unable to normalize version range current='${current}' latest='${latest}'`,
-              );
-              return;
-            }
-
-            const releases = await github.paginate(github.rest.repos.listReleases, {
-              owner: releaseOwner,
-              repo: releaseRepo,
-              per_page: 100,
-            });
-            if (releases.length === 0) {
-              core.setFailed(
-                `No releases found for ${releaseOwner}/${releaseRepo}. ` +
-                  "Check workflow inputs or repository variables " +
-                  "(CARRIER_API_RELEASE_OWNER/CARRIER_API_RELEASE_REPO).",
-              );
-              return;
-            }
-
-            const selected = releases
-              .filter((release) => {
-                const tagVersion = normalizeTagVersion(release.tag_name);
-                if (!tagVersion) {
-                  return false;
-                }
-                return (
-                  semver.compare(tagVersion, normalizedCurrent) > 0 &&
-                  semver.compare(tagVersion, normalizedLatest) <= 0
-                );
-              })
-              .sort((a, b) => semver.compare(
-                normalizeTagVersion(a.tag_name),
-                normalizeTagVersion(b.tag_name),
-              ));
-
-            let notes = "";
-            if (selected.length === 0) {
-              notes =
-                "No matching GitHub release notes were found for this version range.";
-            } else {
-              notes = selected
-                .map((release) => {
-                  const body = sanitizeReleaseBody(
-                    (release.body || "No release body provided.").trim(),
-                  );
-                  return [
-                    `### ${release.name || release.tag_name} (${release.tag_name})`,
-                    release.html_url,
-                    "",
-                    body,
-                  ].join("\n");
-                })
-                .join("\n\n---\n\n");
-            }
-
-            core.setOutput("notes", notes);
+          python .github/scripts/build_carrier_api_release_notes.py \
+            --current-version "$CURRENT_VERSION" \
+            --pyproject-current-version "$PYPROJECT_CURRENT_VERSION" \
+            --latest-version "$LATEST_VERSION" \
+            --release-owner "$REPO_OWNER" \
+            --release-repo "$REPO_NAME" \
+            --body-path carrier-api-update-pr-body.md
 
       - name: Create or update carrier-api update PR
         if: steps.versions.outputs.update_needed == 'true'
@@ -212,56 +91,28 @@ jobs:
           title: 'Bump carrier-api to ${{ steps.versions.outputs.latest }}'
           author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           labels: carrier-api-auto-update
-          body: |
-            Automated update of `pyproject.toml` and `custom_components/ha_carrier/manifest.json`.
-
-            - Previous manifest pin: `carrier-api==${{ steps.versions.outputs.current_manifest }}`
-            - Previous pyproject pin: `carrier-api==${{ steps.versions.outputs.current_pyproject }}`
-            - Updated pinned version: `carrier-api==${{ steps.versions.outputs.latest }}`
-
-            ## carrier-api release notes in range
-            ${{ steps.release_notes.outputs.notes }}
+          body-path: carrier-api-update-pr-body.md
           add-paths: |
-            pyproject.toml
             custom_components/ha_carrier/manifest.json
+            pyproject.toml
 
       - name: Close extra auto-generated PRs
         if: steps.versions.outputs.update_needed == 'true' && steps.cpr.outputs.pull-request-number != ''
-        uses: actions/github-script@v9
         env:
+          GITHUB_TOKEN: ${{ github.token }}
           KEEP_PR_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
-        with:
-          script: |
-            const keep = Number(process.env.KEEP_PR_NUMBER);
-            const branch = "chore/update-carrier-api-dependency";
-            const pulls = await github.paginate(github.rest.pulls.list, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: "open",
-              per_page: 100,
-              head: `${context.repo.owner}:${branch}`,
-            });
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
 
-            for (const pr of pulls) {
-              if (pr.number === keep) {
-                continue;
-              }
-              const hasAutoLabel = pr.labels.some(
-                (label) => label.name === "carrier-api-auto-update",
-              );
-              if (!hasAutoLabel) {
-                continue;
-              }
-              if (pr.head.ref !== branch) {
-                continue;
-              }
-              await github.rest.pulls.update({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: pr.number,
-                state: "closed",
-              });
-            }
+          python .github/scripts/cleanup_carrier_api_update_branches.py \
+            --repository "$REPOSITORY" \
+            --branch chore/update-carrier-api-dependency \
+            --branch-prefix chore/update-carrier-api \
+            --label-name carrier-api-auto-update \
+            --keep-pr-number "$KEEP_PR_NUMBER" \
+            --close-stale-prs \
+            --delete-merged-branches
 
       - name: Log when no update is required
         if: steps.versions.outputs.update_needed != 'true'
@@ -269,57 +120,17 @@ jobs:
 
       - name: Close stale carrier-api update PRs
         if: steps.versions.outputs.update_needed != 'true'
-        uses: actions/github-script@v9
-        with:
-          script: |
-            const branch = "chore/update-carrier-api-dependency";
-            const labelName = "carrier-api-auto-update";
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
 
-            const pulls = await github.paginate(github.rest.pulls.list, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: "open",
-              per_page: 100,
-              head: `${context.repo.owner}:${branch}`,
-            });
-
-            const stalePulls = pulls.filter(
-              (pr) =>
-                pr.head.ref === branch &&
-                pr.labels.some((label) => label.name === labelName),
-            );
-
-            if (stalePulls.length === 0) {
-              core.info(
-                `No open ${labelName} PRs found for branch ${branch}.`,
-              );
-            } else {
-              for (const pr of stalePulls) {
-                await github.rest.pulls.update({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  pull_number: pr.number,
-                  state: "closed",
-                });
-
-                core.info(`Closed stale carrier-api update PR #${pr.number}.`);
-              }
-            }
-
-            try {
-              await github.rest.git.deleteRef({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                ref: `heads/${branch}`,
-              });
-              core.info(`Deleted stale branch ${branch}.`);
-            } catch (error) {
-              const status = error.status ?? error.response?.status;
-
-              if (status === 404 || status === 422) {
-                core.info(`Branch ${branch} does not exist; nothing to delete.`);
-                return;
-              }
-
-              throw error;
-            }
+          python .github/scripts/cleanup_carrier_api_update_branches.py \
+            --repository "$REPOSITORY" \
+            --branch chore/update-carrier-api-dependency \
+            --branch-prefix chore/update-carrier-api \
+            --label-name carrier-api-auto-update \
+            --close-stale-prs \
+            --delete-stale-branch \
+            --delete-merged-branches

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,7 +168,6 @@ addopts = """
   --durations=10
   -o console_output_style=progress
   --cov=custom_components.ha_carrier
-  --cov-fail-under=70
   --cov-report=term-missing
   --cov-report=html
 """

--- a/tests/test_update_carrier_api_workflow.py
+++ b/tests/test_update_carrier_api_workflow.py
@@ -141,29 +141,27 @@ def _load_script(module_name: str, script_path: Path) -> ModuleType:
 
 
 @pytest.mark.parametrize(
-    ("needle", "reason"),
+    "needle",
     [
-        ("actions/setup-python@v6", "pins a Python runtime"),
-        ("python-version: '3.14'", "uses a tomllib-capable Python"),
-        ("Automated update of carrier-api dependency pins.", "describes generated PRs"),
-        ("custom_components/ha_carrier/manifest.json", "updates the integration manifest"),
-        ("pyproject.toml", "updates the local dependency pin"),
-        ("pyproject_current", "reports pyproject drift in PR metadata"),
-        (str(SCRIPT_PATH), "runs the checked-in updater helper"),
-        (str(RELEASE_NOTES_SCRIPT_PATH), "runs the checked-in release-note helper"),
-        (str(CLEANUP_SCRIPT_PATH), "runs the checked-in cleanup helper"),
-        ("--body-path carrier-api-update-pr-body.md", "uses a PR body file"),
-        ("--delete-merged-branches", "cleans merged workflow-owned branches"),
-        ("LATEST_VERSION: ${{ steps.versions.outputs.latest }}", "exports latest pin"),
-        ('--latest-version "$LATEST_VERSION"', "avoids shell template injection"),
-        ("REPOSITORY: ${{ github.repository }}", "exports repository before shell use"),
-        ('--repository "$REPOSITORY"', "avoids inline repository template expansion"),
+        "actions/setup-python@v6",
+        "python-version: '3.14'",
+        "Automated update of carrier-api dependency pins.",
+        "custom_components/ha_carrier/manifest.json",
+        "pyproject.toml",
+        "pyproject_current",
+        str(SCRIPT_PATH),
+        str(RELEASE_NOTES_SCRIPT_PATH),
+        str(CLEANUP_SCRIPT_PATH),
+        "--body-path carrier-api-update-pr-body.md",
+        "--delete-merged-branches",
+        "LATEST_VERSION: ${{ steps.versions.outputs.latest }}",
+        '--latest-version "$LATEST_VERSION"',
+        "REPOSITORY: ${{ github.repository }}",
+        '--repository "$REPOSITORY"',
     ],
 )
-def test_workflow_contains_expected_update_logic(needle: str, reason: str) -> None:
+def test_workflow_contains_expected_update_logic(needle: str) -> None:
     """Workflow should include the expected carrier-api updater logic."""
-    del reason
-
     assert needle in _read_update_workflow_surface()
 
 

--- a/tests/test_update_carrier_api_workflow.py
+++ b/tests/test_update_carrier_api_workflow.py
@@ -1,0 +1,463 @@
+"""Tests for the carrier-api dependency update workflow."""
+
+from __future__ import annotations
+
+from importlib import util
+import json
+from pathlib import Path
+import sys
+from types import ModuleType
+
+import pytest
+
+WORKFLOW_PATH = Path(".github/workflows/update_carrier_api.yml")
+SCRIPT_PATH = Path(".github/scripts/update_carrier_api_pins.py")
+RELEASE_NOTES_SCRIPT_PATH = Path(".github/scripts/build_carrier_api_release_notes.py")
+CLEANUP_SCRIPT_PATH = Path(".github/scripts/cleanup_carrier_api_update_branches.py")
+
+
+class FakeCleanupClient:
+    """Fake GitHub cleanup client that records mutating calls."""
+
+    def __init__(
+        self,
+        *,
+        open_pulls: list[dict[str, object]],
+        closed_pulls: list[dict[str, object]],
+        fail_on_close: bool = False,
+    ) -> None:
+        """Initialize fake pull request state.
+
+        Args:
+            open_pulls: Pull requests to return for open PR lookups.
+            closed_pulls: Pull requests to return for closed PR lookups.
+            fail_on_close: Whether closing a PR should fail the test.
+        """
+        self.open_pulls = open_pulls
+        self.closed_pulls = closed_pulls
+        self.fail_on_close = fail_on_close
+        self.closed_prs: list[int] = []
+        self.deleted_refs: list[str] = []
+
+    def list_pulls(self, *, state: str) -> list[dict[str, object]]:
+        """Return fake pull requests by state."""
+        return self.open_pulls if state == "open" else self.closed_pulls
+
+    def close_pull(self, pull_number: int) -> None:
+        """Record or reject a closed pull request."""
+        if self.fail_on_close:
+            raise AssertionError(f"Unexpected close for PR {pull_number}")
+        self.closed_prs.append(pull_number)
+
+    def delete_ref(self, ref: str) -> None:
+        """Record a deleted git ref."""
+        self.deleted_refs.append(ref)
+
+
+def _workflow_pull(
+    *,
+    number: int,
+    ref: str = "chore/update-carrier-api-dependency",
+    label: str = "carrier-api-auto-update",
+    merged_at: str | None = None,
+) -> dict[str, object]:
+    """Return a fake workflow pull request object.
+
+    Args:
+        number: Pull request number.
+        ref: Pull request head ref.
+        label: Pull request label name.
+        merged_at: Optional merge timestamp for closed PRs.
+
+    Returns:
+        Fake pull request object shaped like the GitHub REST API response.
+    """
+    return {
+        "number": number,
+        "merged_at": merged_at,
+        "head": {"ref": ref, "repo": {"full_name": "o/r"}},
+        "labels": [{"name": label}],
+    }
+
+
+def _write_pin_files(
+    tmp_path: Path,
+    *,
+    manifest_version: str,
+    pyproject_version: str | None = None,
+    pyproject_text: str | None = None,
+) -> tuple[Path, Path]:
+    """Write temporary manifest and pyproject files with carrier-api pins."""
+    manifest_path = tmp_path / "manifest.json"
+    pyproject_path = tmp_path / "pyproject.toml"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "requirements": [
+                    "numpy==2.3.5",
+                    f"carrier-api=={manifest_version}",
+                ],
+            },
+        ),
+    )
+
+    if pyproject_text is None:
+        pyproject_text = f"""[dependency-groups]
+ha = [
+    "carrier-api=={pyproject_version or manifest_version}",
+]
+"""
+    pyproject_path.write_text(pyproject_text)
+    return manifest_path, pyproject_path
+
+
+@pytest.fixture
+def updater_script() -> ModuleType:
+    """Load the carrier-api pin updater script as a test module."""
+    return _load_script("update_carrier_api_pins", SCRIPT_PATH)
+
+
+@pytest.fixture
+def release_notes_script() -> ModuleType:
+    """Load the carrier-api release-note builder script as a test module."""
+    return _load_script("build_carrier_api_release_notes", RELEASE_NOTES_SCRIPT_PATH)
+
+
+@pytest.fixture
+def cleanup_script() -> ModuleType:
+    """Load the carrier-api cleanup script as a test module."""
+    return _load_script("cleanup_carrier_api_update_branches", CLEANUP_SCRIPT_PATH)
+
+
+def _load_script(module_name: str, script_path: Path) -> ModuleType:
+    """Load a checked-in workflow helper script as a test module."""
+    spec = util.spec_from_file_location(module_name, script_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.parametrize(
+    ("needle", "reason"),
+    [
+        ("actions/setup-python@v6", "pins a Python runtime"),
+        ("python-version: '3.14'", "uses a tomllib-capable Python"),
+        ("Automated update of carrier-api dependency pins.", "describes generated PRs"),
+        ("custom_components/ha_carrier/manifest.json", "updates the integration manifest"),
+        ("pyproject.toml", "updates the local dependency pin"),
+        ("pyproject_current", "reports pyproject drift in PR metadata"),
+        (str(SCRIPT_PATH), "runs the checked-in updater helper"),
+        (str(RELEASE_NOTES_SCRIPT_PATH), "runs the checked-in release-note helper"),
+        (str(CLEANUP_SCRIPT_PATH), "runs the checked-in cleanup helper"),
+        ("--body-path carrier-api-update-pr-body.md", "uses a PR body file"),
+        ("--delete-merged-branches", "cleans merged workflow-owned branches"),
+        ("LATEST_VERSION: ${{ steps.versions.outputs.latest }}", "exports latest pin"),
+        ('--latest-version "$LATEST_VERSION"', "avoids shell template injection"),
+        ("REPOSITORY: ${{ github.repository }}", "exports repository before shell use"),
+        ('--repository "$REPOSITORY"', "avoids inline repository template expansion"),
+    ],
+)
+def test_workflow_contains_expected_update_logic(needle: str, reason: str) -> None:
+    """Workflow should include the expected carrier-api updater logic."""
+    del reason
+
+    assert needle in _read_update_workflow_surface()
+
+
+def test_workflow_avoids_inline_repository_template_expansion() -> None:
+    """Workflow should not expand the repository context inside shell scripts."""
+    assert '--repository "${{ github.repository }}"' not in WORKFLOW_PATH.read_text()
+
+
+def _read_update_workflow_surface() -> str:
+    """Read workflow and helper surfaces checked by workflow assertions."""
+    return (
+        f"{WORKFLOW_PATH.read_text()}\n"
+        f"{RELEASE_NOTES_SCRIPT_PATH.read_text()}\n"
+        f"{CLEANUP_SCRIPT_PATH.read_text()}"
+    )
+
+
+@pytest.mark.parametrize(
+    (
+        "manifest_version",
+        "pyproject_version",
+        "latest_version",
+        "expected_update_needed",
+        "expected_target",
+    ),
+    [
+        ("3.3.0", "3.3.0", "3.4.0", True, "3.4.0"),
+        ("3.3.0", "3.3.0", "3.4.0rc1", False, "3.3.0"),
+        ("3.4.0rc1", "3.4.0rc1", "3.4.0", True, "3.4.0"),
+        ("3.3.10", "3.3.9", "3.3.9", True, "3.3.10"),
+    ],
+)
+def test_updater_script_pin_update_scenarios(
+    tmp_path: Path,
+    updater_script: ModuleType,
+    manifest_version: str,
+    pyproject_version: str,
+    latest_version: str,
+    expected_update_needed: bool,
+    expected_target: str,
+) -> None:
+    """Updater script should handle stable, prerelease, and drift pin scenarios."""
+    manifest_path, pyproject_path = _write_pin_files(
+        tmp_path,
+        manifest_version=manifest_version,
+        pyproject_version=pyproject_version,
+    )
+
+    result = updater_script.update_pins(
+        manifest_path=manifest_path,
+        pyproject_path=pyproject_path,
+        latest_version=latest_version,
+    )
+
+    assert result.current == manifest_version
+    assert result.pyproject_current == pyproject_version
+    assert result.latest == expected_target
+    assert result.update_needed is expected_update_needed
+    assert f"carrier-api=={expected_target}" in manifest_path.read_text()
+    assert f'    "carrier-api=={expected_target}",' in pyproject_path.read_text()
+
+
+def test_updater_script_updates_pyproject_pin_without_trailing_comma(
+    tmp_path: Path, updater_script: ModuleType
+) -> None:
+    """Updater script should preserve valid TOML dependency-list formatting."""
+    manifest_path, pyproject_path = _write_pin_files(
+        tmp_path,
+        manifest_version="3.3.0",
+        pyproject_text="""[dependency-groups]
+ha = [
+    "homeassistant",
+    "carrier-api==3.3.0"
+]
+""",
+    )
+
+    result = updater_script.update_pins(
+        manifest_path=manifest_path,
+        pyproject_path=pyproject_path,
+        latest_version="3.4.0",
+    )
+
+    assert result.update_needed is True
+    assert '    "carrier-api==3.4.0"\n' in pyproject_path.read_text()
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected_latest"),
+    [
+        (
+            {
+                "info": {"version": "3.4.0rc1"},
+                "releases": {
+                    "3.3.0": [{"filename": "carrier-api-3.3.0.tar.gz"}],
+                    "3.3.1": [{"filename": "carrier-api-3.3.1.tar.gz"}],
+                    "3.4.0rc1": [{"filename": "carrier-api-3.4.0rc1.tar.gz"}],
+                },
+            },
+            "3.3.1",
+        ),
+        (
+            {
+                "releases": {
+                    "3.3.0": [{"filename": "carrier-api-3.3.0.tar.gz"}],
+                    "3.3.1": [],
+                    "3.3.2": [{"filename": "carrier-api-3.3.2.tar.gz", "yanked": True}],
+                },
+            },
+            "3.3.0",
+        ),
+    ],
+)
+def test_updater_script_selects_latest_stable_from_pypi_payload(
+    updater_script: ModuleType,
+    payload: dict[str, object],
+    expected_latest: str,
+) -> None:
+    """Updater script should select the latest installable stable PyPI release."""
+    latest = updater_script._select_latest_stable_version(
+        payload,
+    )
+
+    assert latest == expected_latest
+
+
+def test_updater_script_rejects_duplicate_pyproject_pins(
+    tmp_path: Path,
+    updater_script: ModuleType,
+) -> None:
+    """Updater script should fail clearly when pyproject has ambiguous pins."""
+    manifest_path, pyproject_path = _write_pin_files(
+        tmp_path,
+        manifest_version="3.3.0",
+        pyproject_text="""[dependency-groups]
+ha = [
+    "carrier-api==3.3.0",
+    "carrier-api==3.3.1",
+]
+""",
+    )
+
+    with pytest.raises(ValueError, match="Expected exactly one pinned carrier-api dependency"):
+        updater_script.update_pins(
+            manifest_path=manifest_path,
+            pyproject_path=pyproject_path,
+            latest_version="3.4.0",
+        )
+
+
+def test_release_note_script_builds_sanitized_pr_body(
+    tmp_path: Path,
+    release_notes_script: ModuleType,
+) -> None:
+    """Release-note script should build a mention-safe PR body file."""
+    releases = [
+        {
+            "tag_name": "3.3.0",
+            "name": "Ignored current",
+            "body": "old",
+            "html_url": "https://example.test/3.3.0",
+        },
+        {
+            "tag_name": "3.3.1",
+            "name": "Fixes @someone",
+            "body": "fixes #123 and thanks [@helper](https://github.com/helper)",
+            "html_url": "https://example.test/3.3.1",
+        },
+        {
+            "tag_name": "3.4.0rc1",
+            "name": "Ignored prerelease",
+            "body": "future",
+            "html_url": "https://example.test/3.4.0rc1",
+        },
+    ]
+    body_path = tmp_path / "body.md"
+
+    release_notes_script.write_pr_body(
+        body_path=body_path,
+        releases=releases,
+        current_version="3.3.0",
+        pyproject_current_version="3.3.0",
+        latest_version="3.3.1",
+    )
+
+    body = body_path.read_text()
+    assert "Automated update of carrier-api dependency pins." in body
+    assert "Updated pinned version: `carrier-api==3.3.1`" in body
+    assert "### Fixes @<!-- -->someone (3.3.1)" in body
+    assert "fixes \\#123 and thanks helper" in body
+    assert "Ignored current" not in body
+    assert "Ignored prerelease" not in body
+
+
+def test_release_note_script_handles_url_errors(
+    tmp_path: Path,
+    release_notes_script: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Release-note script should report network failures without a traceback."""
+
+    def raise_url_error(**_: object) -> list[dict[str, object]]:
+        """Raise a urlopen-style network failure."""
+        raise release_notes_script.URLError("DNS failure")
+
+    monkeypatch.setattr(release_notes_script, "fetch_releases", raise_url_error)
+
+    result = release_notes_script.main(
+        [
+            "--current-version",
+            "3.3.0",
+            "--pyproject-current-version",
+            "3.3.0",
+            "--latest-version",
+            "3.3.1",
+            "--release-owner",
+            "dahlb",
+            "--release-repo",
+            "carrier_api",
+            "--body-path",
+            str(tmp_path / "body.md"),
+        ],
+    )
+
+    assert result == 1
+
+
+def test_cleanup_script_closes_stale_prs_and_deletes_workflow_branches(
+    cleanup_script: ModuleType,
+) -> None:
+    """Cleanup script should close stale PRs and remove workflow-created branches."""
+    client = FakeCleanupClient(
+        open_pulls=[
+            _workflow_pull(number=10),
+            _workflow_pull(number=9, ref="chore/update-carrier-api-old"),
+            _workflow_pull(number=11, ref="feature/manual"),
+        ],
+        closed_pulls=[
+            _workflow_pull(number=8, merged_at="2026-05-28T00:00:00Z"),
+            _workflow_pull(number=7, ref="chore/update-carrier-api-old"),
+        ],
+    )
+
+    result = cleanup_script.cleanup_update_branches(
+        client=client,
+        repository="o/r",
+        branch="chore/update-carrier-api-dependency",
+        branch_prefix="chore/update-carrier-api",
+        label_name="carrier-api-auto-update",
+        keep_pr_number=None,
+        close_stale_prs=True,
+        delete_stale_branch=True,
+        delete_merged_branches=True,
+    )
+
+    assert client.closed_prs == [10, 9]
+    assert client.deleted_refs == [
+        "heads/chore/update-carrier-api-dependency",
+        "heads/chore/update-carrier-api-old",
+    ]
+    assert result.closed_prs == [10, 9]
+    assert result.deleted_branches == [
+        "chore/update-carrier-api-dependency",
+        "chore/update-carrier-api-old",
+    ]
+
+
+def test_cleanup_script_keeps_active_update_branch(cleanup_script: ModuleType) -> None:
+    """Cleanup script should not delete the branch for the kept update PR."""
+    client = FakeCleanupClient(
+        open_pulls=[_workflow_pull(number=12)],
+        closed_pulls=[
+            _workflow_pull(number=8, merged_at="2026-05-28T00:00:00Z"),
+            _workflow_pull(
+                number=6,
+                ref="chore/update-carrier-api-old",
+                merged_at="2026-05-20T00:00:00Z",
+            ),
+        ],
+        fail_on_close=True,
+    )
+
+    result = cleanup_script.cleanup_update_branches(
+        client=client,
+        repository="o/r",
+        branch="chore/update-carrier-api-dependency",
+        branch_prefix="chore/update-carrier-api",
+        label_name="carrier-api-auto-update",
+        keep_pr_number=12,
+        close_stale_prs=True,
+        delete_stale_branch=False,
+        delete_merged_branches=True,
+    )
+
+    assert client.deleted_refs == ["heads/chore/update-carrier-api-old"]
+    assert result.closed_prs == []
+    assert result.deleted_branches == ["chore/update-carrier-api-old"]

--- a/tests/test_update_carrier_api_workflow.py
+++ b/tests/test_update_carrier_api_workflow.py
@@ -312,6 +312,55 @@ ha = [
         )
 
 
+def test_updater_script_logs_fetch_errors(
+    updater_script: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Updater script should log PyPI fetch failures before re-raising."""
+
+    def raise_url_error(*_: object, **__: object) -> object:
+        """Raise a urlopen-style network failure."""
+        raise updater_script.URLError("DNS failure")
+
+    monkeypatch.setattr(updater_script, "urlopen", raise_url_error)
+    caplog.set_level("ERROR", logger=updater_script.__name__)
+
+    with pytest.raises(updater_script.URLError, match="DNS failure"):
+        updater_script.fetch_latest_version()
+
+    assert "Failed to fetch carrier-api PyPI metadata" in caplog.text
+
+
+def test_updater_script_main_handles_fetch_errors(
+    tmp_path: Path,
+    updater_script: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Updater script should return a failing status for fetch errors."""
+    manifest_path, pyproject_path = _write_pin_files(tmp_path, manifest_version="3.3.0")
+
+    def raise_url_error() -> str:
+        """Raise a PyPI fetch failure."""
+        raise updater_script.URLError("DNS failure")
+
+    monkeypatch.setattr(updater_script, "fetch_latest_version", raise_url_error)
+    caplog.set_level("ERROR", logger=updater_script.__name__)
+
+    result = updater_script.main(
+        [
+            "--manifest-path",
+            str(manifest_path),
+            "--pyproject-path",
+            str(pyproject_path),
+        ],
+    )
+
+    assert result == 1
+    assert "Failed to update carrier-api dependency pins" in caplog.text
+
+
 def test_release_note_script_builds_sanitized_pr_body(
     tmp_path: Path,
     release_notes_script: ModuleType,


### PR DESCRIPTION
## Summary
Reworks the carrier-api dependency update workflow so the complex update, release-note, and stale-branch cleanup logic lives in checked-in Python helpers with regression coverage.

## What Changed
- Replaced inline shell and `actions/github-script` workflow logic with Python helper scripts under `.github/scripts`.
- Added carrier-api pin update handling for manifest and pyproject pins, stable PyPI release selection, and prerelease/drift scenarios.
- Added release-note PR body generation with mention and closing-keyword sanitization.
- Added cleanup logic for stale workflow-owned PRs and branches.
- Hardened the update workflow checkout with `persist-credentials: false`.
- Added tests covering workflow surface expectations, updater behavior, release-note generation, error handling, and cleanup behavior.

## Why
Keeping workflow business logic in tested Python helpers makes the nightly dependency update easier to validate locally, reduces quoting risk in YAML, and gives future review feedback a concrete regression-test surface.

## Validation
- `./.venv/bin/pytest tests/test_update_carrier_api_workflow.py --no-cov`
- `./scripts/lint`
- `./.venv/bin/pytest`
