### PR TITLE
feat: add ha_carrier.set_activity_setpoint (edits setpoint without creating a hold)

### DIFF
--- a/custom_components/ha_carrier/climate.py
+++ b/custom_components/ha_carrier/climate.py
@@ -88,10 +88,10 @@ async def async_setup_entry(
     async_add_entities(entities)
     async_add_entities(build_entry_level_entities(coordinator))
 
-    # Expose a no-hold "edit the current activity's comfort set point" service.
+    # PATCH (hava): expose a no-hold "edit the current activity's comfort set point" service.
     # Stock set_temperature always forces a MANUAL hold; this edits whatever activity the zone
     # is currently following, so an independent human hold still wins and an HA outage leaves
-    # the thermostat on its own schedule at the last value.
+    # the thermostat on its own schedule at the last value. See ha/vendor-patches/ha_carrier.
     platform = entity_platform.async_get_current_platform()
     platform.async_register_entity_service(
         "set_activity_setpoint",
@@ -219,6 +219,10 @@ class CarrierClimate(CarrierZoneEntity, ClimateEntity):
             self._attr_target_temperature_step = PRECISION_HALVES
         else:
             self._attr_target_temperature_step = PRECISION_WHOLE
+        # union range for both units (45°F=7°C, 95°F=35°C) — covers
+        # 7–35°C and 45–95°F so the service selector and entity clamp match
+        self._attr_min_temp = 7
+        self._attr_max_temp = 95
         # Read the target set points from the resolved config activity rather
         # than the status zone. The status zone's clsp/htsp is only refreshed by
         # the periodic full poll — the realtime websocket keeps room temperature
@@ -537,13 +541,13 @@ class Thermostat(CarrierClimate):
         self._write_local_state()
 
     async def async_set_activity_setpoint(self, **kwargs: Any) -> None:
-        """Edit the CURRENT activity's comfort set point(s) in place — NO hold.
+        """PATCH (hava): edit the CURRENT activity's comfort set point(s) in place — NO hold.
 
         Unlike async_set_temperature (which forces a MANUAL hold and suspends the schedule), this
         edits the set point of whatever activity the zone is currently following, via the
         carrier_api zone-activity mutation. So a human can still place an independent hold that
         takes precedence, and if HA is offline the thermostat keeps running its own schedule at
-        the last value written.
+        the last value written. Used by the upstairs zone-averaging automations.
 
         Raises:
             HomeAssistantError: when the current activity or a required set point can't be resolved.

--- a/custom_components/ha_carrier/climate.py
+++ b/custom_components/ha_carrier/climate.py
@@ -575,15 +575,6 @@ class Thermostat(CarrierClimate):
                 "'target_temp_low' and 'target_temp_high' in heat_cool mode"
             )
 
-        variables = {
-            "input": {
-                "serial": self.carrier_system.profile.serial,
-                "zoneId": self._required_zone_api_id,
-                "activityType": current.type.value,  # the CURRENT activity, not "manual"
-                "clsp": str(cool_set_point),
-                "htsp": str(heat_set_point),
-            }
-        }
         _LOGGER.debug(
             "set_activity_setpoint; activity=%s heat=%s cool=%s",
             current.type.value,
@@ -593,8 +584,12 @@ class Thermostat(CarrierClimate):
         await self.coordinator.async_perform_api_call(
             "set activity setpoint",
             partial(
-                self.coordinator.api_connection._update_infinity_zone_activity,
-                variables=variables,
+                self.coordinator.api_connection.set_config_activity,
+                system_serial=self.carrier_system.profile.serial,
+                zone_id=self._required_zone_api_id,
+                activity_type=current.type,
+                heat_set_point=str(heat_set_point),
+                cool_set_point=str(cool_set_point),
             ),
         )
         # reflect promptly; deliberately do NOT touch any hold_* / current_status_activity_type

--- a/custom_components/ha_carrier/climate.py
+++ b/custom_components/ha_carrier/climate.py
@@ -6,6 +6,7 @@ from functools import partial
 import logging
 from typing import Any
 
+import voluptuous as vol
 from carrier_api import ActivityTypes, ConfigZoneActivity, FanModes, SystemModes, TemperatureUnits
 from homeassistant.components.climate import (
     ClimateEntity,
@@ -22,6 +23,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import ConfigEntryCarrier
@@ -85,6 +87,21 @@ async def async_setup_entry(
         )
     async_add_entities(entities)
     async_add_entities(build_entry_level_entities(coordinator))
+
+    # Expose a no-hold "edit the current activity's comfort set point" service.
+    # Stock set_temperature always forces a MANUAL hold; this edits whatever activity the zone
+    # is currently following, so an independent human hold still wins and an HA outage leaves
+    # the thermostat on its own schedule at the last value.
+    platform = entity_platform.async_get_current_platform()
+    platform.async_register_entity_service(
+        "set_activity_setpoint",
+        {
+            vol.Optional(ATTR_TEMPERATURE): vol.Coerce(float),
+            vol.Optional(ATTR_TARGET_TEMP_LOW): vol.Coerce(float),
+            vol.Optional(ATTR_TARGET_TEMP_HIGH): vol.Coerce(float),
+        },
+        "async_set_activity_setpoint",
+    )
 
 
 class CarrierClimate(CarrierZoneEntity, ClimateEntity):
@@ -517,4 +534,68 @@ class Thermostat(CarrierClimate):
         manual_activity.heat_set_point = heat_set_point
         self._status_zone.cool_set_point = cool_set_point
         self._status_zone.heat_set_point = heat_set_point
+        self._write_local_state()
+
+    async def async_set_activity_setpoint(self, **kwargs: Any) -> None:
+        """Edit the CURRENT activity's comfort set point(s) in place — NO hold.
+
+        Unlike async_set_temperature (which forces a MANUAL hold and suspends the schedule), this
+        edits the set point of whatever activity the zone is currently following, via the
+        carrier_api zone-activity mutation. So a human can still place an independent hold that
+        takes precedence, and if HA is offline the thermostat keeps running its own schedule at
+        the last value written.
+
+        Raises:
+            HomeAssistantError: when the current activity or a required set point can't be resolved.
+        """
+        current = self._current_activity()
+        if current is None:
+            raise HomeAssistantError("Current activity unavailable, try again later")
+
+        heat_set_point = kwargs.get(ATTR_TARGET_TEMP_LOW)
+        cool_set_point = kwargs.get(ATTR_TARGET_TEMP_HIGH)
+        temperature = kwargs.get(ATTR_TEMPERATURE)
+
+        mode = self.carrier_system.config.mode
+        if mode == SystemModes.COOL.value:
+            heat_set_point = current.heat_set_point
+            cool_set_point = temperature if temperature is not None else cool_set_point
+        elif mode == SystemModes.HEAT.value:
+            heat_set_point = temperature if temperature is not None else heat_set_point
+            cool_set_point = current.cool_set_point
+        # HEAT_COOL / AUTO: use the provided target_temp_low / target_temp_high as-is.
+
+        if heat_set_point is None or cool_set_point is None:
+            raise HomeAssistantError(
+                "set_activity_setpoint needs 'temperature' in heat/cool mode, or both "
+                "'target_temp_low' and 'target_temp_high' in heat_cool mode"
+            )
+
+        variables = {
+            "input": {
+                "serial": self.carrier_system.profile.serial,
+                "zoneId": self._required_zone_api_id,
+                "activityType": current.type.value,  # the CURRENT activity, not "manual"
+                "clsp": str(cool_set_point),
+                "htsp": str(heat_set_point),
+            }
+        }
+        _LOGGER.debug(
+            "set_activity_setpoint; activity=%s heat=%s cool=%s",
+            current.type.value,
+            heat_set_point,
+            cool_set_point,
+        )
+        await self.coordinator.async_perform_api_call(
+            "set activity setpoint",
+            partial(
+                self.coordinator.api_connection._update_infinity_zone_activity,
+                variables=variables,
+            ),
+        )
+        # reflect promptly; deliberately do NOT touch any hold_* / current_status_activity_type
+        current.heat_set_point = heat_set_point
+        current.cool_set_point = cool_set_point
+        self._status_zone.heat_set_point = heat_set_point
+        self._status_zone.cool_set_point = cool_set_point
         self._write_local_state()

--- a/custom_components/ha_carrier/climate.py
+++ b/custom_components/ha_carrier/climate.py
@@ -6,7 +6,6 @@ from functools import partial
 import logging
 from typing import Any
 
-import voluptuous as vol
 from carrier_api import ActivityTypes, ConfigZoneActivity, FanModes, SystemModes, TemperatureUnits
 from homeassistant.components.climate import (
     ClimateEntity,
@@ -25,6 +24,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+import voluptuous as vol
 
 from . import ConfigEntryCarrier
 from .carrier_data_update_coordinator import CarrierDataUpdateCoordinator
@@ -88,10 +89,10 @@ async def async_setup_entry(
     async_add_entities(entities)
     async_add_entities(build_entry_level_entities(coordinator))
 
-    # PATCH (hava): expose a no-hold "edit the current activity's comfort set point" service.
+    # PATCH: expose a no-hold "edit the current activity's comfort set point" service.
     # Stock set_temperature always forces a MANUAL hold; this edits whatever activity the zone
     # is currently following, so an independent human hold still wins and an HA outage leaves
-    # the thermostat on its own schedule at the last value. See ha/vendor-patches/ha_carrier.
+    # the thermostat on its own schedule at the last value.
     platform = entity_platform.async_get_current_platform()
     platform.async_register_entity_service(
         "set_activity_setpoint",
@@ -541,13 +542,13 @@ class Thermostat(CarrierClimate):
         self._write_local_state()
 
     async def async_set_activity_setpoint(self, **kwargs: Any) -> None:
-        """PATCH (hava): edit the CURRENT activity's comfort set point(s) in place — NO hold.
+        """PATCH: edit the CURRENT activity's comfort set point(s) in place — NO hold.
 
         Unlike async_set_temperature (which forces a MANUAL hold and suspends the schedule), this
         edits the set point of whatever activity the zone is currently following, via the
         carrier_api zone-activity mutation. So a human can still place an independent hold that
         takes precedence, and if HA is offline the thermostat keeps running its own schedule at
-        the last value written. Used by the upstairs zone-averaging automations.
+        the last value written.
 
         Raises:
             HomeAssistantError: when the current activity or a required set point can't be resolved.

--- a/custom_components/ha_carrier/climate.py
+++ b/custom_components/ha_carrier/climate.py
@@ -24,7 +24,6 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-
 import voluptuous as vol
 
 from . import ConfigEntryCarrier

--- a/custom_components/ha_carrier/manifest.json
+++ b/custom_components/ha_carrier/manifest.json
@@ -14,7 +14,7 @@
     "carrier_api"
   ],
   "requirements": [
-    "carrier-api==3.5.0"
+    "carrier-api==3.6.0"
   ],
   "version": "2.27.0"
 }

--- a/custom_components/ha_carrier/services.yaml
+++ b/custom_components/ha_carrier/services.yaml
@@ -1,0 +1,40 @@
+set_activity_setpoint:
+  name: Set activity setpoint (no hold)
+  description: >-
+    Edit the CURRENT activity's comfort set point in place WITHOUT creating a manual hold.
+    Unlike the built-in temperature set (which forces a hold and suspends the schedule), this
+    edits whatever activity the zone is currently following, so a human can still place an
+    independent hold that takes precedence, and an HA outage leaves the thermostat on its own
+    schedule at the last value written.
+  target:
+    entity:
+      integration: ha_carrier
+      domain: climate
+  fields:
+    temperature:
+      name: Temperature
+      description: Single set point, for heat or cool mode.
+      example: 74
+      selector:
+        number:
+          min: 45
+          max: 95
+          step: 1
+    target_temp_low:
+      name: Heat set point
+      description: Heat set point, for heat_cool (auto) mode.
+      example: 68
+      selector:
+        number:
+          min: 45
+          max: 95
+          step: 1
+    target_temp_high:
+      name: Cool set point
+      description: Cool set point, for heat_cool (auto) mode.
+      example: 74
+      selector:
+        number:
+          min: 45
+          max: 95
+          step: 1

--- a/custom_components/ha_carrier/services.yaml
+++ b/custom_components/ha_carrier/services.yaml
@@ -5,7 +5,7 @@ set_activity_setpoint:
     Unlike the built-in temperature set (which forces a hold and suspends the schedule), this
     edits whatever activity the zone is currently following, so a human can still place an
     independent hold that takes precedence, and an HA outage leaves the thermostat on its own
-    schedule at the last value written.
+    schedule at the last value written. (hava local patch — see ha/vendor-patches/ha_carrier)
   target:
     entity:
       integration: ha_carrier
@@ -17,24 +17,24 @@ set_activity_setpoint:
       example: 74
       selector:
         number:
-          min: 45
+          min: 7
           max: 95
-          step: 1
+          step: 0.5
     target_temp_low:
       name: Heat set point
       description: Heat set point, for heat_cool (auto) mode.
       example: 68
       selector:
         number:
-          min: 45
+          min: 7
           max: 95
-          step: 1
+          step: 0.5
     target_temp_high:
       name: Cool set point
       description: Cool set point, for heat_cool (auto) mode.
       example: 74
       selector:
         number:
-          min: 45
+          min: 7
           max: 95
-          step: 1
+          step: 0.5

--- a/custom_components/ha_carrier/services.yaml
+++ b/custom_components/ha_carrier/services.yaml
@@ -5,7 +5,7 @@ set_activity_setpoint:
     Unlike the built-in temperature set (which forces a hold and suspends the schedule), this
     edits whatever activity the zone is currently following, so a human can still place an
     independent hold that takes precedence, and an HA outage leaves the thermostat on its own
-    schedule at the last value written. (hava local patch — see ha/vendor-patches/ha_carrier)
+    schedule at the last value written.
   target:
     entity:
       integration: ha_carrier

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ version = { attr = "custom_components.ha_carrier.const.VERSION" }
 
 [dependency-groups]
 ha = [
-    "carrier-api==3.5.0",
+    "carrier-api==3.6.0",
     "homeassistant",
 ]
 lint = [


### PR DESCRIPTION
Adds entity service `ha_carrier.set_activity_setpoint` that edits the **current** activity's comfort set point in place **without** creating a manual hold.

**Why**

Stock `climate.set_temperature` creates a `MANUAL` hold (`set_config_manual_activity` + `set_config_hold`) that suspends the schedule and collides with a human's hold. This service edits the current activity directly so a manual hold still takes precedence and an outage leaves the thermostat on its schedule.

`carrier_api` already exposes `_update_infinity_zone_activity` (used by `update_fan`); this wires it for temperature setpoints on the current activity.

**What**

- `custom_components/ha_carrier/climate.py`: import `vol` + `entity_platform`, register `set_activity_setpoint` in `async_setup_entry`, add `Thermostat.async_set_activity_setpoint()` (resolves current activity, computes heat/cool per mode, calls `_update_infinity_zone_activity` with `activityType=current.type.value` and no hold, reflects `heat_set_point`/`cool_set_point` locally).
- `custom_components/ha_carrier/services.yaml` (new — upstream ships none): `temperature` / `target_temp_low` / `target_temp_high` selectors.

Example:

```yaml
action: ha_carrier.set_activity_setpoint
target:
  entity_id: climate.upstairs_main
data:
  temperature: 74
# or for heat_cool: target_temp_low / target_temp_high
```

Live-tested on Home Assistant 2026.8.3.