### PR TITLE
Fix red main: update workflow test to expect actions/setup-python@v7 (#415)

### DIFF
--- a/tests/test_update_carrier_api_workflow.py
+++ b/tests/test_update_carrier_api_workflow.py
@@ -143,7 +143,7 @@ def _load_script(module_name: str, script_path: Path) -> ModuleType:
 @pytest.mark.parametrize(
     "needle",
     [
-        "actions/setup-python@v6",
+        "actions/setup-python@v7",
         "python-version: '3.14'",
         "Automated update of carrier-api dependency pins.",
         "custom_components/ha_carrier/manifest.json",


### PR DESCRIPTION
## Problem

#415 bumped `actions/setup-python` from v6 to v7 in `.github/workflows/update_carrier_api.yml`, but `tests/test_update_carrier_api_workflow.py` still parametrizes the expected needle `"actions/setup-python@v6"`. So `test_workflow_contains_expected_update_logic[actions/setup-python@v6]` now fails, and `main`'s "pytest and coverage" job has been red since #415 merged.

## Fix

Update that one expected needle to `actions/setup-python@v7` to match the workflow. Single-line change; every other parametrized surface check is unchanged.

`pytest tests/test_update_carrier_api_workflow.py` passes; `ruff format`/`ruff check` clean.
