### PR TITLE
Add Carrier entry-level (Smart Thermostat) climate support

### DIFF
--- a/custom_components/ha_carrier/carrier_data_update_coordinator.py
+++ b/custom_components/ha_carrier/carrier_data_update_coordinator.py
@@ -7,7 +7,7 @@ import functools
 import logging
 from typing import Any, NoReturn
 
-from carrier_api import ApiConnectionGraphql, CarrierApiError, Energy, System
+from carrier_api import ApiConnectionGraphql, CarrierApiError, Energy, EntryLevelSystem, System
 from carrier_api.api_websocket_data_updater import WebsocketDataUpdater
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
@@ -88,6 +88,7 @@ class CarrierDataUpdateCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
             transient_threshold=TRANSIENT_FAILURE_THRESHOLD,
         )
         self.systems: list[System] = []
+        self.entry_level_systems: list[EntryLevelSystem] = []
         self.websocket_data_updater: WebsocketDataUpdater | None = None
         self.websocket_task: asyncio.Task[None] | None = None
         self._websocket_initialized = False
@@ -218,6 +219,7 @@ class CarrierDataUpdateCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
                     stale_system.profile.serial,
                 )
                 self.systems.remove(stale_system)
+        await self._refresh_entry_level_systems()
         if not self._websocket_initialized:
             self.websocket_data_updater = WebsocketDataUpdater(systems=self.systems)
             api_websocket = self.api_connection.api_websocket
@@ -412,6 +414,34 @@ class CarrierDataUpdateCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
         """
         for system in self.systems:
             if system.profile.serial == system_serial:
+                return system
+        return None
+
+    async def _refresh_entry_level_systems(self) -> None:
+        """Refresh entry-level (Smart Thermostat) systems as a best-effort step.
+
+        Entry-level data is independent of the Infinity systems and websocket
+        path, so a failure here is logged and swallowed rather than failing the
+        whole refresh.
+        """
+        try:
+            self.entry_level_systems = await self.api_connection.load_entry_level_data()
+        except asyncio.CancelledError, KeyboardInterrupt, SystemExit:
+            raise
+        except (CarrierApiError, *RECOVERABLE_REFRESH_EXCEPTIONS) as error:
+            _LOGGER.debug("Carrier entry-level refresh failed (non-fatal): %s", error)
+
+    def entry_level_system(self, serial: str) -> EntryLevelSystem | None:
+        """Return the tracked entry-level system matching a serial.
+
+        Args:
+            serial: Entry-level system serial to locate.
+
+        Returns:
+            EntryLevelSystem | None: Matching system, or None when not found.
+        """
+        for system in self.entry_level_systems:
+            if system.serial == serial:
                 return system
         return None
 

--- a/custom_components/ha_carrier/climate.py
+++ b/custom_components/ha_carrier/climate.py
@@ -28,6 +28,7 @@ from . import ConfigEntryCarrier
 from .carrier_data_update_coordinator import CarrierDataUpdateCoordinator
 from .carrier_entity import CarrierZoneEntity
 from .const import CONF_INFINITE_HOLDS, DEFAULT_INFINITE_HOLDS, FAN_AUTO
+from .entry_level_climate import build_entry_level_entities
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -83,6 +84,7 @@ async def async_setup_entry(
             for zone in carrier_system.config.zones
         )
     async_add_entities(entities)
+    async_add_entities(build_entry_level_entities(coordinator))
 
 
 class CarrierClimate(CarrierZoneEntity, ClimateEntity):

--- a/custom_components/ha_carrier/entry_level_climate.py
+++ b/custom_components/ha_carrier/entry_level_climate.py
@@ -1,0 +1,258 @@
+"""Expose Carrier entry-level (Smart Thermostat) zones as climate entities."""
+
+from __future__ import annotations
+
+from functools import partial
+import logging
+from typing import TYPE_CHECKING, Any, ClassVar
+
+from homeassistant.components.climate import (
+    ClimateEntity,
+    ClimateEntityFeature,
+    HVACAction,
+    HVACMode,
+)
+from homeassistant.components.climate.const import ATTR_TARGET_TEMP_HIGH, ATTR_TARGET_TEMP_LOW
+from homeassistant.const import ATTR_TEMPERATURE, PRECISION_WHOLE, UnitOfTemperature
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util import slugify
+
+from .carrier_data_update_coordinator import CarrierDataUpdateCoordinator
+from .const import DOMAIN
+
+if TYPE_CHECKING:
+    from carrier_api import EntryLevelSystem, EntryLevelZone
+
+_LOGGER: logging.Logger = logging.getLogger(__name__)
+
+# The device reports and accepts a lowercase mode string.
+MODE_TO_HVAC: dict[str, HVACMode] = {
+    "cool": HVACMode.COOL,
+    "heat": HVACMode.HEAT,
+    "off": HVACMode.OFF,
+    "auto": HVACMode.HEAT_COOL,
+}
+HVAC_TO_MODE: dict[HVACMode, str] = {
+    HVACMode.COOL: "cool",
+    HVACMode.HEAT: "heat",
+    HVACMode.OFF: "off",
+    HVACMode.HEAT_COOL: "auto",
+}
+
+
+def build_entry_level_entities(
+    coordinator: CarrierDataUpdateCoordinator,
+) -> list[EntryLevelThermostat]:
+    """Build a climate entity for each entry-level zone the coordinator tracks.
+
+    Args:
+        coordinator: Coordinator that supplies Carrier entry-level data.
+
+    Returns:
+        A list of entry-level thermostat entities to register.
+    """
+    return [
+        EntryLevelThermostat(coordinator, system.serial, zone.index)
+        for system in coordinator.entry_level_systems
+        for zone in system.zones
+    ]
+
+
+class EntryLevelThermostat(CoordinatorEntity[CarrierDataUpdateCoordinator], ClimateEntity):
+    """Climate entity controlling one Carrier entry-level thermostat zone."""
+
+    _attr_has_entity_name = True
+    _attr_name = None
+    _attr_temperature_unit = UnitOfTemperature.FAHRENHEIT
+    _attr_target_temperature_step = PRECISION_WHOLE
+    _attr_hvac_modes: ClassVar[list[HVACMode]] = [
+        HVACMode.OFF,
+        HVACMode.COOL,
+        HVACMode.HEAT,
+        HVACMode.HEAT_COOL,
+    ]
+    _attr_supported_features = (
+        ClimateEntityFeature.TARGET_TEMPERATURE
+        | ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
+        | ClimateEntityFeature.TURN_ON
+        | ClimateEntityFeature.TURN_OFF
+    )
+    _enable_turn_on_off_backwards_compatibility = False
+
+    def __init__(self, coordinator: CarrierDataUpdateCoordinator, serial: str, index: int) -> None:
+        """Initialize an entry-level thermostat entity.
+
+        Args:
+            coordinator: Coordinator that supplies Carrier entry-level data.
+            serial: Serial of the entry-level system this entity represents.
+            index: Zone index within the entry-level system.
+        """
+        super().__init__(coordinator, serial)
+        self._serial = serial
+        self._index = index
+        self._attr_unique_id = slugify(f"{serial}_{index}_entry_level_thermostat")
+        system = self._system
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, serial)},
+            manufacturer="Carrier",
+            model=system.model if system is not None else None,
+            sw_version=system.firmware if system is not None else None,
+            name=system.name if system is not None else serial,
+        )
+
+    @property
+    def _system(self) -> EntryLevelSystem | None:
+        """Return the coordinator's entry-level system for this entity."""
+        return self.coordinator.entry_level_system(self._serial)
+
+    @property
+    def _zone(self) -> EntryLevelZone | None:
+        """Return the coordinator's entry-level zone for this entity."""
+        system = self._system
+        if system is None:
+            return None
+        return next((zone for zone in system.zones if zone.index == self._index), None)
+
+    @property
+    def available(self) -> bool:
+        """Return whether coordinator health and device state allow control."""
+        system = self._system
+        return (
+            self.coordinator.last_update_success
+            and system is not None
+            and system.is_connected is not False
+            and self._zone is not None
+        )
+
+    @property
+    def current_temperature(self) -> float | None:
+        """Return the current room temperature."""
+        zone = self._zone
+        return None if zone is None else zone.temperature
+
+    @property
+    def current_humidity(self) -> int | None:
+        """Return the current room humidity."""
+        zone = self._zone
+        return None if zone is None else zone.humidity
+
+    @property
+    def hvac_mode(self) -> HVACMode | None:
+        """Return the current HVAC mode."""
+        zone = self._zone
+        if zone is None or zone.mode is None:
+            return None
+        return MODE_TO_HVAC.get(zone.mode.lower(), HVACMode.OFF)
+
+    @property
+    def hvac_action(self) -> HVACAction | None:
+        """Return the current HVAC action derived from the reported stage."""
+        zone = self._zone
+        if zone is None or not zone.stage_status:
+            return None
+        stage = zone.stage_status.lower()
+        if "cool" in stage:
+            return HVACAction.COOLING
+        if "heat" in stage:
+            return HVACAction.HEATING
+        if self.hvac_mode == HVACMode.OFF:
+            return HVACAction.OFF
+        return HVACAction.IDLE
+
+    @property
+    def target_temperature(self) -> float | None:
+        """Return the single target set point for heat or cool mode."""
+        zone = self._zone
+        if zone is None:
+            return None
+        if self.hvac_mode == HVACMode.HEAT:
+            return zone.heat_set_point
+        if self.hvac_mode == HVACMode.COOL:
+            return zone.cool_set_point
+        return None
+
+    @property
+    def target_temperature_high(self) -> float | None:
+        """Return the cool set point when in heat/cool mode."""
+        zone = self._zone
+        if zone is None or self.hvac_mode != HVACMode.HEAT_COOL:
+            return None
+        return zone.cool_set_point
+
+    @property
+    def target_temperature_low(self) -> float | None:
+        """Return the heat set point when in heat/cool mode."""
+        zone = self._zone
+        if zone is None or self.hvac_mode != HVACMode.HEAT_COOL:
+            return None
+        return zone.heat_set_point
+
+    async def async_set_temperature(self, **kwargs: Any) -> None:
+        """Update the zone's set points.
+
+        Args:
+            **kwargs: Home Assistant temperature arguments.
+        """
+        zone = self._zone
+        if zone is None:
+            raise HomeAssistantError("Entry-level zone unavailable, try again later")
+        cool_set_point = zone.cool_set_point
+        heat_set_point = zone.heat_set_point
+        if (temperature := kwargs.get(ATTR_TEMPERATURE)) is not None:
+            if self.hvac_mode == HVACMode.HEAT:
+                heat_set_point = temperature
+            else:
+                cool_set_point = temperature
+        if (low := kwargs.get(ATTR_TARGET_TEMP_LOW)) is not None:
+            heat_set_point = low
+        if (high := kwargs.get(ATTR_TARGET_TEMP_HIGH)) is not None:
+            cool_set_point = high
+        await self.coordinator.async_perform_api_call(
+            "set entry-level set points",
+            partial(
+                self.coordinator.api_connection.update_entry_level_zone,
+                self._serial,
+                self._index,
+                cool_set_point=cool_set_point,
+                heat_set_point=heat_set_point,
+            ),
+        )
+        zone.cool_set_point = cool_set_point
+        zone.heat_set_point = heat_set_point
+        self.async_write_ha_state()
+
+    async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
+        """Set the HVAC mode.
+
+        Args:
+            hvac_mode: Requested Home Assistant HVAC mode.
+
+        Raises:
+            ValueError: Raised when the mode is unsupported.
+        """
+        mode = HVAC_TO_MODE.get(hvac_mode)
+        if mode is None:
+            raise ValueError(f"unsupported mode: {hvac_mode}")
+        await self.coordinator.async_perform_api_call(
+            "set entry-level mode",
+            partial(
+                self.coordinator.api_connection.update_entry_level_zone,
+                self._serial,
+                self._index,
+                mode=mode,
+            ),
+        )
+        zone = self._zone
+        if zone is not None:
+            zone.mode = mode
+        self.async_write_ha_state()
+
+    async def async_turn_off(self) -> None:
+        """Turn the thermostat off."""
+        await self.async_set_hvac_mode(HVACMode.OFF)
+
+    async def async_turn_on(self) -> None:
+        """Turn the thermostat on (cool)."""
+        await self.async_set_hvac_mode(HVACMode.COOL)

--- a/custom_components/ha_carrier/manifest.json
+++ b/custom_components/ha_carrier/manifest.json
@@ -14,7 +14,7 @@
     "carrier_api"
   ],
   "requirements": [
-    "carrier-api==3.3.0"
+    "carrier-api==3.4.0"
   ],
   "version": "2.23.6"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ version = { attr = "custom_components.ha_carrier.const.VERSION" }
 
 [dependency-groups]
 ha = [
-    "carrier-api==3.3.0",
+    "carrier-api==3.4.0",
     "homeassistant",
 ]
 lint = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import patch
 
-from carrier_api import Config, Energy, Profile, Status, System
+from carrier_api import Config, Energy, EntryLevelSystem, Profile, Status, System
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
@@ -60,6 +60,7 @@ class FakeCarrierApiConnection:
         password: str = PASSWORD,
         identity_id: str = IDENTITY_ID,
         systems: list[System] | None = None,
+        entry_level_systems: list[EntryLevelSystem] | None = None,
     ) -> None:
         """Initialize the fake API connection.
 
@@ -68,11 +69,14 @@ class FakeCarrierApiConnection:
             password: Carrier account password.
             identity_id: Carrier account identity ID returned by user info.
             systems: Systems returned by ``load_data``.
+            entry_level_systems: Entry-level systems returned by
+                ``load_entry_level_data``.
         """
         self.username = username
         self.password = password
         self.identity_id = identity_id
         self.systems = systems or [build_carrier_system()]
+        self.entry_level_systems: list[EntryLevelSystem] = entry_level_systems or []
         self.api_websocket = FakeCarrierWebsocket()
         self.calls: list[tuple[str, dict[str, Any]]] = []
         self.load_data_error: BaseException | None = None
@@ -84,6 +88,18 @@ class FakeCarrierApiConnection:
         if self.load_data_error is not None:
             raise self.load_data_error
         return self.systems
+
+    async def load_entry_level_data(self) -> list[EntryLevelSystem]:
+        """Return configured entry-level systems."""
+        self.calls.append(("load_entry_level_data", {}))
+        return self.entry_level_systems
+
+    async def update_entry_level_zone(
+        self, serial: str, index: int = 0, **kwargs: Any
+    ) -> dict[str, Any]:
+        """Record an entry-level zone write."""
+        self.calls.append(("update_entry_level_zone", {"serial": serial, "index": index, **kwargs}))
+        return {"updateEntryLevelZone": {"success": True}}
 
     async def cleanup(self) -> None:
         """Record credential-validation cleanup."""
@@ -261,6 +277,51 @@ def _status_zone_raw(*, zone_id: str, name: str, occupancy: bool = True) -> dict
         "zoneconditioning": "idle",
         "damperposition": 50,
     }
+
+
+def build_entry_level_system(
+    *,
+    serial: str = "EL123",
+    name: str = "Basement",
+    mode: str = "cool",
+) -> EntryLevelSystem:
+    """Build an entry-level (Smart Thermostat) system for tests.
+
+    Args:
+        serial: Serial number for the entry-level system.
+        name: Display name for the system.
+        mode: Zone HVAC mode string reported by Carrier.
+
+    Returns:
+        EntryLevelSystem: A single-zone entry-level system model.
+    """
+    return EntryLevelSystem(
+        {
+            "serial": serial,
+            "name": name,
+            "model": "TSTATCCEEF-01",
+            "firmware": "1.0.0",
+            "location_id": "LOCATION",
+            "temp_unit_format": "F",
+            "connection": {"isConnected": True, "deviceId": "DEVICE"},
+            "zones": [
+                {
+                    "index": 0,
+                    "mode": mode,
+                    "rt": 75,
+                    "rh": 50,
+                    "clsp": {"current": 78, "min": 60},
+                    "htsp": {"current": 62, "max": 90},
+                    "fan_mode": "auto",
+                    "schedule_enabled": True,
+                    "hold_end_time": 0,
+                    "hold_countdown": 30,
+                    "stage_status": "Idle",
+                    "outside_temp": 90,
+                }
+            ],
+        }
+    )
 
 
 def build_carrier_system(

--- a/tests/test_entry_level_climate.py
+++ b/tests/test_entry_level_climate.py
@@ -1,0 +1,89 @@
+"""Workflow tests for Carrier entry-level (Smart Thermostat) climate entities."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN, HVACMode
+from homeassistant.components.climate.const import SERVICE_SET_HVAC_MODE, SERVICE_SET_TEMPERATURE
+from homeassistant.const import ATTR_ENTITY_ID, ATTR_TEMPERATURE
+from homeassistant.core import HomeAssistant
+from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
+import pytest
+
+from .conftest import FakeCarrierApiConnection, build_entry_level_system, entity_id_for_unique_id
+
+ENTITY_UNIQUE_ID = "el123_0_entry_level_thermostat"
+
+
+@pytest.mark.asyncio
+async def test_entry_level_climate_registers(
+    hass: HomeAssistant,
+    carrier_api: FakeCarrierApiConnection,
+    setup_integration: Callable[..., Any],
+) -> None:
+    """Register an entry-level thermostat with the expected initial state."""
+    hass.config.units = US_CUSTOMARY_SYSTEM
+    carrier_api.entry_level_systems = [build_entry_level_system()]
+    await setup_integration()
+
+    entity_id = entity_id_for_unique_id(hass, CLIMATE_DOMAIN, ENTITY_UNIQUE_ID)
+    state = hass.states.get(entity_id)
+
+    assert state is not None
+    assert state.state == HVACMode.COOL
+    assert state.attributes["current_temperature"] == 75
+    assert state.attributes["current_humidity"] == 50
+    assert state.attributes["temperature"] == 78
+
+
+@pytest.mark.asyncio
+async def test_entry_level_set_temperature(
+    hass: HomeAssistant,
+    carrier_api: FakeCarrierApiConnection,
+    setup_integration: Callable[..., Any],
+) -> None:
+    """Set the cool set point through Home Assistant."""
+    hass.config.units = US_CUSTOMARY_SYSTEM
+    carrier_api.entry_level_systems = [build_entry_level_system()]
+    await setup_integration()
+    entity_id = entity_id_for_unique_id(hass, CLIMATE_DOMAIN, ENTITY_UNIQUE_ID)
+
+    await hass.services.async_call(
+        CLIMATE_DOMAIN,
+        SERVICE_SET_TEMPERATURE,
+        {ATTR_ENTITY_ID: entity_id, ATTR_TEMPERATURE: 72},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    name, payload = carrier_api.calls[-1]
+    assert name == "update_entry_level_zone"
+    assert payload["serial"] == "EL123"
+    assert payload["cool_set_point"] == 72
+
+
+@pytest.mark.asyncio
+async def test_entry_level_set_hvac_mode(
+    hass: HomeAssistant,
+    carrier_api: FakeCarrierApiConnection,
+    setup_integration: Callable[..., Any],
+) -> None:
+    """Change the HVAC mode through Home Assistant."""
+    hass.config.units = US_CUSTOMARY_SYSTEM
+    carrier_api.entry_level_systems = [build_entry_level_system()]
+    await setup_integration()
+    entity_id = entity_id_for_unique_id(hass, CLIMATE_DOMAIN, ENTITY_UNIQUE_ID)
+
+    await hass.services.async_call(
+        CLIMATE_DOMAIN,
+        SERVICE_SET_HVAC_MODE,
+        {ATTR_ENTITY_ID: entity_id, "hvac_mode": HVACMode.HEAT},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    name, payload = carrier_api.calls[-1]
+    assert name == "update_entry_level_zone"
+    assert payload["mode"] == "heat"


### PR DESCRIPTION
## Summary

Adds Home Assistant `climate` entities for the non-Infinity Carrier **Smart
Thermostat** line (e.g. `TSTATCCEEF-01`), which the cloud exposes as
`entryLevelSystems`. These sit on the same account as Infinity systems but are
a different device type, so they aren't picked up today.

## What's added

- The coordinator refreshes entry-level systems alongside Infinity systems.
  The fetch is best-effort and isolated — a failure is logged and swallowed so
  it can never break the Infinity refresh or websocket path.
- A self-contained `EntryLevelThermostat` climate entity (current temperature,
  humidity, cool/heat set points, HVAC mode, and `hvac_action` derived from the
  reported stage). It's built on `CoordinatorEntity` rather than the
  zone-specific Infinity base, since entry-level systems have no Infinity
  zones/profile.

## Dependency

Requires the entry-level support in `carrier_api` (`carrier-api==3.4.0`), added
in dahlb/carrier_api#118. That should merge and release first; the manifest is
already pinned to `3.4.0`.

## Validation

- Confirmed on live hardware (3× `TSTATCCEEF-01`): the three thermostats appear
  as climate entities with correct temperature/humidity/set point/mode reads,
  and all four HVAC modes and set-point writes work on the device.
- Note the same eventual-consistency behavior as Infinity — a write shows up on
  the next coordinator refresh rather than instantly.

## Testing notes

- No changes to the Infinity path; entry-level entities are additive.
- To try it before the `carrier_api` release, point the manifest requirement at
  the `carrier_api` branch and reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
