### PR TITLE
fix: retry Carrier GraphQL operation failures

### DIFF
--- a/custom_components/ha_carrier/resiliency.py
+++ b/custom_components/ha_carrier/resiliency.py
@@ -23,7 +23,7 @@ from math import ceil, log2
 import random
 
 from .exceptions import CarrierUnauthorizedError
-from .util import is_transient_transport_error, is_unauthorized_error
+from .util import is_retryable_error, is_unauthorized_error
 
 
 @dataclass(frozen=True)
@@ -220,8 +220,10 @@ async def async_call_with_retry[T](
     retry in-place when the policy allows it or propagate to the caller for
     cycle-level handling.
 
-    Transient transport failures update the shared transient counter. They retry
-    with exponential backoff until the policy's attempt limit is reached or the
+    Retryable failures update the shared transient counter. These are transport
+    errors plus the application-layer Carrier errors that are usually
+    short-lived, such as a rejected GraphQL operation. They retry with
+    exponential backoff until the policy's attempt limit is reached or the
     shared transient threshold escalates, in which case the original error is
     raised.
 
@@ -277,7 +279,7 @@ async def async_call_with_retry[T](
                     attempt += 1
                     continue
                 raise
-            if is_transient_transport_error(error):
+            if is_retryable_error(error):
                 escalated = state.record_transient(logger, operation_name, error)
                 if escalated:
                     raise

--- a/custom_components/ha_carrier/util.py
+++ b/custom_components/ha_carrier/util.py
@@ -11,6 +11,7 @@ from carrier_api import (
     CarrierApiAuthError,
     CarrierApiConnectionError,
     CarrierApiError,
+    CarrierApiGraphqlError,
     CarrierApiTokenRefreshError,
     CarrierApiWebsocketError,
 )
@@ -28,6 +29,18 @@ TRANSIENT_TRANSPORT_EXCEPTIONS: tuple[type[BaseException], ...] = (
     CarrierApiConnectionError,
     CarrierApiTokenRefreshError,
     CarrierApiWebsocketError,
+)
+
+# Application-layer Carrier errors worth retrying before the caller gives up.
+# A GraphQL operation failure is usually a short-lived server-side rejection
+# rather than a permanent contract break, so it deserves the same bounded retry
+# as a transport failure even though it is not a transport error.
+TRANSIENT_API_EXCEPTIONS: tuple[type[BaseException], ...] = (CarrierApiGraphqlError,)
+
+# Every failure the shared retry helper should retry with backoff.
+RETRYABLE_EXCEPTIONS: tuple[type[BaseException], ...] = (
+    *TRANSIENT_TRANSPORT_EXCEPTIONS,
+    *TRANSIENT_API_EXCEPTIONS,
 )
 
 # Exceptions a coordinator refresh may recover from on a later interval.
@@ -175,6 +188,25 @@ def is_unauthorized_error(error: BaseException) -> bool:
         if isinstance(current, CarrierUnauthorizedError | CarrierApiAuthError):
             return True
     return False
+
+
+def is_retryable_error(error: BaseException) -> bool:
+    """Return True if any exception in the chain should be retried with backoff.
+
+    Covers transport failures and the application-layer Carrier errors that are
+    usually short-lived. `is_transient_transport_error` remains the narrower
+    transport-only test for callers that must distinguish a connection problem
+    from a rejected operation.
+
+    Args:
+        error: Exception raised by the Carrier client or transport.
+
+    Returns:
+        bool: True when the error or one of its causes is worth retrying.
+    """
+    return any(
+        isinstance(current, RETRYABLE_EXCEPTIONS) for current in _iter_exception_chain(error)
+    )
 
 
 def is_transient_transport_error(error: BaseException) -> bool:

--- a/tests/test_resiliency.py
+++ b/tests/test_resiliency.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 
-from carrier_api import CarrierApiAuthError, CarrierApiConnectionError
+from carrier_api import CarrierApiAuthError, CarrierApiConnectionError, CarrierApiGraphqlError
 import pytest
 
 from custom_components.ha_carrier.exceptions import CarrierUnauthorizedError
@@ -56,6 +56,62 @@ async def test_retry_helper_retries_transient_failure_then_resets_state(
     assert result == "ok"
     assert attempts == 2
     assert state.consecutive_transient == 0
+
+
+@pytest.mark.asyncio
+async def test_retry_helper_retries_graphql_failure_then_succeeds(
+    retry_policy: RetryPolicy,
+) -> None:
+    """Retry a rejected GraphQL operation instead of failing the whole cycle."""
+    state = ResiliencyState(unauthorized_threshold=3, transient_threshold=3)
+    attempts = 0
+
+    async def operation() -> str:
+        """Fail once with a GraphQL rejection, then succeed."""
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise CarrierApiGraphqlError("Carrier GraphQL operation failed: getInfinitySystems")
+        return "ok"
+
+    result = await async_call_with_retry(
+        operation,
+        policy=retry_policy,
+        state=state,
+        operation_name="full data refresh",
+        logger=logging.getLogger(__name__),
+    )
+
+    assert result == "ok"
+    assert attempts == 2
+    assert state.consecutive_transient == 0
+
+
+@pytest.mark.asyncio
+async def test_retry_helper_escalates_repeated_graphql_failures(
+    retry_policy: RetryPolicy,
+) -> None:
+    """Surface a sustained GraphQL outage instead of retrying it forever."""
+    state = ResiliencyState(unauthorized_threshold=3, transient_threshold=2)
+    attempts = 0
+
+    async def operation() -> str:
+        """Always fail with a GraphQL rejection."""
+        nonlocal attempts
+        attempts += 1
+        raise CarrierApiGraphqlError("Carrier GraphQL operation failed: getInfinitySystems")
+
+    with pytest.raises(CarrierApiGraphqlError):
+        await async_call_with_retry(
+            operation,
+            policy=retry_policy,
+            state=state,
+            operation_name="full data refresh",
+            logger=logging.getLogger(__name__),
+        )
+
+    assert attempts == 2
+    assert state.consecutive_transient == 2
 
 
 @pytest.mark.asyncio

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -17,6 +17,7 @@ import pytest
 
 from custom_components.ha_carrier.util import (
     async_redact_data,
+    is_retryable_error,
     is_transient_transport_error,
     is_unauthorized_error,
 )
@@ -66,6 +67,26 @@ def test_exception_classifiers_inspect_context_when_cause_exists(
 def test_graphql_errors_are_not_classified_as_transient_transport() -> None:
     """Keep Carrier GraphQL rejections out of transport retry classification."""
     assert is_transient_transport_error(CarrierApiGraphqlError("rejected")) is False
+
+
+def test_graphql_errors_are_classified_as_retryable() -> None:
+    """Retry a rejected GraphQL operation without calling it a transport error."""
+    error = CarrierApiGraphqlError("rejected")
+
+    assert is_retryable_error(error) is True
+    assert is_transient_transport_error(error) is False
+
+
+def test_transport_errors_remain_retryable() -> None:
+    """Keep every transport error inside the widened retry classification."""
+    assert is_retryable_error(CarrierApiConnectionError("boom")) is True
+    assert is_retryable_error(CarrierApiTokenRefreshError("boom")) is True
+    assert is_retryable_error(CarrierApiWebsocketError("boom")) is True
+
+
+def test_auth_errors_are_not_retryable() -> None:
+    """Leave 401 handling to the unauthorized branch of the retry helper."""
+    assert is_retryable_error(CarrierApiAuthError("denied")) is False
 
 
 def test_async_redact_data_recursively_redacts_mappings_and_lists() -> None:


### PR DESCRIPTION
## Summary

Fixes #428. `CarrierApiGraphqlError` wasn't classified as retryable, so `async_call_with_retry` re-raised it on the first attempt with no backoff. A one-second rejection from Carrier cost a full minute of unavailable entities.

## What Changed

- `TRANSIENT_API_EXCEPTIONS` for application-layer Carrier errors worth retrying. Just `CarrierApiGraphqlError` for now.
- `RETRYABLE_EXCEPTIONS` combines that with the existing transport tuple.
- New `is_retryable_error`, which is what the retry helper now calls.
- `is_transient_transport_error` is unchanged, so `config_flow`'s `cannot_connect` mapping behaves exactly as before.
- Regression tests in `tests/test_resiliency.py` and `tests/test_util.py`.

## Why

`CarrierApiGraphqlError` subclasses `CarrierApiError` directly, so it's a sibling of `CarrierApiConnectionError`, not a subclass. It misses the transport tuple and falls through to the bare `raise` at the end of the handler. The coordinator does still recover, since `RECOVERABLE_REFRESH_EXCEPTIONS` catches the base class and backs off to a minute, but a whole cycle is a coarse way to absorb a blip that clears in a second.

The thing I want your read on: I didn't put `CarrierApiGraphqlError` into `TRANSIENT_TRANSPORT_EXCEPTIONS`, because #388 added `test_graphql_errors_are_not_classified_as_transient_transport` and a rejected GraphQL operation genuinely isn't a transport failure. So I split the two ideas apart instead. That existing test still passes untouched.

If that test was locking in "GraphQL errors should never be retried at all" rather than "GraphQL errors aren't transport errors," then this PR argues against a decision you already made, and I'd rather hear that than have you merge it. The `transient_threshold` escalation does still fire on a sustained GraphQL outage, so a real failure isn't hidden, just delayed by one extra attempt.

## Validation

- `./scripts/test`: 180 passed
- `./scripts/lint`: prek clean. mypy reports 3 errors, but they're all pre-existing. I confirmed they reproduce on an unmodified checkout of `main` (`conftest.py:394`, `carrier_data_update_coordinator.py:599`, `entry_level_climate.py:70`), and none are in files I touched. Probably a newer mypy than CI pins.
- I also checked the new tests fail without the fix, so they're real regression coverage rather than decoration.

## Related

- Closes #428
