### PR TITLE
fix: read climate set points from config activity, not stale status

### DIFF
--- a/custom_components/ha_carrier/climate.py
+++ b/custom_components/ha_carrier/climate.py
@@ -202,16 +202,25 @@ class CarrierClimate(CarrierZoneEntity, ClimateEntity):
             self._attr_target_temperature_step = PRECISION_HALVES
         else:
             self._attr_target_temperature_step = PRECISION_WHOLE
+        # Read the target set points from the resolved config activity rather
+        # than the status zone. The status zone's clsp/htsp is only refreshed by
+        # the periodic full poll — the realtime websocket keeps room temperature
+        # current but lets the status set points go stale — so a set point change
+        # (from Home Assistant, the app, or the thermostat) can be missing for up
+        # to the full-refresh interval. The config activity tracks those changes,
+        # so it reflects the true target promptly. Fall back to the status zone
+        # when the current activity can't be resolved from config.
+        setpoint_source = self._current_activity() or self._status_zone
         self._attr_target_temperature = None
         self._attr_target_temperature_high = None
         self._attr_target_temperature_low = None
         if hvac_mode == HVACMode.HEAT:
-            self._attr_target_temperature = self._status_zone.heat_set_point
+            self._attr_target_temperature = setpoint_source.heat_set_point
         elif hvac_mode == HVACMode.COOL:
-            self._attr_target_temperature = self._status_zone.cool_set_point
+            self._attr_target_temperature = setpoint_source.cool_set_point
         elif hvac_mode == HVACMode.HEAT_COOL:
-            self._attr_target_temperature_high = self._status_zone.cool_set_point
-            self._attr_target_temperature_low = self._status_zone.heat_set_point
+            self._attr_target_temperature_high = setpoint_source.cool_set_point
+            self._attr_target_temperature_low = setpoint_source.heat_set_point
 
         if self.carrier_system.config.humidifier_enabled:
             self._attr_target_humidity = self.carrier_system.config.humidifier_heat_target

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -26,6 +26,7 @@ from homeassistant.components.climate.const import (
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
 import pytest
 
 from custom_components.ha_carrier.const import FAN_AUTO
@@ -88,6 +89,38 @@ async def test_climate_preset_mode_uses_status_activity(
 
     assert state is not None
     assert state.attributes["preset_mode"] == "away"
+
+
+@pytest.mark.asyncio
+async def test_climate_setpoint_prefers_config_activity_over_stale_status(
+    hass: HomeAssistant,
+    carrier_api: FakeCarrierApiConnection,
+    setup_integration: Callable[..., Any],
+) -> None:
+    """Surface the config activity set point, not a stale status clsp/htsp.
+
+    The status zone's set points only refresh on the periodic full poll, so a
+    recent change can leave clsp/htsp stale while the resolved config activity is
+    current. The entity should report the config activity value.
+    """
+    hass.config.units = US_CUSTOMARY_SYSTEM
+    carrier_api.systems = [build_carrier_system()]
+    system = carrier_api.systems[0]
+    system.config.mode = "cool"
+    # Fresh set point lives on the resolved (home) config activity...
+    home_activity = system.config.zones[0].find_activity(ActivityTypes.HOME)
+    assert home_activity is not None
+    home_activity.cool_set_point = 63
+    # ...while the status zone still reports a stale cool set point.
+    system.status.zones[0].cool_set_point = 71
+
+    await setup_integration()
+    entity_id = entity_id_for_unique_id(hass, CLIMATE_DOMAIN, "abc123_zone_1_thermostat")
+    state = hass.states.get(entity_id)
+
+    assert state is not None
+    assert state.state == HVACMode.COOL
+    assert state.attributes["temperature"] == 63
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

A zone thermostat's target temperature can stay stale for a while after the set point changes — whether the change comes from Home Assistant, the Carrier app, or the thermostat itself.

## Root cause

`_update_entity_attrs` reads the target set points from the status zone (`_status_zone.cool_set_point` / `heat_set_point`, i.e. Carrier's `clsp` / `htsp`). The realtime websocket keeps the status *room temperature* current, but in practice the status set points only refresh on the periodic full poll (`DEFAULT_UPDATE_INTERVAL_MINUTES`), so a recent change is missing until then. The config activity — already used for preset mode, fan mode, and as the write target in `async_set_temperature` — tracks the change, so the two diverge and the entity reports the stale status value.

## Fix

Read the set points from the resolved config activity (`self._current_activity()`), falling back to the status zone when the current activity can't be resolved. This is the same activity resolution the entity already uses elsewhere, and it reads data the integration already holds in memory — **no new API calls**.

## Verification

- Reproduced on real hardware: with a manual hold active, the config current activity reported the new cool set point while the status `clsp` was still stale; the entity showed the stale value, and shows the correct one after this change.
- Added `test_climate_setpoint_prefers_config_activity_over_stale_status`.
- Full suite green (159 passed) on Python 3.14, `ruff check` / `ruff format` clean.
