### PR TITLE
Re-assert control fields after writes to survive stale websocket replays (#407, #353)

### DIFF
--- a/custom_components/ha_carrier/carrier_data_update_coordinator.py
+++ b/custom_components/ha_carrier/carrier_data_update_coordinator.py
@@ -21,8 +21,10 @@ from homeassistant.helpers.update_coordinator import (
 from .const import (
     DEFAULT_UPDATE_INTERVAL_MINUTES,
     DOMAIN,
+    FULL_RECONCILE_INTERVAL_MINUTES,
     MAX_REFRESH_ATTEMPTS,
     MAX_WRITE_ATTEMPTS,
+    POST_WRITE_INTERCEPT_WINDOW_MINUTES,
     REFRESH_RETRY_BASE_DELAY_SECONDS,
     REFRESH_RETRY_MAX_DELAY_SECONDS,
     RETRY_JITTER_FRACTION,
@@ -42,6 +44,9 @@ from .util import (
 )
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
+
+FULL_RECONCILE_INTERVAL = timedelta(minutes=FULL_RECONCILE_INTERVAL_MINUTES)
+POST_WRITE_INTERCEPT_WINDOW = timedelta(minutes=POST_WRITE_INTERCEPT_WINDOW_MINUTES)
 
 REFRESH_RETRY_POLICY = RetryPolicy(
     name="carrier-refresh",
@@ -96,6 +101,7 @@ class CarrierDataUpdateCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
         self.timestamp_all_data: datetime | None = None
         self.timestamp_websocket: datetime | None = None
         self.timestamp_energy: datetime | None = None
+        self._intercept_guards: dict[tuple[str, str | None], dict[str, Any]] = {}
 
         super().__init__(
             hass,
@@ -111,6 +117,158 @@ class CarrierDataUpdateCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
                 function=self.async_refresh,
             ),
         )
+
+    def _full_reconcile_due(self) -> bool:
+        """Return True when websocket-maintained data is overdue for a full fetch.
+
+        In steady state the poll cycle only refreshes energy and relies on
+        websocket deltas for status. A delta that is dropped or rebroadcast stale
+        leaves a status field frozen with no self-correction while the socket
+        stays connected. A periodic full refresh reconciles that state against an
+        authoritative pull.
+
+        Returns:
+            bool: True when the last full refresh is older than
+                ``FULL_RECONCILE_INTERVAL`` or has never completed.
+        """
+        if self.timestamp_all_data is None:
+            return True
+        return datetime.now(UTC) - self.timestamp_all_data >= FULL_RECONCILE_INTERVAL
+
+    def begin_post_write_intercept(
+        self, system_serial: str, zone_api_id: str | None = None
+    ) -> None:
+        """Open (or refresh) a post-write guard for the system (and zone) just written.
+
+        Carrier's cloud can replay the pre-write snapshot over the websocket
+        (a fast bounce within seconds, or a slow revert ~2 min later), so for a
+        window after each successful write the coordinator re-asserts any control
+        field (mode / set point) the cloud reverts *on the written target* back to
+        the intended value, while still publishing every other field, zone, and
+        system. See ``updated_callback``.
+
+        Guards are tracked independently, keyed by ``(system_serial, zone_api_id)``
+        with a system-level mode guard keyed by ``(system_serial, None)``. Each
+        guard carries its own expiry, so concurrent writes to different systems or
+        zones — a second thermostat, or this integration's own ``climate.turn_off``
+        auto-shutoff writing a different system — each keep their own protection for
+        their own five minutes, and a later write to one target never extends
+        another target's guard. A repeat write to the same target upserts it.
+
+        The system mode guard is re-stamped to the current mode on every write to
+        the system, so it never holds a stale mode; each zone guard freezes that
+        zone's intended set point and expires on its own clock.
+
+        Called by the writing entity from ``_write_local_state`` *after* it has
+        applied its optimistic local mutation, so the snapshot captures the intended
+        post-write control state rather than the pre-write state.
+
+        Args:
+            system_serial: Serial of the system the entity wrote.
+            zone_api_id: Zone written, or None for a system-level write (mode).
+        """
+        system = self.system(system_serial)
+        if system is None:
+            return
+        expires_at = datetime.now(UTC) + POST_WRITE_INTERCEPT_WINDOW
+        self._intercept_guards[(system_serial, None)] = {
+            "expires_at": expires_at,
+            "mode": system.config.mode,
+        }
+        if zone_api_id is not None:
+            zone_state = self._capture_zone_state(system, zone_api_id)
+            if zone_state is not None:
+                self._intercept_guards[(system_serial, zone_api_id)] = {
+                    "expires_at": expires_at,
+                    **zone_state,
+                }
+
+    def _capture_zone_state(self, system: System, zone_api_id: str) -> dict[str, Any] | None:
+        """Return the intended activity type and resolved set points for one zone.
+
+        Resolves the set point the same way the climate entity reads it back
+        (``config_zone.current_status_activity(status_zone) or status_zone``) so a
+        later re-assert compares like with like. Volatile status (temperature,
+        humidity, conditioning, blower) is deliberately excluded so a normal reading
+        update is never mistaken for a reverted write.
+        """
+        status_zone, config_zone = self._zone_pair(system, zone_api_id)
+        if status_zone is None or config_zone is None:
+            return None
+        source = config_zone.current_status_activity(status_zone) or status_zone
+        return {
+            "activity_type": status_zone.current_status_activity_type,
+            "heat_set_point": source.heat_set_point,
+            "cool_set_point": source.cool_set_point,
+        }
+
+    def _prune_intercept_guards(self) -> None:
+        """Drop post-write guards whose own protection period has elapsed."""
+        now = datetime.now(UTC)
+        expired = [
+            key for key, guard in self._intercept_guards.items() if now >= guard["expires_at"]
+        ]
+        for key in expired:
+            del self._intercept_guards[key]
+
+    def _in_post_write_intercept(self) -> bool:
+        """Return True while any written target still has a live post-write guard."""
+        self._prune_intercept_guards()
+        return bool(self._intercept_guards)
+
+    def _zone_pair(self, system: System, zone_api_id: str) -> tuple[Any, Any] | tuple[None, None]:
+        """Return the (status_zone, config_zone) pair for a zone id, or (None, None)."""
+        status_zone = next(
+            (zone for zone in system.status.zones if zone.api_id == zone_api_id), None
+        )
+        config_zone = next(
+            (zone for zone in system.config.zones if zone.api_id == zone_api_id), None
+        )
+        if status_zone is None or config_zone is None:
+            return None, None
+        return status_zone, config_zone
+
+    def _reassert_control(self) -> None:
+        """Restore reverted control fields on every written target with a live guard.
+
+        Runs after ``message_handler`` has applied a websocket message. Only each
+        guarded target — a written system's mode, or a written zone's set point — is
+        considered; every other system, zone, and non-control field is left exactly
+        as delivered, so a revert on a guarded target never drops — or reverts —
+        another target's update. Does not read the API. When Carrier finally accepts
+        a write its value matches the snapshot and nothing is rewritten; when a
+        guard expires that target is trusted again.
+        """
+        self._prune_intercept_guards()
+        for (system_serial, zone_api_id), guard in self._intercept_guards.items():
+            system = self.system(system_serial)
+            if system is None:
+                continue
+            if zone_api_id is None:
+                if system.config.mode != guard["mode"]:
+                    system.config.mode = guard["mode"]
+            else:
+                self._reassert_zone(system, zone_api_id, guard)
+
+    def _reassert_zone(self, system: System, zone_api_id: str, zone_state: dict[str, Any]) -> None:
+        """Restore one written zone's reverted activity type and set points."""
+        status_zone, config_zone = self._zone_pair(system, zone_api_id)
+        if status_zone is None or config_zone is None:
+            return
+        source = config_zone.current_status_activity(status_zone) or status_zone
+        if (
+            source.heat_set_point == zone_state["heat_set_point"]
+            and source.cool_set_point == zone_state["cool_set_point"]
+            and status_zone.current_status_activity_type == zone_state["activity_type"]
+        ):
+            return
+        status_zone.current_status_activity_type = zone_state["activity_type"]
+        status_zone.heat_set_point = zone_state["heat_set_point"]
+        status_zone.cool_set_point = zone_state["cool_set_point"]
+        reasserted = config_zone.find_activity(zone_state["activity_type"])
+        if reasserted is not None:
+            reasserted.heat_set_point = zone_state["heat_set_point"]
+            reasserted.cool_set_point = zone_state["cool_set_point"]
 
     async def _async_update_data(self) -> list[dict[str, Any]]:
         """Fetch Carrier data and translate escalated failures for Home Assistant.
@@ -133,6 +291,13 @@ class CarrierDataUpdateCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
             UpdateFailed: Raised when transient failures escalate or refresh
                 cannot complete successfully for other reasons.
         """
+        if not self.data_flush and self._full_reconcile_due():
+            _LOGGER.debug(
+                "forcing full refresh: last full reconcile was >= %s minutes ago",
+                FULL_RECONCILE_INTERVAL_MINUTES,
+            )
+            self.data_flush = True
+
         if self.data_flush:
             refresh_context = "full data refresh"
             refresh_operation = self._async_full_refresh
@@ -238,6 +403,9 @@ class CarrierDataUpdateCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
         self.timestamp_energy = self.timestamp_all_data
         self.data_flush = False
         self.update_interval = timedelta(minutes=DEFAULT_UPDATE_INTERVAL_MINUTES)
+        # A full read is authoritative; end every post-write guard so re-assert
+        # cannot fight freshly-read truth.
+        self._intercept_guards = {}
 
     async def _async_energy_refresh(self) -> None:
         """Refresh energy data while accounting for failures once per cycle.
@@ -481,4 +649,10 @@ class CarrierDataUpdateCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
                     "%s",
                     async_redact_data(self.mapped_system_data(system), TO_REDACT_MAPPED),
                 )
+        if self._in_post_write_intercept():
+            # Re-assert any control field (mode / set point) the cloud reverted
+            # back to the intended post-write value. The message is still
+            # published normally below, so every other field and zone in the
+            # same websocket message reaches Home Assistant.
+            self._reassert_control()
         self.async_update_listeners()

--- a/custom_components/ha_carrier/carrier_entity.py
+++ b/custom_components/ha_carrier/carrier_entity.py
@@ -95,6 +95,11 @@ class CarrierEntity(CoordinatorEntity[CarrierDataUpdateCoordinator]):
         coordinator refresh round-trip.
         """
         self._sync_entity_attrs()
+        # The optimistic local mutation has already been applied by the caller;
+        # open the post-write intercept window now, scoped to the system (and
+        # zone) this entity actually wrote, so the coordinator snapshots the
+        # intended post-write control state and never touches other targets.
+        self.coordinator.begin_post_write_intercept(self._system_serial, self.zone_api_id)
         self.async_write_ha_state()
 
     @property

--- a/custom_components/ha_carrier/const.py
+++ b/custom_components/ha_carrier/const.py
@@ -44,6 +44,19 @@ HEAT_SOURCE_ODU_ONLY_LABEL = "heat pump only"
 HEAT_SOURCE_SYSTEM_LABEL = "system in control"
 
 DEFAULT_UPDATE_INTERVAL_MINUTES: int = 30
+# Force a full refresh at least this often even while the websocket stays
+# connected, so websocket-maintained status that silently goes stale (a dropped
+# or rebroadcast partial delta) is reconciled against an authoritative full pull.
+# Kept a multiple of the poll interval so intermediate polls stay lightweight
+# (energy-only) and only every Nth poll pays for a full pull.
+FULL_RECONCILE_INTERVAL_MINUTES: int = DEFAULT_UPDATE_INTERVAL_MINUTES * 4
+# After an HA write, Carrier's cloud can replay the pre-write snapshot over the
+# websocket (a fast bounce within seconds, or a slow revert ~2 min later). For
+# this window after a write the coordinator re-asserts any control field (mode /
+# set point) the cloud reverts back to the intended value, so HA never shows the
+# stale value. The stale replay is forward-timestamped, so it cannot be told
+# apart by content — the window is the only reliable discriminator.
+POST_WRITE_INTERCEPT_WINDOW_MINUTES: int = 5
 UNAUTHORIZED_RETRY_THRESHOLD: int = 3
 MAX_WRITE_ATTEMPTS: int = 2
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -330,6 +330,8 @@ def build_carrier_system(
     name: str = "Home",
     zone_name: str = "Living Room",
     zone_id: str = "1",
+    second_zone_id: str | None = None,
+    second_zone_name: str = "Bedroom",
     has_heat_pump: bool = True,
     fan_enabled: bool | None = None,
     disconnected: bool = False,
@@ -341,6 +343,10 @@ def build_carrier_system(
         name: Human-readable system name. Defaults to ``"Home"``.
         zone_name: Display name for the single zone. Defaults to ``"Living Room"``.
         zone_id: Identifier assigned to the zone. Defaults to ``"1"``.
+        second_zone_id: When set, add a second zone with this id to both config and
+            status, producing a multi-zone system. Defaults to ``None`` (single zone).
+        second_zone_name: Display name for the optional second zone. Defaults to
+            ``"Bedroom"``.
         has_heat_pump: When ``True``, configure the outdoor unit as a variable-capacity
             heat pump; otherwise configure it as an air conditioner. Defaults to ``True``.
         fan_enabled: Optional Carrier ``cfgfan`` value. Defaults to ``None`` to omit the
@@ -383,6 +389,10 @@ def build_carrier_system(
         "vacfan": "off",
         "zones": [_zone_raw(zone_id=zone_id, name=zone_name)],
     }
+    status_zones = [_status_zone_raw(zone_id=zone_id, name=zone_name)]
+    if second_zone_id is not None:
+        config_raw["zones"].append(_zone_raw(zone_id=second_zone_id, name=second_zone_name))
+        status_zones.append(_status_zone_raw(zone_id=second_zone_id, name=second_zone_name))
     if fan_enabled is not None:
         config_raw["cfgfan"] = "on" if fan_enabled else "off"
     config = Config(config_raw)
@@ -399,7 +409,7 @@ def build_carrier_system(
             "idu": {"cfm": 1200, "blwrpm": 500, "statpress": 0.2, "opstat": "idle"},
             "odu": {"opstat": "idle"},
             "utcTime": "2026-05-05T12:00:00+00:00",
-            "zones": [_status_zone_raw(zone_id=zone_id, name=zone_name)],
+            "zones": status_zones,
         }
     )
     energy = Energy(

--- a/tests/test_carrier_data_update_coordinator.py
+++ b/tests/test_carrier_data_update_coordinator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import patch
@@ -15,6 +16,7 @@ from custom_components.ha_carrier.carrier_data_update_coordinator import (
     CarrierDataUpdateCoordinator,
 )
 from custom_components.ha_carrier.const import (
+    FULL_RECONCILE_INTERVAL_MINUTES,
     TRANSIENT_FAILURE_THRESHOLD,
     UNAUTHORIZED_RETRY_THRESHOLD,
 )
@@ -318,6 +320,519 @@ async def test_energy_refresh_records_one_unauthorized_per_cycle(
 
 
 @pytest.mark.asyncio
+async def test_update_data_forces_full_refresh_when_reconcile_interval_elapsed() -> None:
+    """Force a full reconcile when websocket-maintained data is overdue for a full fetch."""
+    coordinator = CarrierDataUpdateCoordinator.__new__(CarrierDataUpdateCoordinator)
+    coordinator.data_flush = False
+    coordinator.systems = [build_carrier_system()]
+    coordinator.timestamp_all_data = datetime.now(UTC) - timedelta(
+        minutes=FULL_RECONCILE_INTERVAL_MINUTES + 1
+    )
+    full_refresh_called = False
+    energy_refresh_called = False
+
+    async def fake_full_refresh(self: CarrierDataUpdateCoordinator) -> None:
+        """Record that the periodic poll performed a full reconcile."""
+        nonlocal full_refresh_called
+        full_refresh_called = True
+        self.data_flush = False
+
+    async def fake_energy_refresh(self: CarrierDataUpdateCoordinator) -> None:
+        """Record that the periodic poll performed only an energy refresh."""
+        nonlocal energy_refresh_called
+        energy_refresh_called = True
+
+    with (
+        patch.object(CarrierDataUpdateCoordinator, "_async_full_refresh", fake_full_refresh),
+        patch.object(CarrierDataUpdateCoordinator, "_async_energy_refresh", fake_energy_refresh),
+        patch.object(
+            CarrierDataUpdateCoordinator,
+            "mapped_system_data",
+            staticmethod(lambda _system: {"serial": "ABC123"}),
+        ),
+    ):
+        await coordinator._async_update_data()
+
+    assert full_refresh_called is True
+    assert energy_refresh_called is False
+
+
+@pytest.mark.asyncio
+async def test_update_data_stays_energy_only_before_reconcile_interval() -> None:
+    """Keep the periodic poll energy-only until the full-reconcile interval elapses."""
+    coordinator = CarrierDataUpdateCoordinator.__new__(CarrierDataUpdateCoordinator)
+    coordinator.data_flush = False
+    coordinator.systems = [build_carrier_system()]
+    coordinator.timestamp_all_data = datetime.now(UTC) - timedelta(
+        minutes=FULL_RECONCILE_INTERVAL_MINUTES - 1
+    )
+    full_refresh_called = False
+    energy_refresh_called = False
+
+    async def fake_full_refresh(self: CarrierDataUpdateCoordinator) -> None:
+        """Record an unexpected full refresh."""
+        nonlocal full_refresh_called
+        full_refresh_called = True
+
+    async def fake_energy_refresh(self: CarrierDataUpdateCoordinator) -> None:
+        """Record the expected energy-only refresh."""
+        nonlocal energy_refresh_called
+        energy_refresh_called = True
+
+    with (
+        patch.object(CarrierDataUpdateCoordinator, "_async_full_refresh", fake_full_refresh),
+        patch.object(CarrierDataUpdateCoordinator, "_async_energy_refresh", fake_energy_refresh),
+        patch.object(
+            CarrierDataUpdateCoordinator,
+            "mapped_system_data",
+            staticmethod(lambda _system: {"serial": "ABC123"}),
+        ),
+    ):
+        await coordinator._async_update_data()
+
+    assert energy_refresh_called is True
+    assert full_refresh_called is False
+
+
+def test_full_reconcile_due_covers_timestamp_states() -> None:
+    """Report reconcile due when never refreshed or overdue, and not when fresh."""
+    coordinator = CarrierDataUpdateCoordinator.__new__(CarrierDataUpdateCoordinator)
+
+    coordinator.timestamp_all_data = None
+    assert coordinator._full_reconcile_due() is True
+
+    coordinator.timestamp_all_data = datetime.now(UTC) - timedelta(
+        minutes=FULL_RECONCILE_INTERVAL_MINUTES + 1
+    )
+    assert coordinator._full_reconcile_due() is True
+
+    coordinator.timestamp_all_data = datetime.now(UTC) - timedelta(
+        minutes=FULL_RECONCILE_INTERVAL_MINUTES - 1
+    )
+    assert coordinator._full_reconcile_due() is False
+
+
+@pytest.mark.asyncio
+async def test_begin_post_write_intercept_captures_written_target_only() -> None:
+    """Opening a guard records the written system's mode and that zone's set points."""
+    coordinator = CarrierDataUpdateCoordinator.__new__(CarrierDataUpdateCoordinator)
+    system = build_carrier_system()
+    coordinator.systems = [system]
+    coordinator._intercept_guards = {}
+    status_zone = system.status.zones[0]
+    resolved = system.config.zones[0].current_status_activity(status_zone) or status_zone
+
+    coordinator.begin_post_write_intercept(system.profile.serial, status_zone.api_id)
+
+    mode_guard = coordinator._intercept_guards[(system.profile.serial, None)]
+    assert mode_guard["expires_at"] > datetime.now(UTC)
+    assert mode_guard["mode"] == system.config.mode
+    zone_guard = coordinator._intercept_guards[(system.profile.serial, status_zone.api_id)]
+    assert zone_guard["expires_at"] > datetime.now(UTC)
+    assert zone_guard["activity_type"] == status_zone.current_status_activity_type
+    assert zone_guard["cool_set_point"] == resolved.cool_set_point
+    assert zone_guard["heat_set_point"] == resolved.heat_set_point
+
+
+@pytest.mark.asyncio
+async def test_reasserts_reverted_mode_and_still_publishes() -> None:
+    """A reverted system mode is restored, and the message is still published."""
+    coordinator = CarrierDataUpdateCoordinator.__new__(CarrierDataUpdateCoordinator)
+    system = build_carrier_system()
+    coordinator.systems = [system]
+    coordinator._intercept_guards = {}
+    original_mode = system.config.mode
+    coordinator.begin_post_write_intercept(system.profile.serial, system.status.zones[0].api_id)
+
+    # Stale replay reverts the mode.
+    system.config.mode = "heat" if original_mode != "heat" else "cool"
+
+    notified = False
+
+    def fake_notify() -> None:
+        nonlocal notified
+        notified = True
+
+    with patch.object(coordinator, "async_update_listeners", fake_notify):
+        await coordinator.updated_callback("stale replay reverts mode")
+
+    assert system.config.mode == original_mode
+    assert notified is True
+
+
+@pytest.mark.asyncio
+async def test_system_level_write_reasserts_mode_without_zone() -> None:
+    """A system-level write (zone_api_id=None) protects mode and records no zone."""
+    coordinator = CarrierDataUpdateCoordinator.__new__(CarrierDataUpdateCoordinator)
+    system = build_carrier_system()
+    coordinator.systems = [system]
+    coordinator._intercept_guards = {}
+    original_mode = system.config.mode
+
+    coordinator.begin_post_write_intercept(system.profile.serial, None)
+
+    assert (system.profile.serial, None) in coordinator._intercept_guards
+    # No zone guard is recorded for a system-level write.
+    assert all(zone is None for _serial, zone in coordinator._intercept_guards)
+
+    # Stale replay reverts the system mode.
+    system.config.mode = "heat" if original_mode != "heat" else "cool"
+
+    notified = False
+
+    def fake_notify() -> None:
+        nonlocal notified
+        notified = True
+
+    with patch.object(coordinator, "async_update_listeners", fake_notify):
+        await coordinator.updated_callback("stale replay reverts mode")
+
+    assert system.config.mode == original_mode
+    assert notified is True
+
+
+@pytest.mark.asyncio
+async def test_reasserts_reverted_setpoint_and_still_publishes() -> None:
+    """A reverted set point is restored to the written value; message still published."""
+    coordinator = CarrierDataUpdateCoordinator.__new__(CarrierDataUpdateCoordinator)
+    system = build_carrier_system()
+    coordinator.systems = [system]
+    coordinator._intercept_guards = {}
+    status_zone = system.status.zones[0]
+    activity = system.config.zones[0].find_activity(status_zone.current_status_activity_type)
+    assert activity is not None
+    commanded_cool = activity.cool_set_point
+    coordinator.begin_post_write_intercept(system.profile.serial, status_zone.api_id)
+
+    # Stale replay reverts the resolved set point.
+    activity.cool_set_point = commanded_cool + 3
+    status_zone.cool_set_point = commanded_cool + 3
+
+    notified = False
+
+    def fake_notify() -> None:
+        nonlocal notified
+        notified = True
+
+    with patch.object(coordinator, "async_update_listeners", fake_notify):
+        await coordinator.updated_callback("stale replay reverts setpoint")
+
+    resolved = system.config.zones[0].current_status_activity(status_zone)
+    assert resolved is not None
+    assert resolved.cool_set_point == commanded_cool
+    assert status_zone.cool_set_point == commanded_cool
+    assert notified is True
+
+
+@pytest.mark.asyncio
+async def test_matching_state_is_not_rewritten() -> None:
+    """When nothing reverted, re-assert leaves state as-is and still publishes."""
+    coordinator = CarrierDataUpdateCoordinator.__new__(CarrierDataUpdateCoordinator)
+    system = build_carrier_system()
+    coordinator.systems = [system]
+    coordinator._intercept_guards = {}
+    coordinator.begin_post_write_intercept(system.profile.serial, system.status.zones[0].api_id)
+    before_mode = system.config.mode
+
+    notified = False
+
+    def fake_notify() -> None:
+        nonlocal notified
+        notified = True
+
+    with patch.object(coordinator, "async_update_listeners", fake_notify):
+        await coordinator.updated_callback("benign reading update")
+
+    assert system.config.mode == before_mode
+    assert notified is True
+
+
+@pytest.mark.asyncio
+async def test_control_revert_does_not_drop_other_system_update() -> None:
+    """A reverted control field on the written system must not drop another system's update.
+
+    One Carrier websocket message carries every system/zone, applied by
+    message_handler before updated_callback runs. Re-asserting only the written
+    system's reverted field (instead of suppressing the whole notification) keeps
+    the other system's already-applied change (e.g. going idle) reaching Home
+    Assistant.
+    """
+    coordinator = CarrierDataUpdateCoordinator.__new__(CarrierDataUpdateCoordinator)
+    system_a = build_carrier_system(serial="A", zone_id="1")
+    system_b = build_carrier_system(serial="B", zone_id="2")
+    coordinator.systems = [system_a, system_b]
+    coordinator._intercept_guards = {}
+    # Only system A was written.
+    coordinator.begin_post_write_intercept(system_a.profile.serial, system_a.status.zones[0].api_id)
+    a_mode = system_a.config.mode
+
+    # One websocket message: system A's mode reverted AND system B goes idle.
+    system_a.config.mode = "heat" if a_mode != "heat" else "cool"
+    system_b.status.zones[0].conditioning = "idle"
+
+    notified = False
+
+    def fake_notify() -> None:
+        nonlocal notified
+        notified = True
+
+    with patch.object(coordinator, "async_update_listeners", fake_notify):
+        await coordinator.updated_callback("reverts A, idles B")
+
+    assert notified is True, "system B's idle update must still reach HA"
+    assert system_a.config.mode == a_mode
+    assert system_b.status.zones[0].conditioning == "idle"
+
+
+@pytest.mark.asyncio
+async def test_legit_change_on_unwritten_system_survives() -> None:
+    """A legitimate control change on an unwritten system during the window is not reverted.
+
+    Windows are scoped to written systems only, so a real mode change on any other
+    system during one — a second thermostat, or this integration's own
+    ``climate.turn_off`` auto-shutoff writing a different system — flows through
+    untouched instead of being reverted to the written system's stale snapshot.
+    """
+    coordinator = CarrierDataUpdateCoordinator.__new__(CarrierDataUpdateCoordinator)
+    system_a = build_carrier_system(serial="A", zone_id="1")
+    system_b = build_carrier_system(serial="B", zone_id="2")
+    coordinator.systems = [system_a, system_b]
+    coordinator._intercept_guards = {}
+    # Only system A was written.
+    coordinator.begin_post_write_intercept(system_a.profile.serial, system_a.status.zones[0].api_id)
+    a_mode = system_a.config.mode
+    b_new_mode = "off" if system_b.config.mode != "off" else "cool"
+
+    # One websocket message: A's mode reverts (stale replay) AND B legitimately changes.
+    system_a.config.mode = "heat" if a_mode != "heat" else "cool"
+    system_b.config.mode = b_new_mode
+
+    notified = False
+
+    def fake_notify() -> None:
+        nonlocal notified
+        notified = True
+
+    with patch.object(coordinator, "async_update_listeners", fake_notify):
+        await coordinator.updated_callback("reverts A, legit change on B")
+
+    assert system_a.config.mode == a_mode, "written system A's reverted mode is restored"
+    assert system_b.config.mode == b_new_mode, "unwritten system B's legit change survives"
+    assert notified is True
+
+
+@pytest.mark.asyncio
+async def test_overlapping_windows_protect_each_written_target() -> None:
+    """A second write to a different target must not drop the first target's protection.
+
+    Windows are tracked per written system, so two writes to different systems
+    within their windows each keep their own protection. This is the singleton-vs-
+    collection regression: a coordinator-wide single window would let the second
+    write overwrite the first, silently abandoning the first target's revert guard.
+    """
+    coordinator = CarrierDataUpdateCoordinator.__new__(CarrierDataUpdateCoordinator)
+    system_a = build_carrier_system(serial="A", zone_id="1")
+    system_b = build_carrier_system(serial="B", zone_id="2")
+    coordinator.systems = [system_a, system_b]
+    coordinator._intercept_guards = {}
+    a_zone = system_a.status.zones[0]
+    b_zone = system_b.status.zones[0]
+    a_activity = system_a.config.zones[0].find_activity(a_zone.current_status_activity_type)
+    b_activity = system_b.config.zones[0].find_activity(b_zone.current_status_activity_type)
+    assert a_activity is not None and b_activity is not None
+    a_cool = a_activity.cool_set_point
+    b_cool = b_activity.cool_set_point
+
+    # Two writes to different systems, both still within their windows.
+    coordinator.begin_post_write_intercept(system_a.profile.serial, a_zone.api_id)
+    coordinator.begin_post_write_intercept(system_b.profile.serial, b_zone.api_id)
+
+    # One websocket message replays BOTH systems' pre-write set points.
+    a_activity.cool_set_point = a_cool + 3
+    a_zone.cool_set_point = a_cool + 3
+    b_activity.cool_set_point = b_cool + 3
+    b_zone.cool_set_point = b_cool + 3
+
+    notified = False
+
+    def fake_notify() -> None:
+        nonlocal notified
+        notified = True
+
+    with patch.object(coordinator, "async_update_listeners", fake_notify):
+        await coordinator.updated_callback("reverts both A and B")
+
+    a_resolved = system_a.config.zones[0].current_status_activity(a_zone)
+    b_resolved = system_b.config.zones[0].current_status_activity(b_zone)
+    assert a_resolved is not None and b_resolved is not None
+    assert a_resolved.cool_set_point == a_cool, "first write's revert must be restored"
+    assert b_resolved.cool_set_point == b_cool, "second write's revert must be restored"
+    assert notified is True
+
+
+@pytest.mark.asyncio
+async def test_updated_callback_notifies_when_not_in_window() -> None:
+    """Outside a post-write window, updates publish normally without re-assert."""
+    coordinator = CarrierDataUpdateCoordinator.__new__(CarrierDataUpdateCoordinator)
+    coordinator.systems = [build_carrier_system()]
+    coordinator._intercept_guards = {}
+
+    notified = False
+
+    def fake_notify() -> None:
+        nonlocal notified
+        notified = True
+
+    with patch.object(coordinator, "async_update_listeners", fake_notify):
+        await coordinator.updated_callback("normal update")
+
+    assert notified is True
+
+
+@pytest.mark.asyncio
+async def test_expired_guard_is_pruned_and_not_reasserted() -> None:
+    """A guard past its expiry is dropped and no longer re-asserts a revert."""
+    coordinator = CarrierDataUpdateCoordinator.__new__(CarrierDataUpdateCoordinator)
+    system = build_carrier_system()
+    coordinator.systems = [system]
+    original_mode = system.config.mode
+    coordinator._intercept_guards = {
+        (system.profile.serial, None): {
+            "expires_at": datetime.now(UTC) - timedelta(seconds=1),
+            "mode": original_mode,
+        }
+    }
+
+    # Stale replay reverts the mode after the guard has already expired.
+    system.config.mode = "heat" if original_mode != "heat" else "cool"
+    reverted_mode = system.config.mode
+
+    notified = False
+
+    def fake_notify() -> None:
+        nonlocal notified
+        notified = True
+
+    with patch.object(coordinator, "async_update_listeners", fake_notify):
+        await coordinator.updated_callback("post-expiry update")
+
+    assert system.config.mode == reverted_mode, "expired guard must not re-assert"
+    assert coordinator._intercept_guards == {}
+    assert notified is True
+
+
+@pytest.mark.asyncio
+async def test_same_system_zone_guard_expiry_is_independent() -> None:
+    """A written zone's guard expires on its own clock, not extended by a sibling write.
+
+    Two zones of the SAME system are written a few minutes apart. The first zone's
+    guard reaching its own expiry must not be kept alive by the second zone's later
+    write — otherwise a legitimate later change to the first zone would be clobbered
+    as if it were a stale replay. This is the per-entry-expiry regression: a shared
+    per-system clock would let the sibling write extend the first zone's guard.
+    """
+    coordinator = CarrierDataUpdateCoordinator.__new__(CarrierDataUpdateCoordinator)
+    system = build_carrier_system(serial="A", zone_id="1", second_zone_id="2")
+    coordinator.systems = [system]
+    coordinator._intercept_guards = {}
+    zone1 = next(zone for zone in system.status.zones if zone.api_id == "1")
+    zone2 = next(zone for zone in system.status.zones if zone.api_id == "2")
+    cfg1 = next(zone for zone in system.config.zones if zone.api_id == "1")
+    cfg2 = next(zone for zone in system.config.zones if zone.api_id == "2")
+    act1 = cfg1.find_activity(zone1.current_status_activity_type)
+    act2 = cfg2.find_activity(zone2.current_status_activity_type)
+    assert act1 is not None and act2 is not None
+    zone2_cool = act2.cool_set_point
+
+    coordinator.begin_post_write_intercept("A", "1")
+    coordinator.begin_post_write_intercept("A", "2")
+    # Zone 1's own five minutes have elapsed while zone 2's guard is still live.
+    coordinator._intercept_guards[("A", "1")]["expires_at"] = datetime.now(UTC) - timedelta(
+        seconds=1
+    )
+
+    # One websocket message: zone 1 gets a legitimate NEW value; zone 2 is stale-reverted.
+    zone1_new_cool = act1.cool_set_point + 5
+    act1.cool_set_point = zone1_new_cool
+    zone1.cool_set_point = zone1_new_cool
+    act2.cool_set_point = zone2_cool + 3
+    zone2.cool_set_point = zone2_cool + 3
+
+    notified = False
+
+    def fake_notify() -> None:
+        nonlocal notified
+        notified = True
+
+    with patch.object(coordinator, "async_update_listeners", fake_notify):
+        await coordinator.updated_callback("zone1 legit change, zone2 revert")
+
+    resolved1 = cfg1.current_status_activity(zone1)
+    resolved2 = cfg2.current_status_activity(zone2)
+    assert resolved1 is not None and resolved2 is not None
+    assert resolved1.cool_set_point == zone1_new_cool, "expired zone-1 guard must not clobber"
+    assert resolved2.cool_set_point == zone2_cool, "live zone-2 guard still restores its revert"
+    assert ("A", "1") not in coordinator._intercept_guards
+    assert notified is True
+
+
+@pytest.mark.asyncio
+async def test_full_refresh_ends_post_write_window(
+    carrier_api: FakeCarrierApiConnection,
+) -> None:
+    """An authoritative full read ends every post-write guard."""
+    coordinator = CarrierDataUpdateCoordinator.__new__(CarrierDataUpdateCoordinator)
+    coordinator.systems = [build_carrier_system()]
+    _set_coordinator_api_connection(coordinator, carrier_api)
+    coordinator.resiliency = ResiliencyState(
+        unauthorized_threshold=UNAUTHORIZED_RETRY_THRESHOLD,
+        transient_threshold=TRANSIENT_FAILURE_THRESHOLD,
+    )
+    coordinator._websocket_initialized = True
+    coordinator._intercept_guards = {
+        ("ABC123", None): {
+            "expires_at": datetime.now(UTC) + timedelta(minutes=1),
+            "mode": "cool",
+        }
+    }
+
+    await coordinator._async_full_refresh()
+
+    assert coordinator._intercept_guards == {}
+
+
+@pytest.mark.asyncio
+async def test_failed_write_does_not_begin_intercept() -> None:
+    """A failed write must not open a post-write intercept window."""
+    coordinator = CarrierDataUpdateCoordinator.__new__(CarrierDataUpdateCoordinator)
+    coordinator.resiliency = ResiliencyState(
+        unauthorized_threshold=UNAUTHORIZED_RETRY_THRESHOLD,
+        transient_threshold=TRANSIENT_FAILURE_THRESHOLD,
+    )
+    coordinator._intercept_guards = {}
+
+    async def request() -> None:
+        """Raise a retryable write communication failure."""
+        raise CarrierApiConnectionError("timeout")
+
+    async def fake_reconcile(
+        self: CarrierDataUpdateCoordinator,
+        operation_name: str,
+        error: BaseException | None = None,
+    ) -> None:
+        """Swallow the reconcile so the error path can finish."""
+        return
+
+    with (
+        patch.object(CarrierDataUpdateCoordinator, "_async_reconcile_failed_write", fake_reconcile),
+        pytest.raises(HomeAssistantError),
+    ):
+        await coordinator.async_perform_api_call("set mode", request)
+
+    assert coordinator._intercept_guards == {}
+
+
+@pytest.mark.asyncio
 async def test_energy_refresh_escalates_after_threshold(
     carrier_api: FakeCarrierApiConnection,
 ) -> None:
@@ -347,6 +862,7 @@ async def test_updated_callback_records_timestamp_and_notifies_listeners() -> No
     """Handle websocket callbacks by timestamping and notifying listeners."""
     coordinator = CarrierDataUpdateCoordinator.__new__(CarrierDataUpdateCoordinator)
     coordinator.systems = [build_carrier_system()]
+    coordinator._intercept_guards = {}
     notified = False
 
     def fake_update_listeners() -> None:


### PR DESCRIPTION
## Problem

After a write, Carrier's cloud can replay the pre-write snapshot over the websocket — a fast bounce within seconds, or a slow revert up to ~2 minutes later — reverting the just-written mode/setpoint in Home Assistant (#407, #353). The replay is forward-timestamped and content-indistinguishable from a real update, so it can't be filtered by timestamp or content.

The coordinator only does an authoritative full read at startup / socket reconnect; steady-state polls are energy-only and zone status is maintained purely from websocket deltas with no reconciliation, so a replayed stale delta sticks until the next full read (which is why a reload clears it).

## Fix

Open a short per-write guard (5 min) scoped to the written system and zone. While a guard is live, each websocket message re-asserts only the reverted control field (mode / setpoint) back to the intended value, then publishes normally so every other field, zone, and system still updates. Guards are keyed per target with independent expiry, so concurrent writes never clobber or extend one another. A full read clears all guards. No extra API reads are issued.

A periodic full reconcile backstops any field left silently stale by a dropped or rebroadcast websocket delta; like any full read, it also clears the guards.

## Notes

- Control fields guarded: system `mode` (re-stamped to current on every write to the system) and each written zone's resolved activity type + heat/cool set point. `hvac_action`/conditioning and other volatile status are deliberately not guarded (they change legitimately).
- The notification to Home Assistant is never swallowed — a revert on one target never drops another target's update in the same websocket message.
- Adds unit tests for the guard lifecycle (capture, re-assert, per-entry expiry/pruning, overlapping writes, unwritten-target pass-through) and the periodic reconcile.
