### PR TITLE
Bound websocket staleness with scheduled reconciles (background tick + post-write burst)

### DIFF
--- a/custom_components/ha_carrier/__init__.py
+++ b/custom_components/ha_carrier/__init__.py
@@ -169,6 +169,12 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntryCarrie
             f"{DOMAIN}_ws_{config_entry.entry_id}",
         )
         coordinator.websocket_task = websocket_task
+        coordinator.start_reconcile_schedule()
+        # Like cancel_websocket_task below, registering on unload covers the
+        # failed-setup path too (HA fires on_unload callbacks when setup fails
+        # later in this function); stop_reconcile_schedule is idempotent, so
+        # the second call from async_unload_entry on a normal unload is safe.
+        config_entry.async_on_unload(coordinator.stop_reconcile_schedule)
 
         def cancel_websocket_task() -> None:
             """Request websocket listener shutdown during entry unload.
@@ -267,6 +273,7 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntryCarri
         bool: True when all platforms were unloaded cleanly.
     """
     _LOGGER.debug("unload entry")
+    config_entry.runtime_data.stop_reconcile_schedule()
     websocket_task = config_entry.runtime_data.websocket_task
 
     if websocket_task is not None:

--- a/custom_components/ha_carrier/carrier_data_update_coordinator.py
+++ b/custom_components/ha_carrier/carrier_data_update_coordinator.py
@@ -7,11 +7,13 @@ import functools
 import logging
 from typing import Any, NoReturn
 
+from aiohttp import ClientError
 from carrier_api import ApiConnectionGraphql, CarrierApiError, Energy, EntryLevelSystem, System
 from carrier_api.api_websocket_data_updater import WebsocketDataUpdater
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
 from homeassistant.helpers.debounce import Debouncer
+from homeassistant.helpers.event import async_call_later, async_track_time_interval
 from homeassistant.helpers.update_coordinator import (
     REQUEST_REFRESH_DEFAULT_COOLDOWN,
     DataUpdateCoordinator,
@@ -25,6 +27,8 @@ from .const import (
     MAX_REFRESH_ATTEMPTS,
     MAX_WRITE_ATTEMPTS,
     POST_WRITE_INTERCEPT_WINDOW_MINUTES,
+    RECONCILE_BACKGROUND_INTERVAL_SECONDS,
+    RECONCILE_BURST_DELAYS_SECONDS,
     REFRESH_RETRY_BASE_DELAY_SECONDS,
     REFRESH_RETRY_MAX_DELAY_SECONDS,
     RETRY_JITTER_FRACTION,
@@ -39,6 +43,7 @@ from .resiliency import ResiliencyState, RetryPolicy, async_call_with_retry
 from .util import (
     RECOVERABLE_REFRESH_EXCEPTIONS,
     RECOVERABLE_WRITE_COMMUNICATION_EXCEPTIONS,
+    TRANSIENT_TRANSPORT_EXCEPTIONS,
     async_redact_data,
     is_unauthorized_error,
 )
@@ -69,6 +74,16 @@ WRITE_RETRY_POLICY = RetryPolicy(
 ENERGY_REFRESH_EXCEPTIONS: tuple[type[BaseException], ...] = (
     *RECOVERABLE_REFRESH_EXCEPTIONS,
     CarrierUnauthorizedError,
+)
+
+# Failures a reconcile send may hit: raw websocket transport errors from
+# aiohttp plus the carrier_api transient wrappers. A reconcile is a best-effort
+# nudge, so these are logged and swallowed — the next scheduled send retries.
+RECONCILE_SEND_EXCEPTIONS: tuple[type[BaseException], ...] = (
+    ClientError,
+    TimeoutError,
+    OSError,
+    *TRANSIENT_TRANSPORT_EXCEPTIONS,
 )
 
 
@@ -102,6 +117,9 @@ class CarrierDataUpdateCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
         self.timestamp_websocket: datetime | None = None
         self.timestamp_energy: datetime | None = None
         self._intercept_guards: dict[tuple[str, str | None], dict[str, Any]] = {}
+        self._reconcile_tick_unsub: Callable[[], None] | None = None
+        self._reconcile_burst_unsub: Callable[[], None] | None = None
+        self._reconcile_burst_index: int = 0
 
         super().__init__(
             hass,
@@ -117,6 +135,96 @@ class CarrierDataUpdateCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
                 function=self.async_refresh,
             ),
         )
+
+    def start_reconcile_schedule(self) -> None:
+        """Start the periodic websocket reconcile tick. Idempotent.
+
+        Carrier's realtime push stream is at-most-once: a dropped delta, or a
+        stale post-write snapshot delivered after the genuine transition it
+        predates, leaves a status field frozen with nothing to correct it while
+        the compressor runs steadily (the cloud only pushes edges). The stream
+        carries no sequence numbers and stale snapshots are re-stamped with
+        fresh timestamps, so a wrong value cannot be detected — only outlived.
+        The tick sends ``{"action": "reconcile"}`` on the open socket every
+        ``RECONCILE_BACKGROUND_INTERVAL_SECONDS`` so the cloud re-pushes current
+        state, bounding how long any silently stale field can survive.
+        """
+        if self._reconcile_tick_unsub is None:
+            self._reconcile_tick_unsub = async_track_time_interval(
+                self.hass,
+                self._async_reconcile_tick,
+                timedelta(seconds=RECONCILE_BACKGROUND_INTERVAL_SECONDS),
+            )
+
+    def stop_reconcile_schedule(self) -> None:
+        """Stop the periodic tick and cancel any pending burst step."""
+        if self._reconcile_tick_unsub is not None:
+            self._reconcile_tick_unsub()
+            self._reconcile_tick_unsub = None
+        self._cancel_reconcile_burst()
+
+    def _cancel_reconcile_burst(self) -> None:
+        """Cancel the pending burst step, if one is scheduled."""
+        if self._reconcile_burst_unsub is not None:
+            self._reconcile_burst_unsub()
+            self._reconcile_burst_unsub = None
+
+    def schedule_reconcile_burst(self) -> None:
+        """(Re)start the post-write reconcile burst.
+
+        Right after a write the cloud's read model lags the physical unit, so
+        its pushes — including the post-write snapshot the API layer already
+        requests — can restate pre-write status that overwrites a genuine
+        transition (for example a zone stuck ``idle`` while the compressor
+        runs). The burst re-asks on ``RECONCILE_BURST_DELAYS_SECONDS`` backoff:
+        early steps converge the UI quickly when the cloud is fast, the later
+        steps land after the cloud's measured worst-case lag and after
+        ``POST_WRITE_INTERCEPT_WINDOW_MINUTES`` expires, re-pulling truth once
+        the post-write guard stops re-asserting. A newer write restarts the
+        burst; its race window supersedes the old one.
+        """
+        self._cancel_reconcile_burst()
+        self._reconcile_burst_index = 0
+        self._schedule_next_burst_step()
+
+    def _schedule_next_burst_step(self) -> None:
+        """Schedule the burst step at the current backoff delay."""
+        delay = RECONCILE_BURST_DELAYS_SECONDS[self._reconcile_burst_index]
+        self._reconcile_burst_unsub = async_call_later(self.hass, delay, self._async_burst_step)
+
+    async def _async_burst_step(self, _now: datetime) -> None:
+        """Send one burst reconcile and schedule the next step, if any.
+
+        Only ``RECONCILE_SEND_EXCEPTIONS`` are swallowed by the send. Anything
+        else is a genuine bug and deliberately propagates, abandoning the rest
+        of this burst; the periodic tick still recovers state on its cadence.
+        """
+        self._reconcile_burst_unsub = None
+        await self._async_send_reconcile()
+        self._reconcile_burst_index += 1
+        if self._reconcile_burst_index < len(RECONCILE_BURST_DELAYS_SECONDS):
+            self._schedule_next_burst_step()
+
+    async def _async_reconcile_tick(self, _now: datetime) -> None:
+        """Send the periodic background reconcile."""
+        await self._async_send_reconcile()
+
+    async def _async_send_reconcile(self) -> None:
+        """Ask Carrier to re-push current state over the websocket.
+
+        Best-effort: skipped quietly when the websocket client does not exist
+        yet, and transport failures are logged at debug and swallowed — the
+        next scheduled send is the retry. A dead socket is already handled by
+        the websocket task's own full-refresh recovery path.
+        """
+        api_websocket = self.api_connection.api_websocket
+        if api_websocket is None:
+            _LOGGER.debug("reconcile skipped: websocket client not initialized")
+            return
+        try:
+            await api_websocket.send_reconcile()
+        except RECONCILE_SEND_EXCEPTIONS as error:
+            _LOGGER.debug("reconcile send failed; next scheduled send retries: %s", error)
 
     def _full_reconcile_due(self) -> bool:
         """Return True when websocket-maintained data is overdue for a full fetch.
@@ -544,7 +652,7 @@ class CarrierDataUpdateCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
                 exhausted for retryable failures or for non-retryable failures.
         """
         try:
-            return await async_call_with_retry(
+            result = await async_call_with_retry(
                 request,
                 policy=WRITE_RETRY_POLICY,
                 state=self.resiliency,
@@ -570,6 +678,10 @@ class CarrierDataUpdateCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
             raise HomeAssistantError(
                 "Carrier rejected the request. Check the requested setting and try again."
             ) from error
+        # Successful write: the cloud's read model now lags the unit, so start
+        # the reconcile burst to converge websocket-maintained status quickly.
+        self.schedule_reconcile_burst()
+        return result
 
     def system(self, system_serial: str) -> System | None:
         """Return the tracked system matching a Carrier serial.

--- a/custom_components/ha_carrier/const.py
+++ b/custom_components/ha_carrier/const.py
@@ -57,6 +57,22 @@ FULL_RECONCILE_INTERVAL_MINUTES: int = DEFAULT_UPDATE_INTERVAL_MINUTES * 4
 # stale value. The stale replay is forward-timestamped, so it cannot be told
 # apart by content — the window is the only reliable discriminator.
 POST_WRITE_INTERCEPT_WINDOW_MINUTES: int = 5
+# Carrier's realtime service accepts an {"action": "reconcile"} frame that makes
+# the cloud re-push its current state over the websocket. The push stream is
+# at-most-once with no sequence numbers, and stale snapshots are re-stamped with
+# fresh timestamps, so a lost or clobbered delta cannot be detected — it can only
+# be outlived. Scheduled reconciles bound how long any stale field survives:
+# - A background tick re-asks on a fixed interval so a lost push for a
+#   thermostat-initiated transition (zone staging, cycle edges) self-heals.
+# - After every write, a burst of reconciles on exponential backoff converges
+#   the display quickly while the cloud's own read model is still catching up
+#   (measured lag up to ~2 minutes). The last step (cumulative ~8.5 minutes)
+#   intentionally lands past POST_WRITE_INTERCEPT_WINDOW_MINUTES so truth is
+#   re-pulled after the post-write guard stops re-asserting.
+# Each reconcile is one small frame on the open socket (the client already sends
+# a keepalive every 55 seconds); no REST/GraphQL calls are involved.
+RECONCILE_BACKGROUND_INTERVAL_SECONDS: int = 300
+RECONCILE_BURST_DELAYS_SECONDS: tuple[int, ...] = (2, 4, 8, 16, 32, 64, 128, 256)
 UNAUTHORIZED_RETRY_THRESHOLD: int = 3
 MAX_WRITE_ATTEMPTS: int = 2
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,6 +33,14 @@ class FakeCarrierWebsocket:
         self.callbacks: list[Callable[[str], Any]] = []
         self.listener_errors: list[BaseException] = []
         self.listener_calls = 0
+        self.reconcile_calls = 0
+        self.reconcile_errors: list[BaseException] = []
+
+    async def send_reconcile(self) -> None:
+        """Record a reconcile request, raising a queued error when present."""
+        if self.reconcile_errors:
+            raise self.reconcile_errors.pop(0)
+        self.reconcile_calls += 1
 
     def callback_add(self, callback: Callable[[str], Any]) -> None:
         """Store a websocket callback registered by the coordinator.

--- a/tests/test_reconcile_schedule.py
+++ b/tests/test_reconcile_schedule.py
@@ -1,0 +1,219 @@
+"""Tests for scheduled websocket reconciles (background tick + post-write burst)."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from datetime import timedelta
+from unittest.mock import patch
+
+from carrier_api import CarrierApiWebsocketError
+from freezegun.api import FrozenDateTimeFactory
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry, async_fire_time_changed
+
+from custom_components.ha_carrier.const import (
+    DOMAIN,
+    RECONCILE_BACKGROUND_INTERVAL_SECONDS,
+    RECONCILE_BURST_DELAYS_SECONDS,
+)
+
+from .conftest import PASSWORD, USERNAME, FakeCarrierApiConnection
+
+
+async def _advance(hass: HomeAssistant, freezer: FrozenDateTimeFactory, seconds: float) -> None:
+    """Advance frozen time and run any Home Assistant timers that came due."""
+    freezer.tick(timedelta(seconds=seconds))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+
+async def _noop_write() -> None:
+    """Stand in for a Carrier write request."""
+
+
+@pytest.mark.asyncio
+async def test_background_tick_sends_reconcile_periodically(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    carrier_api: FakeCarrierApiConnection,
+    setup_integration: Callable[..., Awaitable[ConfigEntry]],
+) -> None:
+    """Send one reconcile frame per background interval while set up."""
+    await setup_integration()
+    websocket = carrier_api.api_websocket
+    websocket.reconcile_calls = 0
+
+    await _advance(hass, freezer, RECONCILE_BACKGROUND_INTERVAL_SECONDS)
+    assert websocket.reconcile_calls == 1
+
+    await _advance(hass, freezer, RECONCILE_BACKGROUND_INTERVAL_SECONDS)
+    assert websocket.reconcile_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_write_triggers_exponential_burst(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    carrier_api: FakeCarrierApiConnection,
+    setup_integration: Callable[..., Awaitable[ConfigEntry]],
+) -> None:
+    """Follow a write with reconciles at each exponential backoff delay."""
+    config_entry = await setup_integration()
+    coordinator = config_entry.runtime_data
+    websocket = carrier_api.api_websocket
+    websocket.reconcile_calls = 0
+
+    await coordinator.async_perform_api_call("test write", _noop_write)
+    await hass.async_block_till_done()
+    assert websocket.reconcile_calls == 0
+
+    # Steps through 128 s sit at cumulative 254 s, before the first 300 s
+    # background tick, so each advance observes exactly one burst send.
+    expected = 0
+    for delay in RECONCILE_BURST_DELAYS_SECONDS[:-1]:
+        await _advance(hass, freezer, delay)
+        expected += 1
+        assert websocket.reconcile_calls == expected
+
+    # The final 256 s step lands at cumulative 510 s, crossing the 300 s
+    # background tick: one burst send plus one tick send.
+    await _advance(hass, freezer, RECONCILE_BURST_DELAYS_SECONDS[-1])
+    expected += 2
+    assert websocket.reconcile_calls == expected
+
+    # Burst exhausted. The background tick that fired late (at 510 s)
+    # rescheduled itself for 810 s, so advancing to 600 s sends nothing.
+    await _advance(hass, freezer, 90)
+    assert websocket.reconcile_calls == expected
+
+    # Crossing 810 s: background tick only — no ninth burst step exists.
+    await _advance(hass, freezer, 300)
+    expected += 1
+    assert websocket.reconcile_calls == expected
+
+
+@pytest.mark.asyncio
+async def test_new_write_restarts_burst(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    carrier_api: FakeCarrierApiConnection,
+    setup_integration: Callable[..., Awaitable[ConfigEntry]],
+) -> None:
+    """Reset the burst schedule, cancelling pending steps, on a new write."""
+    config_entry = await setup_integration()
+    coordinator = config_entry.runtime_data
+    websocket = carrier_api.api_websocket
+    websocket.reconcile_calls = 0
+
+    await coordinator.async_perform_api_call("first write", _noop_write)
+    await _advance(hass, freezer, 2)
+    await _advance(hass, freezer, 4)
+    assert websocket.reconcile_calls == 2
+
+    # Second write at t=6: the old chain's next step would fire at t=14.
+    await coordinator.async_perform_api_call("second write", _noop_write)
+    await _advance(hass, freezer, 2)
+    assert websocket.reconcile_calls == 3
+    await _advance(hass, freezer, 4)
+    assert websocket.reconcile_calls == 4
+
+    # t=14: the cancelled first chain must not fire an extra send.
+    await _advance(hass, freezer, 2)
+    assert websocket.reconcile_calls == 4
+
+    # t=20: the restarted chain's 8 s step fires.
+    await _advance(hass, freezer, 6)
+    assert websocket.reconcile_calls == 5
+
+
+@pytest.mark.asyncio
+async def test_reconcile_skipped_without_websocket(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    carrier_api: FakeCarrierApiConnection,
+    setup_integration: Callable[..., Awaitable[ConfigEntry]],
+) -> None:
+    """Skip sending quietly when no websocket client exists."""
+    await setup_integration()
+    websocket = carrier_api.api_websocket
+    websocket.reconcile_calls = 0
+    carrier_api.api_websocket = None
+
+    await _advance(hass, freezer, RECONCILE_BACKGROUND_INTERVAL_SECONDS)
+    assert websocket.reconcile_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_reconcile_send_errors_are_swallowed(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    carrier_api: FakeCarrierApiConnection,
+    setup_integration: Callable[..., Awaitable[ConfigEntry]],
+) -> None:
+    """Keep the schedule alive when a reconcile send fails in transport."""
+    await setup_integration()
+    websocket = carrier_api.api_websocket
+    websocket.reconcile_calls = 0
+    websocket.reconcile_errors.append(CarrierApiWebsocketError("send failed"))
+
+    await _advance(hass, freezer, RECONCILE_BACKGROUND_INTERVAL_SECONDS)
+    assert websocket.reconcile_calls == 0
+
+    await _advance(hass, freezer, RECONCILE_BACKGROUND_INTERVAL_SECONDS)
+    assert websocket.reconcile_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_setup_failure_after_start_stops_reconcile_tick(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    carrier_api: FakeCarrierApiConnection,
+    patch_carrier_api: FakeCarrierApiConnection,
+) -> None:
+    """Leave no running tick behind when setup fails after the tick started."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title=USERNAME,
+        unique_id=USERNAME,
+        data={CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD},
+        version=2,
+    )
+    config_entry.add_to_hass(hass)
+
+    with patch.object(
+        hass.config_entries,
+        "async_forward_entry_setups",
+        side_effect=RuntimeError("platform setup failed"),
+    ):
+        assert not await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    websocket = carrier_api.api_websocket
+    websocket.reconcile_calls = 0
+    await _advance(hass, freezer, RECONCILE_BACKGROUND_INTERVAL_SECONDS)
+    assert websocket.reconcile_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_unload_cancels_reconcile_timers(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    carrier_api: FakeCarrierApiConnection,
+    setup_integration: Callable[..., Awaitable[ConfigEntry]],
+) -> None:
+    """Stop both the background tick and any pending burst on unload."""
+    config_entry = await setup_integration()
+    coordinator = config_entry.runtime_data
+    websocket = carrier_api.api_websocket
+
+    await coordinator.async_perform_api_call("test write", _noop_write)
+
+    assert await hass.config_entries.async_unload(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    websocket.reconcile_calls = 0
+    await _advance(hass, freezer, RECONCILE_BACKGROUND_INTERVAL_SECONDS * 2)
+    assert websocket.reconcile_calls == 0


### PR DESCRIPTION
## Problem

The realtime push stream is at-most-once: messages carry no sequence numbers, and stale snapshots arrive re-stamped with fresh timestamps (the same behavior #412 works around for control fields). So when a delta is lost — or a post-write snapshot built from the cloud's lagging read model lands *after* the genuine transition it predates and overwrites it — a status field freezes, and nothing corrects it while the unit runs steadily, because the cloud only pushes edges.

Live example (2026-07-22): turning two zones on ~15 s apart started the compressor instantly, but the zone's `conditioning` stayed `idle` in HA for 16+ minutes — the wall unit and a later full read both showed `active_cool` the whole time; only a manual integration reload fixed the display. #353 and #407 look like the same unorderable-stream problem surfacing in other fields.

Since the stream can't be ordered from the receiving end, a wrong value can't be *detected* — only *outlived*. #412 protects control fields (mode/setpoints) after writes; this PR bounds staleness for everything else without guessing at any field's value.

## Change

Use the cloud's own resync primitive — the same `{"action": "reconcile"}` frame `carrier_api` already sends after each write — on a schedule:

- **Background tick** every `RECONCILE_BACKGROUND_INTERVAL_SECONDS` (300 s): covers lost pushes for thermostat-initiated transitions (zone staging, cycle edges). Worst-case staleness drops from "until the next edge or 2 h full refresh" to ~5 min.
- **Post-write burst** on exponential backoff (2, 4, 8, …, 256 s): converges the display quickly right after writes, where the stale-snapshot race lives. The last step (cumulative ~8.5 min) intentionally lands after `POST_WRITE_INTERCEPT_WINDOW_MINUTES` expires, re-pulling truth once the #412 guard stops re-asserting. A newer write restarts the burst.

Each send is one small frame on the already-open socket (the client keepalives every 55 s), so there are no extra REST/GraphQL calls. Sends are best-effort: skipped when no websocket client exists, transport failures logged at debug and swallowed (the next scheduled send retries). Both timers are cleaned up on unload, including the failed-setup path via `config_entry.async_on_unload`. Reconcile-triggered pushes flow through the existing callback path, so the #412 intercept guard applies to them unchanged.

## Tests

7 new tests in `tests/test_reconcile_schedule.py` (tick cadence, burst timing including late-fire interval rescheduling, burst restart cancelling the old chain, missing-websocket guard, transport-error swallow, unload cleanup, and no leaked timer when setup fails partway). Full suite: 182 passed. `ruff format --check` / `ruff check` clean at 0.15.21.
